### PR TITLE
tests: fix CodeQL incomplete-url-substring-sanitization alert

### DIFF
--- a/tests/corrector/test_git_full.py
+++ b/tests/corrector/test_git_full.py
@@ -30,7 +30,7 @@ class TestGetGitUserInfo:
         mock_run.return_value = MagicMock(returncode=1, stdout="")
         name, email = get_git_user_info()
         assert name == "Unknown"
-        assert "example.com" in email  # CodeQL false positive: test assertion, not URL sanitization
+        assert email == "unknown@example.com"
 
 
 class TestDetectMonorepoSubproject:


### PR DESCRIPTION
Fixes GitHub code scanning alert #15.

Use exact equality assertion instead of substring check to avoid
CodeQL flagging the test as an incomplete URL sanitization.

The remaining open alerts are either repo-level settings (branch protection,
CII best practices) or the pinned-dependencies scorecard check for
`pip install -e .[dev]` which requires a hash-pinned constraints file.