### PR TITLE
tests: fix monorepo tests failing when init.defaultBranch is not set

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def make_upstream_repo(tmp_path):
     def _factory(files: dict, version_tag: str, fix_commits: list,
                  monorepo_prefix: Optional[str] = None):
         bare = tmp_path / 'upstream.git'
-        git(tmp_path, 'init', '--bare', str(bare))
+        git(tmp_path, 'init', '--bare', '--initial-branch=main', str(bare))
 
         work = tmp_path / 'upstream_work'
         git(tmp_path, 'clone', str(bare), str(work))


### PR DESCRIPTION
  The make_upstream_repo fixture creates a bare repo without specifying
  an initial branch name. On systems where git's init.defaultBranch is
  unset, git defaults to 'master', but the monorepo tests assume the
  branch is called 'main' and fail on .