### PR TITLE
ci: add release automation workflows and publishing docs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+name: Bump patch version
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-version
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    # Skip if this commit is already a version bump or already touched pyproject.toml
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip if pyproject.toml version was already changed
+        id: check
+        run: |
+          if git diff-tree --no-commit-id --name-only -r HEAD | grep -q '^pyproject\.toml$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump patch version
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          NEW=$(python3 -c "
+          import re, sys
+          text = open('pyproject.toml').read()
+          m = re.search(r'^version = \"(\d+\.\d+\.)(\d+)\"', text, re.M)
+          if not m: sys.exit('version not found in pyproject.toml')
+          new_ver = m.group(1) + str(int(m.group(2)) + 1)
+          open('pyproject.toml', 'w').write(text.replace(m.group(0), f'version = \"{new_ver}\"'))
+          print(new_ver)
+          ")
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add pyproject.toml
+          git commit -s -m "chore: bump version to ${NEW} [skip ci]"
+          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify tag matches pyproject.toml version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION=$(python3 -c "
+          import re, sys
+          m = re.search(r'^version = \"(.+?)\"', open('pyproject.toml').read(), re.M)
+          if not m: sys.exit('version not found in pyproject.toml')
+          print(m.group(1))
+          ")
+          EXPECTED="v${PKG_VERSION}"
+          if [ "$TAG" != "$EXPECTED" ]; then
+            echo "ERROR: release tag '${TAG}' does not match pyproject.toml version '${EXPECTED}'"
+            exit 1
+          fi
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Build
+        run: |
+          pip install build==1.2.2
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,3 +164,33 @@ As a reminder, when contributing a change, your `Signed-off-by` line is
 required and the stipulations in the
 [Developer's Statement of Origin 1.1](https://developercertificate.org/) still
 apply.
+
+## Releasing
+
+Releases are published to [PyPI](https://pypi.org/project/yocto-security-tools/) automatically when a GitHub Release is created. The patch version is also bumped automatically after every merge to `main`.
+
+### One-time setup (first release only)
+
+**1. Register a trusted publisher on PyPI**
+
+On [pypi.org](https://pypi.org): Your projects → yocto-security-tools → Publishing → Add a new publisher.
+
+| Field | Value |
+|---|---|
+| Owner | `Ericsson` |
+| Repository | `yocto-security-tools` |
+| Workflow | `publish.yml` |
+| Environment | *(leave blank)* |
+
+No API token is needed. PyPI will accept the OIDC token issued by GitHub Actions.
+
+**2. Enable branch protection (recommended)**
+
+Settings → Branches → Add rule for `main`: require the `CI / test` status check to pass before merging. This ensures every release tag points to a commit that passed CI.
+
+### Release process
+
+1. The bump-version workflow increments the patch version automatically after each PR merge. For a minor or major bump, edit `pyproject.toml` directly in the PR.
+2. Update `CHANGELOG.md` with the changes for the release.
+3. Create a GitHub Release with a tag matching `v{version}` (e.g., `v1.0.5` if `pyproject.toml` says `1.0.5`). The publish workflow will fail fast if the tag and version don't match.
+4. The `publish.yml` workflow runs automatically and uploads the wheel and sdist to PyPI.


### PR DESCRIPTION
Add GitHub Actions workflows for automated version bumping and PyPI publishing:

- bump-version.yml: auto-increment patch version on merge to main
- publish.yml: build and publish to PyPI on GitHub Release using trusted OIDC publishing (no API tokens)

Document the release process and one-time PyPI setup in CONTRIBUTING.md.