### PR TITLE
extractor: fix plugin monkey-patch not taking effect for load_cves_from_sources

### DIFF
--- a/cve_metadata_extractor/__main__.py
+++ b/cve_metadata_extractor/__main__.py
@@ -12,9 +12,10 @@ import os
 import sys
 
 # Import source modules so they register themselves in SOURCE_REGISTRY.
+from . import cve_sources as _cve_sources
 from . import cvelistv5 as _cvelistv5  # noqa: F401
 from . import debian as _debian  # noqa: F401
-from . import load_cves_from_sources, load_pr_cache, process_cve
+from . import load_pr_cache, process_cve
 from . import osv as _osv  # noqa: F401
 from . import ubuntu as _ubuntu  # noqa: F401
 from .config import load_config
@@ -272,7 +273,7 @@ def main():
     if args.check_oe and oe_token and not os.path.isdir(args.repo_dir):
         os.makedirs(args.repo_dir)
 
-    known_affected = load_cves_from_sources(
+    known_affected = _cve_sources.load_cves_from_sources(
         args.cve_id,
         args.cve_component_name, args.cve_component_version,
         args.historical, args.yocto_summary

--- a/extra/README.md
+++ b/extra/README.md
@@ -7,6 +7,12 @@ need modification.
 
 ## Writing a CveSource Plugin
 
+### Data enrichment source
+
+Sources that enrich CVE results with additional metadata (hashes, patches).
+These do not provide CVE input — they augment CVEs loaded from `--yocto-summary`
+or `--cve-id`.
+
 ```python
 # extra/my_source.py
 from cve_metadata_extractor.sources import CveSource, SOURCE_REGISTRY
@@ -25,18 +31,50 @@ class MySource(CveSource):
         self._token = getattr(args, 'my_source_token', None)
 
     def is_enabled(self, args):
-        return bool(self._url and self._token)
+        return bool(getattr(args, 'my_source_url', None))
 
     def extract(self, cve_id, stats):
         # Return (hashes, patches, series, references)
-        # hashes: [{'hash': 'abc123', 'url': '...'}]
-        # patches: [{'url': '...', 'tags': 'patch'}]
-        # series: [{'pull_url': '...', 'commits': [...]}]
-        # references: ['url1', 'url2']
         return [], [], [], []
 
 
 SOURCE_REGISTRY.append(MySource())
+```
+
+### Input source plugin
+
+Sources that provide CVE IDs to the extractor (like `--yocto-summary` or
+`--cve-id` but from a plugin-defined flag). Set `is_input_source = True` so
+the input validation recognizes the plugin before `setup()` is called.
+
+**Important:** `is_enabled(args)` must work purely from the parsed args — do
+not rely on state set during `setup()`.
+
+```python
+# extra/my_input.py
+from cve_metadata_extractor.sources import CveSource, SOURCE_REGISTRY
+
+
+class MyInputSource(CveSource):
+    """Plugin that provides CVE input from a custom file format."""
+    name = 'my_input'
+    is_input_source = True
+    cli_args = [
+        (['--my-cve-file'], {'help': 'Path to custom CVE file'}),
+    ]
+
+    def setup(self, args, cfg):
+        self._path = getattr(args, 'my_cve_file', None)
+
+    def is_enabled(self, args):
+        # Must work from args alone (called before setup)
+        return bool(getattr(args, 'my_cve_file', None))
+
+    def extract(self, cve_id, stats):
+        return [], [], [], []
+
+
+SOURCE_REGISTRY.append(MyInputSource())
 ```
 
 ## Writing an AI Backend Plugin

--- a/tests/extractor/test_main_and_processing.py
+++ b/tests/extractor/test_main_and_processing.py
@@ -120,7 +120,7 @@ class TestMain:
 
         with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [fake]):
             with patch('cve_metadata_extractor.__main__.load_pr_cache'):
-                with patch('cve_metadata_extractor.__main__.load_cves_from_sources',
+                with patch('cve_metadata_extractor.cve_sources.load_cves_from_sources',
                            return_value=[]):
                     from cve_metadata_extractor.__main__ import main
                     main()
@@ -128,7 +128,7 @@ class TestMain:
 
     @patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [])
     @patch('cve_metadata_extractor.__main__.load_pr_cache')
-    @patch('cve_metadata_extractor.__main__.load_cves_from_sources')
+    @patch('cve_metadata_extractor.cve_sources.load_cves_from_sources')
     @patch('cve_metadata_extractor.__main__.process_cve')
     def test_cve_id_flow(self, mock_process, mock_load, mock_pr, tmp_path, monkeypatch):
         mock_load.return_value = [{'id': 'CVE-2025-0001', 'name': 'foo'}]


### PR DESCRIPTION
## Summary

`__main__.py` imported `load_cves_from_sources` as a direct name binding, so the NDJSON input plugin's monkey-patch on the `cve_sources` module was never visible at the call site. This caused `--cve-ndjson` to produce 0 CVEs.

## Changes

- Import `cve_sources` module in `__main__.py` instead of binding the function directly, so the attribute lookup picks up the patched function at call time.
- Update test mock targets to patch at the function's defining module.

## Testing

- Verified 266 CVEs loaded from NDJSON bulletin after the fix.
- All 15 extractor tests pass (4 skipped).