### PR TITLE
cve_metadata_extractor: improve incremental merge and ubuntu retry logic

### DIFF
--- a/cve_metadata_extractor/__main__.py
+++ b/cve_metadata_extractor/__main__.py
@@ -20,7 +20,7 @@ from . import osv as _osv  # noqa: F401
 from . import ubuntu as _ubuntu  # noqa: F401
 from .config import load_config
 from .sources import SOURCE_REGISTRY
-from .utils import PR_CACHE
+from .utils import PR_CACHE, deduplicate_metadata
 
 
 def _get_version() -> str:
@@ -230,6 +230,88 @@ def _print_summary(results, stats, args):
                   f"to: {os.path.abspath(args.cache)}")
 
 
+def _iter_sources(entries):
+    '''Yield unique source names from hash_details or patch_details entries.'''
+    seen = set()
+    for entry in entries:
+        for s in entry.get('source', '').split(', '):
+            if s and s not in seen:
+                seen.add(s)
+                yield s
+
+
+def _expand_sources(entries):
+    '''Expand multi-source entries into individual single-source copies.'''
+    for entry in entries:
+        for s in entry.get('source', '').split(', '):
+            if s:
+                yield dict(entry, source=s)
+
+
+def _accumulate_stats(result, stats, *, only_sources=None):
+    '''Count per-source statistics from an existing result entry.
+
+    Args:
+        result: A CVE result dict with hash_details/patch_details.
+        stats: Mutable stats dict to increment.
+        only_sources: If set, only count these source names.
+    '''
+    for s in _iter_sources(result.get('hash_details', [])):
+        if only_sources and s not in only_sources:
+            continue
+        key = f'{s}_hashes'
+        if key in stats:
+            stats[key] += 1
+    for s in _iter_sources(result.get('patch_details', [])):
+        if only_sources and s not in only_sources:
+            continue
+        key = f'{s}_patches'
+        if key in stats:
+            stats[key] += 1
+
+
+def _merge_results(existing, new):
+    '''Merge new result into existing, preserving data from inactive sources.
+
+    Deduplicates hash_details by hash and patch_details by url,
+    combining source strings. References and series are merged by key.
+    '''
+    all_hashes = list(_expand_sources(
+        existing.get('hash_details', []) + new.get('hash_details', [])))
+    all_patches = list(_expand_sources(
+        existing.get('patch_details', []) + new.get('patch_details', [])))
+    merged_hashes, merged_patches = deduplicate_metadata(all_hashes, all_patches)
+
+    # Merge references by url
+    ref_dict = {}
+    for ref in existing.get('references', []) + new.get('references', []):
+        url = ref['url']
+        if url not in ref_dict:
+            ref_dict[url] = {'url': url, 'sources': list(ref.get('sources', []))}
+        else:
+            ref_dict[url]['sources'].extend(ref.get('sources', []))
+    merged_refs = [{'url': r['url'], 'sources': sorted(set(r['sources']))}
+                   for r in ref_dict.values()]
+
+    # Merge series by pull_url
+    seen_series = {}
+    for s in existing.get('series', []) + new.get('series', []):
+        seen_series.setdefault(s['pull_url'], s)
+    merged_series = list(seen_series.values())
+
+    # Start from new result (has updated scalar fields), override list fields
+    merged = dict(new)
+    merged['hash_details'] = merged_hashes
+    merged['hashes'] = [h['hash'] for h in merged_hashes]
+    merged['patch_details'] = merged_patches
+    merged['patches'] = [p['url'] for p in merged_patches]
+    merged['references'] = merged_refs
+    if merged_series:
+        merged['series'] = merged_series
+
+    return merged
+
+
 def main():
     '''Main function.'''
     cfg = load_config()
@@ -304,12 +386,23 @@ def main():
                     PR_CACHE.pop(ref['url'], None)
                 reprocessed += 1
             else:
+                _accumulate_stats(existing_results[cve_id], stats)
                 skipped += 1
                 continue
         result = process_cve(
             cve, idx, len(known_affected), args,
             active_sources, stats, oe_token)
         if result:
+            if cve_id in existing_results:
+                result = _merge_results(existing_results[cve_id], result)
+                # Count stats for inactive sources preserved from existing data
+                active_names = {s.name for s in active_sources}
+                inactive = (
+                    set(_iter_sources(existing_results[cve_id].get('hash_details', [])))
+                    | set(_iter_sources(existing_results[cve_id].get('patch_details', [])))
+                ) - active_names
+                _accumulate_stats(existing_results[cve_id], stats,
+                                  only_sources=inactive)
             results[cve_id] = result
 
     if skipped:

--- a/cve_metadata_extractor/ubuntu.py
+++ b/cve_metadata_extractor/ubuntu.py
@@ -40,21 +40,45 @@ def get_ubuntu_cve(cache, cve_id, refresh=False):
     if cache_exists(cache_file) and not refresh:
         return cache_load(cache_file)
 
-    try:
-        time.sleep(0.05)
-        resp = requests.get(
-            f'{UBUNTU_API}/security/cves/{cve_id}.json', timeout=10)
-        if resp.status_code == 404:
-            data = {}
-        else:
+    max_retries = 3
+    base_delay = float(_cfg.get('ubuntu_delay', 1.0))
+    data = {}
+    for attempt in range(max_retries):
+        try:
+            time.sleep(base_delay * (2 ** attempt))
+            resp = requests.get(
+                f'{UBUNTU_API}/security/cves/{cve_id}.json', timeout=30)
+            if resp.status_code == 404:
+                break
+            if resp.status_code == 429:
+                logging.warning('Ubuntu API rate limited for %s, retrying...',
+                                cve_id)
+                continue
             resp.raise_for_status()
             data = resp.json()
-    except requests.RequestException as e:
-        logging.warning('Ubuntu API request failed for %s: %s', cve_id, e)
-        data = {}
+            break
+        except requests.RequestException as e:
+            logging.warning('Ubuntu API request failed for %s (attempt %d/%d):'
+                            ' %s', cve_id, attempt + 1, max_retries, e)
+    else:
+        logging.warning('Gave up fetching Ubuntu data for %s after %d'
+                        ' attempts', cve_id, max_retries)
 
     cache_dump(data, cache_file)
     return data
+
+
+def _process_url(url, hashes, patch_links, series, *, add_patch_link=False):
+    '''Extract hash, detect PRs/issues, and add to results for a single URL.'''
+    if '/pull/' in url:
+        process_pr_url(url, series)
+    elif _GITLAB_ISSUE_RE.match(url):
+        process_gitlab_issue_url(url, series)
+    h = extract_commit_hash(url)
+    if h and not any(e['hash'] == h for e in hashes):
+        hashes.append({'hash': h, 'url': url})
+        if add_patch_link:
+            patch_links.append({'url': url, 'tags': 'fix'})
 
 
 def extract_from_ubuntu_response(ubuntu_data):
@@ -82,27 +106,14 @@ def extract_from_ubuntu_response(ubuntu_data):
                 continue
             url = match.group(0)
             patch_links.append({'url': url, 'tags': 'patch'})
-            if '/pull/' in url:
-                process_pr_url(url, series)
-            elif _GITLAB_ISSUE_RE.match(url):
-                process_gitlab_issue_url(url, series)
-            h = extract_commit_hash(url)
-            if h and not any(e['hash'] == h for e in hashes):
-                hashes.append({'hash': h, 'url': url})
+            _process_url(url, hashes, patch_links, series)
 
     # Extract from references list
     for url in ubuntu_data.get('references') or []:
         if not url:
             continue
         references.append(url)
-        if '/pull/' in url:
-            process_pr_url(url, series)
-        elif _GITLAB_ISSUE_RE.match(url):
-            process_gitlab_issue_url(url, series)
-        h = extract_commit_hash(url)
-        if h and not any(e['hash'] == h for e in hashes):
-            hashes.append({'hash': h, 'url': url})
-            patch_links.append({'url': url, 'tags': 'fix'})
+        _process_url(url, hashes, patch_links, series, add_patch_link=True)
 
     return patch_links, hashes, series, references
 

--- a/tests/extractor/test_accumulate_stats.py
+++ b/tests/extractor/test_accumulate_stats.py
@@ -1,0 +1,54 @@
+"""Tests for _accumulate_stats used during incremental processing."""
+
+from cve_metadata_extractor.__main__ import _accumulate_stats
+
+
+class TestAccumulateStats:
+    def test_counts_single_source(self):
+        stats = {'debian_hashes': 0, 'debian_patches': 0}
+        result = {
+            'hash_details': [{'hash': 'abc', 'source': 'debian'}],
+            'patch_details': [{'url': 'http://x', 'source': 'debian'}],
+        }
+        _accumulate_stats(result, stats)
+        assert stats == {'debian_hashes': 1, 'debian_patches': 1}
+
+    def test_counts_comma_separated_sources(self):
+        stats = {
+            'bdba_hashes': 0, 'bdba_patches': 0,
+            'debian_hashes': 0, 'debian_patches': 0,
+        }
+        result = {
+            'hash_details': [{'hash': 'a', 'source': 'bdba, debian'}],
+            'patch_details': [],
+        }
+        _accumulate_stats(result, stats)
+        assert stats['bdba_hashes'] == 1
+        assert stats['debian_hashes'] == 1
+
+    def test_ignores_unknown_sources(self):
+        stats = {'debian_hashes': 0, 'debian_patches': 0}
+        result = {
+            'hash_details': [{'hash': 'a', 'source': 'unknown'}],
+            'patch_details': [],
+        }
+        _accumulate_stats(result, stats)
+        assert stats == {'debian_hashes': 0, 'debian_patches': 0}
+
+    def test_deduplicates_per_cve(self):
+        """Multiple hashes from same source count as 1 CVE with hashes."""
+        stats = {'osv_hashes': 0, 'osv_patches': 0}
+        result = {
+            'hash_details': [
+                {'hash': 'a', 'source': 'osv'},
+                {'hash': 'b', 'source': 'osv'},
+            ],
+            'patch_details': [],
+        }
+        _accumulate_stats(result, stats)
+        assert stats['osv_hashes'] == 1
+
+    def test_handles_missing_fields(self):
+        stats = {'debian_hashes': 0, 'debian_patches': 0}
+        _accumulate_stats({}, stats)
+        assert stats == {'debian_hashes': 0, 'debian_patches': 0}

--- a/tests/extractor/test_ubuntu.py
+++ b/tests/extractor/test_ubuntu.py
@@ -14,11 +14,13 @@ from cve_metadata_extractor.ubuntu import (
 )
 
 
+@patch('cve_metadata_extractor.ubuntu.time.sleep')
 class TestGetUbuntuCve(unittest.TestCase):
     '''Test Ubuntu API client with caching.'''
 
-    def test_caches_response(self):
+    def test_caches_response(self, _mock_sleep):
         '''API response is cached to file.'''
+        from shared.json_cache import cache_exists
         with tempfile.TemporaryDirectory() as tmpdir:
             ubuntu_data = {'id': 'CVE-2026-35386', 'patches': {}}
             with patch('cve_metadata_extractor.ubuntu.requests.get') as mock_get:
@@ -30,11 +32,10 @@ class TestGetUbuntuCve(unittest.TestCase):
 
                 result = get_ubuntu_cve(tmpdir, 'CVE-2026-35386')
                 self.assertEqual(result, ubuntu_data)
-                self.assertTrue(
-                    os.path.isfile(
-                        os.path.join(tmpdir, 'CVE-2026-35386-ubuntu.json.gz')))
+                cache_file = os.path.join(tmpdir, 'CVE-2026-35386-ubuntu.json')
+                self.assertTrue(cache_exists(cache_file))
 
-    def test_uses_cache_on_second_call(self):
+    def test_uses_cache_on_second_call(self, _mock_sleep):
         '''Second call reads from cache, no API request.'''
         with tempfile.TemporaryDirectory() as tmpdir:
             ubuntu_data = {'id': 'CVE-2026-35386', 'patches': {}}
@@ -47,7 +48,7 @@ class TestGetUbuntuCve(unittest.TestCase):
                 self.assertEqual(result, ubuntu_data)
                 mock_get.assert_not_called()
 
-    def test_refresh_bypasses_cache(self):
+    def test_refresh_bypasses_cache(self, _mock_sleep):
         '''refresh=True re-fetches even if cache exists.'''
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_file = os.path.join(tmpdir, 'CVE-2026-35386-ubuntu.json')
@@ -66,7 +67,33 @@ class TestGetUbuntuCve(unittest.TestCase):
                 self.assertEqual(result, new_data)
                 mock_get.assert_called_once()
 
-    def test_404_returns_empty_dict(self):
+    def test_gives_up_warning_after_retries(self, _mock_sleep):
+        '''Logs warning when all retries are exhausted.'''
+        import requests as req
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('cve_metadata_extractor.ubuntu.requests.get') as mock_get:
+                mock_get.side_effect = req.ConnectionError('timeout')
+                with self.assertLogs('root', level='WARNING') as cm:
+                    result = get_ubuntu_cve(tmpdir, 'CVE-2026-99999')
+                self.assertEqual(result, {})
+                self.assertTrue(any('Gave up fetching Ubuntu data' in m
+                                    for m in cm.output))
+
+    def test_retries_on_429_then_succeeds(self, _mock_sleep):
+        '''429 triggers retry; success on next attempt.'''
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resp_429 = MagicMock(status_code=429)
+            resp_200 = MagicMock(status_code=200)
+            resp_200.json.return_value = {'id': 'CVE-2026-1234'}
+            resp_200.raise_for_status = MagicMock()
+
+            with patch('cve_metadata_extractor.ubuntu.requests.get',
+                       side_effect=[resp_429, resp_200]) as mock_get:
+                result = get_ubuntu_cve(tmpdir, 'CVE-2026-1234')
+                self.assertEqual(result['id'], 'CVE-2026-1234')
+                self.assertEqual(mock_get.call_count, 2)
+
+    def test_404_returns_empty_dict(self, _mock_sleep):
         '''404 response caches and returns empty dict.'''
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch('cve_metadata_extractor.ubuntu.requests.get') as mock_get:


### PR DESCRIPTION
- Add _merge_results() to preserve data from inactive sources when reprocessing CVEs incrementally, deduplicating by hash/url and combining source strings
- Add _accumulate_stats() to correctly count per-source statistics for both skipped and reprocessed entries
- Add retry with exponential backoff to Ubuntu API client, handling 429 rate-limiting and transient failures (3 attempts, configurable base delay)
- Refactor extract_from_ubuntu_response() to use shared _process_url() helper, removing duplicated hash/PR extraction logic
- Add tests for retry exhaustion and 429 recovery