### PR TITLE
agent: add Claude Code CLI backend for cve-agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 │   ├── orchestrator.py          # Resolution loop (run corrector → AI → retry)
 │   ├── session.py               # Guarded sessions (file-scope enforcement)
 │   ├── backend.py               # AIBackend interface + KiroBackend
+│   ├── claude_backend.py        # ClaudeBackend (drives the `claude` CLI)
 │   └── context.py / knowledge.py / review.py
 ├── extra/                       # Plugin directory (.gitignore'd .py files)
 └── tests/{agent,corrector,extractor,shared}/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@
 ├── cve_agent/                   # Tool 3: AI orchestration
 │   ├── orchestrator.py          # Resolution loop (run corrector → AI → retry)
 │   ├── session.py               # Guarded sessions (file-scope enforcement)
-│   ├── backend.py               # AIBackend interface + KiroBackend
+│   ├── backend.py               # AIBackend interface + backend registry
+│   ├── kiro_backend.py          # KiroBackend (drives `kiro-cli`, default)
 │   ├── claude_backend.py        # ClaudeBackend (drives the `claude` CLI)
 │   └── context.py / knowledge.py / review.py
 ├── extra/                       # Plugin directory (.gitignore'd .py files)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **cve-agent**: `claude` backend that drives the Claude Code CLI directly, selectable with `--backend claude` (kiro remains the default). Model names are mapped to Claude aliases, and the backend passes through Anthropic/cloud auth environment variables.
+- **tests**: integration test runner accepts `AGENT_BACKEND` / `AGENT_MODEL` environment variables so the agent test cases can run against any registered backend (e.g. `AGENT_BACKEND=claude`), plus opt-in live smoke tests (`CLAUDE_LIVE_TESTS=1 pytest -m live`) that verify the emitted CLI flags and a real conflict resolution against an installed `claude` binary.
+- **tests**: CLI contract tests using a stub `claude` executable (argv/env/cwd recording, no API key needed) and guard-parity tests that fail if the Claude backend's tool allow/deny lists drift from the kiro agent manifest.
 
 ## [1.0.1] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **cve-agent**: `claude` backend that drives the Claude Code CLI directly, selectable with `--backend claude` (kiro remains the default). Model names are mapped to Claude aliases, and the backend passes through Anthropic/cloud auth environment variables.
+
 ## [1.0.1] - 2026-07-03
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,9 @@ See [extra/README.md](extra/README.md) for a complete example.
 
 The built-in backends are `kiro` (`KiroBackend`) and `claude` (`ClaudeBackend`),
 both in `cve_agent/`. `cve_agent/claude_backend.py` is a good reference for a
-first-class backend that shells out to a CLI: it is registered at import in
-`cve_agent/backend.py` (whereas `extra/` plugins are auto-discovered at runtime).
+first-class backend that shells out to a CLI: it is registered on first use by
+`_ensure_builtin_backends()` in `cve_agent/backend.py` (whereas `extra/` plugins
+are auto-discovered at runtime).
 
 ## Commit Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,12 @@ See [extra/README.md](extra/README.md) for a complete example.
 3. Implement `run_session()` and `is_available()`
 4. Call `register_backend(YourBackend())`
 
-The built-in backends are `kiro` (`KiroBackend`) and `claude` (`ClaudeBackend`),
-both in `cve_agent/`. `cve_agent/claude_backend.py` is a good reference for a
-first-class backend that shells out to a CLI: it is registered on first use by
-`_ensure_builtin_backends()` in `cve_agent/backend.py` (whereas `extra/` plugins
-are auto-discovered at runtime).
+The built-in backends are `kiro` (`cve_agent/kiro_backend.py`) and `claude`
+(`cve_agent/claude_backend.py`) — one module per backend, so a new first-class
+backend is a new file next to them. Either is a good reference for a backend
+that shells out to a CLI: both are registered on first use by
+`_ensure_builtin_backends()` in `cve_agent/backend.py` (whereas `extra/`
+plugins are auto-discovered at runtime).
 
 ## Commit Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ See [extra/README.md](extra/README.md) for a complete example.
 3. Implement `run_session()` and `is_available()`
 4. Call `register_backend(YourBackend())`
 
+The built-in backends are `kiro` (`KiroBackend`) and `claude` (`ClaudeBackend`),
+both in `cve_agent/`. `cve_agent/claude_backend.py` is a good reference for a
+first-class backend that shells out to a CLI: it is registered at import in
+`cve_agent/backend.py` (whereas `extra/` plugins are auto-discovered at runtime).
+
 ## Commit Messages
 
 Use conventional format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ pytest                              # all tests
 pytest tests/corrector/ -v          # specific component
 pytest -m "not integration"         # skip integration tests
 pytest --cov --cov-report=term      # with coverage
+CLAUDE_LIVE_TESTS=1 pytest -m live  # live AI-backend smoke tests (needs an
+                                    # authenticated `claude` CLI on PATH)
 ```
 
 ## Code Quality

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Standalone CVE management tools for Yocto/OpenEmbedded Linux distributions.
 - Python 3.9+
 - Git
 - For `cve-corrector` / `cve-agent`: a sourced Yocto build environment (`BBPATH` set)
-- For `cve-agent`: [kiro-cli](https://github.com/aws/kiro-cli) (or a custom AI backend plugin)
+- For `cve-agent`: an AI backend — [kiro-cli](https://github.com/aws/kiro-cli) (default) or [Claude Code](https://code.claude.com) (`--backend claude`), or a custom backend plugin
 
 ## Installation
 
@@ -62,15 +62,27 @@ cve-corrector --continue
 ### AI-assisted backporting
 
 ```bash
-# Requires kiro-cli (or another AI backend)
+# Requires an AI backend CLI: kiro-cli (default) or Claude Code
 cve-agent --cve-id CVE-2024-1234 --cve-info cve-metadata.json --trust
 
 # Batch mode
 cve-agent --cve-list cves.txt --cve-info cve-metadata.json --trust
 
-# Use a different AI backend
+# Use the Claude Code backend (install and authenticate the `claude` CLI first)
+cve-agent --cve-id CVE-2024-1234 --cve-info cve-metadata.json --backend claude --model sonnet
+
+# Use a custom backend plugin from extra/
 cve-agent --cve-id CVE-2024-1234 --cve-info cve-metadata.json --backend my_backend
 ```
+
+**AI backends.** `kiro` (default) drives [kiro-cli](https://github.com/aws/kiro-cli);
+`claude` drives the [Claude Code](https://code.claude.com) `claude` CLI directly.
+The Claude Code backend needs a recent `claude` on `PATH`, already authenticated
+(Anthropic API key, or Bedrock/Vertex), supporting `-p`, `--permission-mode`,
+`--allowedTools`/`--disallowedTools`, `--append-system-prompt`, and `--add-dir`.
+Pass `--model sonnet|opus|haiku` (or a full model id); the default
+`claude-sonnet-4.6` is mapped to `sonnet`. Both backends run under the same
+file-scope guard, so the AI can only modify the files the upstream fix touches.
 
 ## How It Works
 

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -214,9 +214,10 @@ def _parse_args() -> argparse.Namespace:
     # --- AI session ---
     ai_group = parser.add_argument_group('AI session')
     ai_group.add_argument('--backend', default='kiro',
-                        help='AI backend to use (default: %(default)s)')
+                        help='AI backend: kiro or claude (default: %(default)s)')
     ai_group.add_argument('--model', default='claude-sonnet-4.6',
-                        help='Model for AI sessions (default: %(default)s)')
+                        help='Model for AI sessions; the claude backend also '
+                             'accepts aliases like sonnet/opus (default: %(default)s)')
     ai_group.add_argument('--max-retries', type=int, default=DEFAULT_MAX_RETRIES,
                         help='Max resolution attempts (default: %(default)s)')
     ai_group.add_argument('--session-timeout', type=int,
@@ -301,6 +302,18 @@ def main() -> None:
 
     if args.backend == 'kiro':
         ensure_agents(interactive=not args.trust)
+    else:
+        from .backend import get_backend
+        try:
+            backend = get_backend(args.backend)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(EXIT_AGENT_ERROR)
+        if not backend.is_available():
+            print(f"Error: backend '{args.backend}' prerequisites not met — "
+                  "is the required CLI installed and on PATH?", file=sys.stderr)
+            sys.exit(EXIT_AGENT_ERROR)
+        backend.setup(interactive=not args.trust)
 
     if args.trust and not _show_trust_warning():
         print("Trust mode declined. Exiting.")

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -3,15 +3,9 @@
 """Pluggable AI backend interface for CVE agent sessions."""
 import logging
 import os
-import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-
-from shared import build_git_env
-
-from .git import has_in_progress_operation
 
 
 @dataclass
@@ -44,64 +38,7 @@ class AIBackend:
         """Perform any one-time setup."""
 
 
-class KiroBackend(AIBackend):
-    """Default backend using kiro-cli."""
-    name = "kiro"
-
-    def is_available(self) -> bool:
-        import shutil
-        return shutil.which("kiro-cli") is not None
-
-    def run_session(self, prompt: str, workspace_path: Path,
-                   allowed_files: set, model: str,
-                   timeout: int, interactive: bool) -> SessionResult:
-        agent_name = ('yocto-cve-backport-interactive' if interactive
-                      else 'yocto-cve-backport')
-        env = build_git_env()
-        cmd = ['kiro-cli', 'chat', '--agent', agent_name, '--model', model]
-        if not interactive:
-            cmd.append('--no-interactive')
-            cmd.append('--trust-tools=fs_read,fs_write,execute_bash')
-        cmd.append(prompt)
-
-        start = time.monotonic()
-        timed_out = False
-        try:
-            subprocess.run(cmd, cwd=workspace_path, env=env,
-                         check=False, timeout=timeout)
-        except subprocess.TimeoutExpired:
-            timed_out = True
-        except FileNotFoundError:
-            logging.error("kiro-cli not found. Install it or add to PATH.")
-        except KeyboardInterrupt:
-            pass
-
-        duration = time.monotonic() - start
-        if timed_out:
-            return SessionResult(resolved=False, duration=duration)
-
-        resolved = self._check_resolution(workspace_path)
-        return SessionResult(resolved=resolved, duration=duration)
-
-    def _check_resolution(self, workspace_path: Path) -> bool:
-        if has_in_progress_operation(workspace_path):
-            return False
-        result = subprocess.run(
-            ['git', 'status', '--porcelain'],
-            cwd=workspace_path, capture_output=True, text=True, check=False)
-        if result.returncode != 0:
-            return False
-        for line in result.stdout.splitlines():
-            if line and len(line) >= 2 and (line[0] == 'U' or line[1] == 'U'):
-                return False
-        return True
-
-    def setup(self, **kwargs) -> None:
-        from .setup import ensure_agents
-        ensure_agents(interactive=kwargs.get('interactive', True))
-
-
-_BACKENDS: dict[str, AIBackend] = {"kiro": KiroBackend()}
+_BACKENDS: dict[str, AIBackend] = {}
 
 
 def _ensure_builtin_backends() -> None:
@@ -111,7 +48,13 @@ def _ensure_builtin_backends() -> None:
     AIBackend/SessionResult from here — an import at the bottom of this
     module makes ``import cve_agent.claude_backend`` fail with a circular
     import whenever it is imported before ``cve_agent.backend``.
+
+    A backend already registered under the same name (an ``extra/`` plugin
+    loaded first) is left in place, so plugin override semantics hold.
     """
+    if "kiro" not in _BACKENDS:
+        from .kiro_backend import KiroBackend
+        _BACKENDS["kiro"] = KiroBackend()
     if "claude" not in _BACKENDS:
         from .claude_backend import ClaudeBackend
         _BACKENDS["claude"] = ClaudeBackend()

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -11,6 +11,8 @@ from typing import Optional
 
 from shared import build_git_env
 
+from .git import has_in_progress_operation
+
 
 @dataclass
 class SessionResult:
@@ -82,6 +84,8 @@ class KiroBackend(AIBackend):
         return SessionResult(resolved=resolved, duration=duration)
 
     def _check_resolution(self, workspace_path: Path) -> bool:
+        if has_in_progress_operation(workspace_path):
+            return False
         result = subprocess.run(
             ['git', 'status', '--porcelain'],
             cwd=workspace_path, capture_output=True, text=True, check=False)

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -171,3 +171,11 @@ def load_extra_backends() -> None:
             spec.loader.exec_module(mod)  # type: ignore[union-attr]
         except Exception as e:
             logging.debug("Extra backend load %s: %s", py_file.name, e)
+
+
+# Register additional built-in backends. Imported here (after the registry
+# helpers are defined) so ClaudeBackend can import AIBackend/SessionResult from
+# this module without a circular import.
+from .claude_backend import ClaudeBackend  # noqa: E402
+
+register_backend(ClaudeBackend())

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -104,6 +104,19 @@ class KiroBackend(AIBackend):
 _BACKENDS: dict[str, AIBackend] = {"kiro": KiroBackend()}
 
 
+def _ensure_builtin_backends() -> None:
+    """Register built-in backends that live in their own modules.
+
+    Imported lazily (not at module bottom) because those modules import
+    AIBackend/SessionResult from here — an import at the bottom of this
+    module makes ``import cve_agent.claude_backend`` fail with a circular
+    import whenever it is imported before ``cve_agent.backend``.
+    """
+    if "claude" not in _BACKENDS:
+        from .claude_backend import ClaudeBackend
+        _BACKENDS["claude"] = ClaudeBackend()
+
+
 def register_backend(backend: AIBackend) -> None:
     """Register an additional AI backend."""
     _BACKENDS[backend.name] = backend
@@ -111,6 +124,7 @@ def register_backend(backend: AIBackend) -> None:
 
 def get_backend(name: str = "kiro") -> AIBackend:
     """Get backend by name."""
+    _ensure_builtin_backends()
     if name not in _BACKENDS:
         raise ValueError(
             f"Unknown backend '{name}'. Available: {list(_BACKENDS.keys())}")
@@ -119,6 +133,7 @@ def get_backend(name: str = "kiro") -> AIBackend:
 
 def available_backends() -> list:
     """List registered backend names."""
+    _ensure_builtin_backends()
     return list(_BACKENDS.keys())
 
 
@@ -175,11 +190,3 @@ def load_extra_backends() -> None:
             spec.loader.exec_module(mod)  # type: ignore[union-attr]
         except Exception as e:
             logging.debug("Extra backend load %s: %s", py_file.name, e)
-
-
-# Register additional built-in backends. Imported here (after the registry
-# helpers are defined) so ClaudeBackend can import AIBackend/SessionResult from
-# this module without a circular import.
-from .claude_backend import ClaudeBackend  # noqa: E402
-
-register_backend(ClaudeBackend())

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -3,7 +3,7 @@
 """Claude Code AI backend for CVE agent sessions.
 
 Drives the ``claude`` CLI (Claude Code) directly — no kiro-cli in the loop.
-Mirrors :class:`cve_agent.backend.KiroBackend`: it builds a headless command,
+Mirrors :class:`cve_agent.kiro_backend.KiroBackend`: it builds a headless command,
 runs it in the recipe workspace, and reports whether the conflict was resolved.
 
 The authoritative file-scope guard remains the git pre-commit hook plus the

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -1,0 +1,183 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Claude Code AI backend for CVE agent sessions.
+
+Drives the ``claude`` CLI (Claude Code) directly — no kiro-cli in the loop.
+Mirrors :class:`cve_agent.backend.KiroBackend`: it builds a headless command,
+runs it in the recipe workspace, and reports whether the conflict was resolved.
+
+The authoritative file-scope guard remains the git pre-commit hook plus the
+post-session revert installed by :func:`cve_agent.session.guarded_session`.
+The ``--allowedTools`` / ``--disallowedTools`` lists below are defense-in-depth
+mirrors of ``cve_agent/agents/yocto-cve-backport.json``.
+"""
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from shared import build_git_env
+
+from .backend import AIBackend, SessionResult
+
+# Packaged agent instructions, injected as the Claude system prompt for parity
+# with the kiro agent (whose ``prompt`` field points at the same file).
+_AGENT_INSTRUCTIONS = Path(__file__).resolve().parent / "AGENT_INSTRUCTIONS.md"
+
+# Map kiro-style model names to Claude Code aliases. Valid Claude aliases and
+# full model IDs pass through unchanged; an empty value falls back to "sonnet".
+_MODEL_ALIASES = {
+    "claude-sonnet-4.6": "sonnet",
+    "claude-sonnet-4-6": "sonnet",
+    "claude-opus-4.6": "opus",
+    "claude-opus-4-6": "opus",
+    "claude-haiku-4.5": "haiku",
+    "claude-haiku-4-5": "haiku",
+}
+
+# Tool allow-list — mirrors execute_bash.allowedCommands plus fs_read/fs_write
+# from cve_agent/agents/yocto-cve-backport.json.
+_ALLOWED_TOOLS = (
+    "Read", "Edit", "Write", "MultiEdit",
+    "Bash(git status:*)",
+    "Bash(git diff:*)",
+    "Bash(git log:*)",
+    "Bash(git show:*)",
+    "Bash(git add:*)",
+    "Bash(git cherry-pick:*)",
+    "Bash(git am:*)",
+    "Bash(git rev-parse:*)",
+    "Bash(git merge-base:*)",
+    "Bash(devtool build:*)",
+    "Bash(cat:*)",
+    "Bash(head:*)",
+    "Bash(tail:*)",
+)
+
+# Secrets / system paths: deny read AND write. Absolute paths use Claude Code's
+# leading "//" glob form; "~" expands to the user's home directory.
+_DENIED_READ_WRITE = (
+    "//etc/**",
+    "//proc/**",
+    "//sys/**",
+    "~/.ssh/**",
+    "~/.aws/**",
+    "~/.kiro/**",
+    "~/.gitconfig",
+    "~/.netrc",
+)
+
+# Project source and tests: deny writes only (mirrors fs_write.deniedPaths).
+_DENIED_WRITE = (
+    "**/cve_agent/**/*.py",
+    "**/cve_corrector/**/*.py",
+    "**/cve_metadata_extractor/**/*.py",
+    "**/shared/**/*.py",
+    "**/tests/**",
+)
+
+# Auth/config env vars the `claude` CLI needs but build_git_env() filters out.
+# The prefixes cover ANTHROPIC_*/CLAUDE_CODE_* (API key, auth token, base URL,
+# Bedrock/Vertex toggles); the explicit names cover the cloud-credential vars
+# used by the Bedrock and Vertex deployments.
+_CLAUDE_ENV_PREFIXES = ("ANTHROPIC_", "CLAUDE_CODE_")
+_CLAUDE_ENV_VARS = (
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+    "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE",
+    "GOOGLE_APPLICATION_CREDENTIALS", "CLOUD_ML_REGION",
+)
+
+
+def _claude_auth_env() -> dict[str, str]:
+    """Collect Claude/cloud auth env vars that build_git_env() filters out."""
+    return {
+        key: value for key, value in os.environ.items()
+        if key in _CLAUDE_ENV_VARS or key.startswith(_CLAUDE_ENV_PREFIXES)
+    }
+
+
+class ClaudeBackend(AIBackend):
+    """Backend that drives the Claude Code CLI (``claude``) directly."""
+    name = "claude"
+
+    def is_available(self) -> bool:
+        return shutil.which("claude") is not None
+
+    def _map_model(self, model: str) -> str:
+        if not model:
+            return "sonnet"
+        # Known kiro-style name -> alias; otherwise assume a valid alias or id.
+        return _MODEL_ALIASES.get(model, model)
+
+    def _build_command(self, prompt: str, agent_dir: Path,
+                       model: str, interactive: bool) -> list[str]:
+        cmd = ["claude"]
+        if not interactive:
+            cmd.append("-p")
+        cmd += ["--model", self._map_model(model)]
+        cmd += ["--permission-mode", "acceptEdits" if not interactive else "default"]
+        # The context file and agent artifacts live outside the session cwd.
+        cmd += ["--add-dir", str(agent_dir)]
+        if _AGENT_INSTRUCTIONS.is_file():
+            cmd += ["--append-system-prompt",
+                    _AGENT_INSTRUCTIONS.read_text(encoding="utf-8")]
+        else:
+            logging.warning(
+                "Agent instructions not found (%s); running without a system "
+                "prompt. File scope is still enforced by the pre-commit hook.",
+                _AGENT_INSTRUCTIONS)
+        for tool in _ALLOWED_TOOLS:
+            cmd += ["--allowedTools", tool]
+        for path in _DENIED_READ_WRITE:
+            for tool in ("Read", "Edit", "Write"):
+                cmd += ["--disallowedTools", f"{tool}({path})"]
+        for path in _DENIED_WRITE:
+            for tool in ("Edit", "Write"):
+                cmd += ["--disallowedTools", f"{tool}({path})"]
+        cmd.append(prompt)
+        return cmd
+
+    def run_session(self, prompt: str, workspace_path: Path,
+                   allowed_files: set, model: str,
+                   timeout: int, interactive: bool) -> SessionResult:
+        from . import get_agent_dir
+
+        agent_dir = get_agent_dir(workspace_path)
+        # Start from the git-safe env (used by claude's child git processes),
+        # then restore the Claude/cloud auth vars build_git_env() filters out.
+        env = build_git_env()
+        env.update(_claude_auth_env())
+        cmd = self._build_command(prompt, agent_dir, model, interactive)
+
+        start = time.monotonic()
+        timed_out = False
+        try:
+            subprocess.run(cmd, cwd=workspace_path, env=env,
+                         check=False, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+        except FileNotFoundError:
+            logging.error(
+                "claude CLI not found. Install Claude Code or add it to PATH.")
+        except KeyboardInterrupt:
+            pass
+
+        duration = time.monotonic() - start
+        if timed_out:
+            return SessionResult(resolved=False, duration=duration)
+
+        resolved = self._check_resolution(workspace_path)
+        return SessionResult(resolved=resolved, duration=duration)
+
+    def _check_resolution(self, workspace_path: Path) -> bool:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=workspace_path, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.splitlines():
+            if line and len(line) >= 2 and (line[0] == "U" or line[1] == "U"):
+                return False
+        return True

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -11,9 +11,11 @@ post-session revert installed by :func:`cve_agent.session.guarded_session`.
 The ``--allowedTools`` / ``--disallowedTools`` lists below are defense-in-depth
 mirrors of ``cve_agent/agents/yocto-cve-backport.json``.
 """
+import contextlib
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -21,6 +23,7 @@ from pathlib import Path
 from shared import build_git_env
 
 from .backend import AIBackend, SessionResult
+from .git import has_in_progress_operation
 
 # Packaged agent instructions, injected as the Claude system prompt for parity
 # with the kiro agent (whose ``prompt`` field points at the same file).
@@ -136,6 +139,13 @@ class ClaudeBackend(AIBackend):
         for path in _DENIED_WRITE:
             for tool in ("Edit", "Write"):
                 cmd += ["--disallowedTools", f"{tool}({path})"]
+        # "--" marks end-of-options: without it, claude's arg parser folds the
+        # trailing prompt word-by-word into the preceding --disallowedTools
+        # list instead of treating it as the prompt (reproduced: each word of
+        # the prompt showed up as its own bogus "Permission deny rule" error,
+        # and headless -p mode then failed with "Input must be provided
+        # either through stdin or as a prompt argument").
+        cmd.append("--")
         cmd.append(prompt)
         return cmd
 
@@ -151,27 +161,73 @@ class ClaudeBackend(AIBackend):
         env.update(_claude_auth_env())
         cmd = self._build_command(prompt, agent_dir, model, interactive)
 
+        pre_head = self._current_head(workspace_path)
         start = time.monotonic()
-        timed_out = False
+        interrupted = None
         try:
-            subprocess.run(cmd, cwd=workspace_path, env=env,
-                         check=False, timeout=timeout)
-        except subprocess.TimeoutExpired:
-            timed_out = True
+            proc = subprocess.Popen(cmd, cwd=workspace_path, env=env,
+                                    start_new_session=True)
         except FileNotFoundError:
             logging.error(
                 "claude CLI not found. Install Claude Code or add it to PATH.")
-        except KeyboardInterrupt:
-            pass
+            proc = None
+
+        if proc is not None:
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                interrupted = "timed out"
+                self._kill_process_group(proc)
+            except KeyboardInterrupt:
+                interrupted = "was interrupted"
+                self._kill_process_group(proc)
 
         duration = time.monotonic() - start
-        if timed_out:
-            return SessionResult(resolved=False, duration=duration)
-
         resolved = self._check_resolution(workspace_path)
+        if interrupted and resolved:
+            # The session was killed before it exited normally — it may have
+            # already finished its git commit right before being killed, in
+            # which case HEAD moved and the resolution is real. But a clean
+            # tree with an unmoved HEAD means the session never got anywhere
+            # (e.g. a hard hang before touching git); don't credit that as
+            # resolved just because nothing was ever staged.
+            if self._current_head(workspace_path) == pre_head:
+                logging.warning(
+                    "claude session %s after %.1fs with no new commit in "
+                    "%s; treating as unresolved despite a clean git status",
+                    interrupted, duration, workspace_path)
+                resolved = False
+            else:
+                logging.warning(
+                    "claude session %s after %.1fs but had already "
+                    "committed a resolution in %s before being killed",
+                    interrupted, duration, workspace_path)
         return SessionResult(resolved=resolved, duration=duration)
 
+    @staticmethod
+    def _kill_process_group(proc: subprocess.Popen) -> None:
+        """SIGKILL the whole process group, not just the direct child.
+
+        ``proc`` was started with ``start_new_session=True`` so its pid is
+        also its process group id. Killing only the direct child would leave
+        a grandchild git process (e.g. one claude shelled out to for
+        ``cherry-pick --continue``) free to keep mutating the workspace while
+        the post-timeout resolution check reads git state right after.
+        """
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+    def _current_head(self, workspace_path: Path) -> str:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=workspace_path, capture_output=True, text=True, check=False)
+        return result.stdout.strip() if result.returncode == 0 else ""
+
     def _check_resolution(self, workspace_path: Path) -> bool:
+        if has_in_progress_operation(workspace_path):
+            return False
         result = subprocess.run(
             ["git", "status", "--porcelain"],
             cwd=workspace_path, capture_output=True, text=True, check=False)

--- a/cve_agent/git.py
+++ b/cve_agent/git.py
@@ -68,6 +68,25 @@ def get_all_upstream_shas(cve_info: dict, workspace_path: Path) -> list[str]:
     return [hashes[0]] if hashes else []
 
 
+def has_in_progress_operation(workspace_path: Path) -> bool:
+    """Check whether a cherry-pick or merge is still mid-flight.
+
+    Staging a conflicted file (`git add`) clears its U marker in `git status
+    --porcelain` output, but the operation itself isn't finalized until
+    `--continue` commits it. Both backends must treat this as unresolved even
+    when porcelain shows nothing outstanding, or a session that staged but
+    never continued looks identical to a genuinely finished one.
+
+    Args:
+        workspace_path: Path to workspace.
+
+    Returns:
+        True if CHERRY_PICK_HEAD or MERGE_HEAD is present under .git.
+    """
+    git_dir = workspace_path / '.git'
+    return (git_dir / 'CHERRY_PICK_HEAD').exists() or (git_dir / 'MERGE_HEAD').exists()
+
+
 def get_changed_files(git_args: list[str], cwd: Path) -> set[str]:
     """Run a git command and return the output lines as a set.
 

--- a/cve_agent/kiro_backend.py
+++ b/cve_agent/kiro_backend.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Kiro AI backend for CVE agent sessions.
+
+Drives ``kiro-cli`` with the packaged ``yocto-cve-backport`` agent. This is
+the default backend; :mod:`cve_agent.claude_backend` mirrors its behaviour
+for the ``claude`` CLI.
+"""
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+from shared import build_git_env
+
+from .backend import AIBackend, SessionResult
+from .git import has_in_progress_operation
+
+
+class KiroBackend(AIBackend):
+    """Default backend using kiro-cli."""
+    name = "kiro"
+
+    def is_available(self) -> bool:
+        import shutil
+        return shutil.which("kiro-cli") is not None
+
+    def run_session(self, prompt: str, workspace_path: Path,
+                   allowed_files: set, model: str,
+                   timeout: int, interactive: bool) -> SessionResult:
+        agent_name = ('yocto-cve-backport-interactive' if interactive
+                      else 'yocto-cve-backport')
+        env = build_git_env()
+        cmd = ['kiro-cli', 'chat', '--agent', agent_name, '--model', model]
+        if not interactive:
+            cmd.append('--no-interactive')
+            cmd.append('--trust-tools=fs_read,fs_write,execute_bash')
+        cmd.append(prompt)
+
+        start = time.monotonic()
+        timed_out = False
+        try:
+            subprocess.run(cmd, cwd=workspace_path, env=env,
+                         check=False, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+        except FileNotFoundError:
+            logging.error("kiro-cli not found. Install it or add to PATH.")
+        except KeyboardInterrupt:
+            pass
+
+        duration = time.monotonic() - start
+        if timed_out:
+            return SessionResult(resolved=False, duration=duration)
+
+        resolved = self._check_resolution(workspace_path)
+        return SessionResult(resolved=resolved, duration=duration)
+
+    def _check_resolution(self, workspace_path: Path) -> bool:
+        if has_in_progress_operation(workspace_path):
+            return False
+        result = subprocess.run(
+            ['git', 'status', '--porcelain'],
+            cwd=workspace_path, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.splitlines():
+            if line and len(line) >= 2 and (line[0] == 'U' or line[1] == 'U'):
+                return False
+        return True
+
+    def setup(self, **kwargs) -> None:
+        from .setup import ensure_agents
+        ensure_agents(interactive=kwargs.get('interactive', True))

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -85,7 +85,7 @@ def _is_empty_cherry_pick(workspace_path: Path, cve_info: dict) -> bool:
 def _resolution_loop(config: AgentConfig, workspace_path: Path,
                      exit_code: int, cve_info: dict,
                      knowledge_base: KnowledgeBase) -> CveResult:
-    """Run the resolution loop: context -> kiro-cli -> approval -> continue."""
+    """Run the resolution loop: context -> AI backend -> approval -> continue."""
     start_time = time.monotonic()
     current_step = exit_code
     attempt = 0
@@ -138,14 +138,16 @@ def _run_single_resolution_attempt(
         backend_name=config.backend)
 
     if not session_result.resolved:
-        print(f"Kiro session did not resolve conflicts for {config.cve_id}")
+        print(f"{config.backend} session did not resolve conflicts for {config.cve_id}")
         if config.trust_mode:
             return _AttemptOutcome()
-        response = input("Retry kiro session? [y]es / [n]o (escalate): ").strip().lower()
+        response = input(
+            f"Retry {config.backend} session? [y]es / [n]o (escalate): "
+        ).strip().lower()
         if response in ('n', 'no'):
             return _AttemptOutcome(result=_make_result(
                 config.cve_id, ResultStatus.ESCALATED,
-                attempt, start_time, "Kiro session failed to resolve"
+                attempt, start_time, f"{config.backend} session failed to resolve"
             ))
         return _AttemptOutcome()
 
@@ -162,7 +164,8 @@ def _run_single_resolution_attempt(
     if not workspace_path.exists():
         return _AttemptOutcome(result=_make_result(
             config.cve_id, ResultStatus.CONFLICT_RESOLVED,
-            attempt, start_time, "Resolved via kiro-cli (workspace finalized)"
+            attempt, start_time,
+            f"Resolved via {config.backend} (workspace finalized)"
         ))
 
     approval, feedback = request_approval(workspace_path, upstream_sha, config)
@@ -202,7 +205,7 @@ def _finalize_resolution(config: AgentConfig, knowledge_base: KnowledgeBase,
         )
         return _AttemptOutcome(result=_make_result(
             config.cve_id, ResultStatus.CONFLICT_RESOLVED,
-            attempt, start_time, "Resolved via kiro-cli"
+            attempt, start_time, f"Resolved via {config.backend}"
         ))
 
     if continue_exit in UNRECOVERABLE_EXITS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 markers = [
     "integration: tests that create git repos or require external resources",
+    "live: opt-in tests that drive a real AI backend CLI (needs binary + auth)",
 ]
 
 [tool.coverage.run]

--- a/tests/agent/test_backend.py
+++ b/tests/agent/test_backend.py
@@ -1,15 +1,23 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 """Tests for pluggable AI backend interface."""
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from cve_agent.backend import (
     AIBackend,
+    KiroBackend,
     SessionResult,
     available_backends,
     get_backend,
     register_backend,
 )
+
+
+def _completed(cmd, stdout=""):
+    return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
 
 class MockBackend(AIBackend):
@@ -43,3 +51,22 @@ def test_default_backend_is_kiro():
     assert 'kiro' in available_backends()
     backend = get_backend('kiro')
     assert backend.name == 'kiro'
+
+
+@pytest.mark.parametrize("marker", ["CHERRY_PICK_HEAD", "MERGE_HEAD"])
+def test_kiro_check_resolution_mid_operation_is_unresolved(tmp_path, monkeypatch, marker):
+    """Same false-positive this backend shares with ClaudeBackend: staging a
+    conflicted file clears its U marker, but the cherry-pick/merge itself
+    isn't finalized until --continue commits it.
+    """
+    workspace = tmp_path / "workspace" / "sources" / "openssl"
+    workspace.mkdir(parents=True)
+    git_dir = workspace / ".git"
+    git_dir.mkdir()
+    (git_dir / marker).write_text("deadbeef\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        return _completed(cmd, stdout="")  # staged: no U markers left
+
+    monkeypatch.setattr("cve_agent.backend.subprocess.run", fake_run)
+    assert KiroBackend()._check_resolution(workspace) is False

--- a/tests/agent/test_backend.py
+++ b/tests/agent/test_backend.py
@@ -2,18 +2,20 @@
 # SPDX-License-Identifier: MIT
 """Tests for pluggable AI backend interface."""
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+import cve_agent
 from cve_agent.backend import (
     AIBackend,
-    KiroBackend,
     SessionResult,
     available_backends,
     get_backend,
     register_backend,
 )
+from cve_agent.kiro_backend import KiroBackend
 
 
 def _completed(cmd, stdout=""):
@@ -53,6 +55,18 @@ def test_default_backend_is_kiro():
     assert backend.name == 'kiro'
 
 
+def test_kiro_backend_module_imports_standalone():
+    """Importing cve_agent.kiro_backend before cve_agent.backend must work —
+    same import-order guarantee test_claude_backend.py asserts for the claude
+    module. A fresh interpreter is the only reliable way to test import order.
+    """
+    project_root = Path(cve_agent.__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "-c", "import cve_agent.kiro_backend"],
+        capture_output=True, text=True, check=False, cwd=project_root)
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.parametrize("marker", ["CHERRY_PICK_HEAD", "MERGE_HEAD"])
 def test_kiro_check_resolution_mid_operation_is_unresolved(tmp_path, monkeypatch, marker):
     """Same false-positive this backend shares with ClaudeBackend: staging a
@@ -68,5 +82,5 @@ def test_kiro_check_resolution_mid_operation_is_unresolved(tmp_path, monkeypatch
     def fake_run(cmd, **kwargs):
         return _completed(cmd, stdout="")  # staged: no U markers left
 
-    monkeypatch.setattr("cve_agent.backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.kiro_backend.subprocess.run", fake_run)
     assert KiroBackend()._check_resolution(workspace) is False

--- a/tests/agent/test_cases_orchestration.py
+++ b/tests/agent/test_cases_orchestration.py
@@ -311,6 +311,38 @@ class TestAgentConflictResolved:
 
         assert result.status == ResultStatus.CONFLICT_RESOLVED
 
+    def test_agent_conflict_resolved_summary_names_actual_backend(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """The resolution summary must name whichever backend actually ran,
+        not a hardcoded "kiro-cli" — misleading once more than one backend
+        exists, since a claude-resolved CVE would be reported as kiro's work.
+        """
+        bare, hashes = make_upstream_repo(
+            files={'src/file.c': 'line1\nline2\nline3\nvulnerable\nline5\n'},
+            version_tag='v1.36.1',
+            fix_commits=[{'files': {'src/file.c': 'line1\nline2\nline3\nfixed\nline5\n'},
+                          'message': 'Fix vulnerability'}])
+
+        ws = make_workspace(bare, 'busybox', 'v1.36.1',
+                            existing_patch_commits=[
+                                {'files': {'src/file.c': 'line1\nline2\nline3\nexisting\nline5\n'},
+                                 'message': 'Existing patch'}])
+        meta = make_meta_layer('busybox', '1.36.1',
+                               existing_patches={'0001-Existing-patch.patch': 'p\n'})
+        mock_bitbake_env(ws, meta, 'busybox', '1.36.1')
+
+        cve_id = 'CVE-2026-26158'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'busybox', hashes)
+        config = _cfg(cve_id, cve_info_path, meta, backend='claude')
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        result = _run(config, kb, session_side_effect=_resolve_conflict_side_effect)
+
+        assert result.status == ResultStatus.CONFLICT_RESOLVED
+        assert 'claude' in result.resolution_summary.lower()
+        assert 'kiro' not in result.resolution_summary.lower()
+
 
 # ---------------------------------------------------------------------------
 # Test 7: Conflict state resume

--- a/tests/agent/test_claude_backend.py
+++ b/tests/agent/test_claude_backend.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 """Tests for the Claude Code (`claude` CLI) AI backend."""
+import signal
 import subprocess
 from pathlib import Path
 
@@ -23,6 +24,47 @@ def _make_workspace(tmp_path: Path) -> Path:
 
 def _completed(cmd, stdout=""):
     return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+
+class _FakePopen:
+    """Minimal stand-in for subprocess.Popen driving the `claude` process."""
+
+    def __init__(self, cmd, wait_effect=None, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.pid = 4321
+        self._wait_effect = wait_effect
+        self.wait_calls = 0
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        if self.wait_calls == 1 and self._wait_effect is not None:
+            raise self._wait_effect
+        return 0
+
+
+def _popen_ctor(calls, wait_effect=None):
+    """Fake subprocess.Popen constructor recording (cmd, kwargs) into `calls`.
+
+    `wait_effect`, if given, is raised from the *first* proc.wait() call
+    (simulating a timeout or Ctrl-C); the follow-up proc.wait() made by
+    ClaudeBackend._kill_process_group() always succeeds.
+    """
+    def _ctor(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _FakePopen(cmd, wait_effect=wait_effect, **kwargs)
+    return _ctor
+
+
+def _git_stub(porcelain="", head="deadbeef"):
+    """Fake subprocess.run for the `git status`/`git rev-parse HEAD` calls
+    ClaudeBackend makes around the claude session (unrelated to the Popen
+    call driving `claude` itself)."""
+    def _run(cmd, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return _completed(cmd, stdout=f"{head}\n")
+        return _completed(cmd, stdout=porcelain)
+    return _run
 
 
 def test_claude_backend_registered():
@@ -58,13 +100,11 @@ def test_map_model(given, expected):
 
 def test_run_session_noninteractive_command(tmp_path, monkeypatch):
     workspace = _make_workspace(tmp_path)
-    calls = []
+    popen_calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        return _completed(cmd)
-
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
 
     result = ClaudeBackend().run_session(
         "Read the file /x/context.md and follow it.",
@@ -73,8 +113,7 @@ def test_run_session_noninteractive_command(tmp_path, monkeypatch):
     assert result.resolved is True
     assert result.duration >= 0
 
-    claude_cmd, claude_kwargs = next(
-        (c, k) for c, k in calls if c[0] == "claude")
+    claude_cmd, claude_kwargs = popen_calls[0]
 
     # Headless print mode, model mapped, auto-accept edits.
     assert claude_cmd[1] == "-p"
@@ -92,27 +131,30 @@ def test_run_session_noninteractive_command(tmp_path, monkeypatch):
     assert "Read(//etc/**)" in claude_cmd
     assert "Edit(**/cve_agent/**/*.py)" in claude_cmd
 
-    # Prompt is passed positionally as the final argument.
+    # Prompt is passed positionally as the final argument, after a "--"
+    # end-of-options marker (without it, claude's parser folds a multi-word
+    # trailing prompt word-by-word into the preceding --disallowedTools list).
+    assert claude_cmd[-2] == "--"
     assert claude_cmd[-1] == "Read the file /x/context.md and follow it."
 
-    # Safe subprocess usage in the recipe workspace.
+    # Safe subprocess usage in the recipe workspace, in its own process
+    # group so a timeout can kill the whole tree rather than just claude.
     assert claude_kwargs["cwd"] == workspace
     assert claude_kwargs.get("shell", False) is False
+    assert claude_kwargs["start_new_session"] is True
 
 
 def test_run_session_denies_every_sensitive_path(tmp_path, monkeypatch):
     """Every deny entry from the kiro manifest translation must be emitted."""
     workspace = _make_workspace(tmp_path)
-    calls = []
+    popen_calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return _completed(cmd)
-
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
     ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
 
-    claude_cmd = next(c for c in calls if c[0] == "claude")
+    claude_cmd, _ = popen_calls[0]
     for path in _DENIED_READ_WRITE:
         for tool in ("Read", "Edit", "Write"):
             assert f"{tool}({path})" in claude_cmd
@@ -126,16 +168,14 @@ def test_run_session_passes_claude_auth_env(tmp_path, monkeypatch):
     workspace = _make_workspace(tmp_path)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-123")
     monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
-    calls = []
+    popen_calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        return _completed(cmd)
-
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
     ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
 
-    _, claude_kwargs = next((c, k) for c, k in calls if c[0] == "claude")
+    _, claude_kwargs = popen_calls[0]
     assert claude_kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-test-123"
     assert claude_kwargs["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
 
@@ -144,58 +184,130 @@ def test_run_session_missing_binary_does_not_crash(tmp_path, monkeypatch):
     """A missing claude binary is handled gracefully (parity with kiro)."""
     workspace = _make_workspace(tmp_path)
 
-    def fake_run(cmd, **kwargs):
-        if cmd[0] == "claude":
-            raise FileNotFoundError(cmd[0])
-        return _completed(cmd)
+    def raise_not_found(cmd, **kwargs):
+        raise FileNotFoundError(cmd[0])
 
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen", raise_not_found)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
     result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
     assert result.duration >= 0
 
 
 def test_run_session_keyboard_interrupt_does_not_crash(tmp_path, monkeypatch):
-    """Ctrl-C during a session is swallowed, not propagated (parity with kiro)."""
+    """Ctrl-C during a session is swallowed, not propagated (parity with kiro),
+    the process group is still killed so nothing is left running, and — same
+    as a timeout — a clean-but-unmoved-HEAD tree must not be credited as
+    resolved just because Ctrl-C landed before claude touched git at all.
+    """
     workspace = _make_workspace(tmp_path)
+    popen_calls = []
+    killed = []
 
-    def fake_run(cmd, **kwargs):
-        if cmd[0] == "claude":
-            raise KeyboardInterrupt
-        return _completed(cmd)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls, wait_effect=KeyboardInterrupt()))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run",
+                        _git_stub(head="unmoved-head"))
+    monkeypatch.setattr("cve_agent.claude_backend.os.killpg",
+                        lambda pid, sig: killed.append((pid, sig)))
 
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
     result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
     assert result.duration >= 0
+    assert result.resolved is False
+    assert killed == [(4321, signal.SIGKILL)]
 
 
 def test_run_session_interactive_omits_print(tmp_path, monkeypatch):
     workspace = _make_workspace(tmp_path)
-    calls = []
+    popen_calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return _completed(cmd)
-
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
 
     ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, True)
 
-    claude_cmd = next(c for c in calls if c[0] == "claude")
+    claude_cmd, _ = popen_calls[0]
     assert "-p" not in claude_cmd
     assert claude_cmd[claude_cmd.index("--permission-mode") + 1] == "default"
 
 
 def test_run_session_timeout_returns_unresolved(tmp_path, monkeypatch):
+    """claude times out AND the workspace genuinely still has conflicts."""
     workspace = _make_workspace(tmp_path)
 
-    def fake_run(cmd, **kwargs):
-        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
-
-    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "cve_agent.claude_backend.subprocess.Popen",
+        _popen_ctor([], wait_effect=subprocess.TimeoutExpired("claude", 1)))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run",
+                        _git_stub(porcelain="UU crypto/asn1/tasn_dec.c\n"))
 
     result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 1, False)
     assert result.resolved is False
     assert result.duration >= 0
+
+
+def test_run_session_timeout_but_already_resolved(tmp_path, monkeypatch):
+    """claude finishes its git commit right before the kill signal lands.
+
+    A subprocess timeout only means the claude process didn't exit in time —
+    not that its work was lost. If HEAD actually advanced (a real commit was
+    made) and the tree is clean, that must be reported as resolved rather
+    than triggering a wasted retry.
+    """
+    workspace = _make_workspace(tmp_path)
+    heads = iter(["before-head", "after-head"])
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return _completed(cmd, stdout=f"{next(heads)}\n")
+        return _completed(cmd, stdout="")
+
+    monkeypatch.setattr(
+        "cve_agent.claude_backend.subprocess.Popen",
+        _popen_ctor([], wait_effect=subprocess.TimeoutExpired("claude", 1)))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+
+    result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 1, False)
+    assert result.resolved is True
+    assert result.duration >= 0
+
+
+def test_run_session_timeout_with_no_progress_is_unresolved(tmp_path, monkeypatch):
+    """A hard hang that never touched git must not be reported as resolved
+    just because the tree happens to be clean. Same HEAD before and after
+    means no commit was made, so nothing was actually fixed — this is the
+    scenario a bare "clean tree => resolved" check on timeout would miss.
+    """
+    workspace = _make_workspace(tmp_path)
+
+    monkeypatch.setattr(
+        "cve_agent.claude_backend.subprocess.Popen",
+        _popen_ctor([], wait_effect=subprocess.TimeoutExpired("claude", 1)))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run",
+                        _git_stub(porcelain="", head="same-head"))
+
+    result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 1, False)
+    assert result.resolved is False
+
+
+def test_run_session_timeout_kills_process_group(tmp_path, monkeypatch):
+    """On timeout, the whole process group must be killed, not just the
+    direct child — otherwise an orphaned grandchild git process (e.g. one
+    claude shelled out to for `cherry-pick --continue`) can keep mutating
+    the workspace while the post-timeout resolution check runs.
+    """
+    workspace = _make_workspace(tmp_path)
+    killed = []
+
+    monkeypatch.setattr(
+        "cve_agent.claude_backend.subprocess.Popen",
+        _popen_ctor([], wait_effect=subprocess.TimeoutExpired("claude", 1)))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
+    monkeypatch.setattr("cve_agent.claude_backend.os.killpg",
+                        lambda pid, sig: killed.append((pid, sig)))
+
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 1, False)
+    assert killed == [(4321, signal.SIGKILL)]
 
 
 @pytest.mark.parametrize("porcelain,expected", [
@@ -212,3 +324,45 @@ def test_check_resolution(tmp_path, monkeypatch, porcelain, expected):
 
     monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
     assert ClaudeBackend()._check_resolution(workspace) is expected
+
+
+@pytest.mark.parametrize("marker", ["CHERRY_PICK_HEAD", "MERGE_HEAD"])
+def test_check_resolution_mid_operation_is_unresolved(tmp_path, monkeypatch, marker):
+    """Staging a conflicted file clears the U marker in porcelain output, but
+    the cherry-pick/merge itself isn't finalized until --continue commits it.
+    Without this check, a session that staged-but-never-continued looks
+    identical to a genuinely finished one — exactly what happened in a real
+    run: claude got blocked mid-session and the false "resolved" verdict let
+    the workflow proceed past a fix that was never actually committed.
+    """
+    workspace = _make_workspace(tmp_path)
+    git_dir = workspace / ".git"
+    git_dir.mkdir()
+    (git_dir / marker).write_text("deadbeef\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        return _completed(cmd, stdout="")  # staged: no U markers left
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    assert ClaudeBackend()._check_resolution(workspace) is False
+
+
+def test_check_resolution_clean_with_no_git_dir(tmp_path, monkeypatch):
+    """Sanity: the marker check must not error when .git doesn't exist."""
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return _completed(cmd, stdout="")
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    assert ClaudeBackend()._check_resolution(workspace) is True
+
+
+def test_current_head_returns_empty_on_failure(tmp_path, monkeypatch):
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="not a repo")
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    assert ClaudeBackend()._current_head(workspace) == ""

--- a/tests/agent/test_claude_backend.py
+++ b/tests/agent/test_claude_backend.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for the Claude Code (`claude` CLI) AI backend."""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cve_agent.backend import available_backends, get_backend
+from cve_agent.claude_backend import (
+    _DENIED_READ_WRITE,
+    _DENIED_WRITE,
+    ClaudeBackend,
+)
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    """Create a devtool-style workspace: <build>/workspace/sources/<recipe>."""
+    workspace = tmp_path / "workspace" / "sources" / "openssl"
+    workspace.mkdir(parents=True)
+    return workspace
+
+
+def _completed(cmd, stdout=""):
+    return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+
+def test_claude_backend_registered():
+    assert "claude" in available_backends()
+    backend = get_backend("claude")
+    assert backend.name == "claude"
+    assert isinstance(backend, ClaudeBackend)
+
+
+def test_is_available_true(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/claude")
+    assert ClaudeBackend().is_available() is True
+
+
+def test_is_available_false(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    assert ClaudeBackend().is_available() is False
+
+
+@pytest.mark.parametrize("given,expected", [
+    ("claude-sonnet-4.6", "sonnet"),
+    ("claude-sonnet-4-6", "sonnet"),
+    ("claude-opus-4.6", "opus"),
+    ("", "sonnet"),
+    ("sonnet", "sonnet"),
+    ("opus", "opus"),
+    ("haiku", "haiku"),
+    ("claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022"),
+])
+def test_map_model(given, expected):
+    assert ClaudeBackend()._map_model(given) == expected
+
+
+def test_run_session_noninteractive_command(tmp_path, monkeypatch):
+    workspace = _make_workspace(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+
+    result = ClaudeBackend().run_session(
+        "Read the file /x/context.md and follow it.",
+        workspace, {"crypto/foo.c"}, "claude-sonnet-4.6", 300, False)
+
+    assert result.resolved is True
+    assert result.duration >= 0
+
+    claude_cmd, claude_kwargs = next(
+        (c, k) for c, k in calls if c[0] == "claude")
+
+    # Headless print mode, model mapped, auto-accept edits.
+    assert claude_cmd[1] == "-p"
+    assert claude_cmd[claude_cmd.index("--model") + 1] == "sonnet"
+    assert claude_cmd[claude_cmd.index("--permission-mode") + 1] == "acceptEdits"
+
+    # Context file lives outside cwd, so the agent dir must be shared.
+    assert "--add-dir" in claude_cmd
+    # System prompt carries the packaged agent instructions.
+    assert "--append-system-prompt" in claude_cmd
+
+    # Tool allow-list and deny-list are present (defense-in-depth).
+    assert "Edit" in claude_cmd
+    assert "Bash(git status:*)" in claude_cmd
+    assert "Read(//etc/**)" in claude_cmd
+    assert "Edit(**/cve_agent/**/*.py)" in claude_cmd
+
+    # Prompt is passed positionally as the final argument.
+    assert claude_cmd[-1] == "Read the file /x/context.md and follow it."
+
+    # Safe subprocess usage in the recipe workspace.
+    assert claude_kwargs["cwd"] == workspace
+    assert claude_kwargs.get("shell", False) is False
+
+
+def test_run_session_denies_every_sensitive_path(tmp_path, monkeypatch):
+    """Every deny entry from the kiro manifest translation must be emitted."""
+    workspace = _make_workspace(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+
+    claude_cmd = next(c for c in calls if c[0] == "claude")
+    for path in _DENIED_READ_WRITE:
+        for tool in ("Read", "Edit", "Write"):
+            assert f"{tool}({path})" in claude_cmd
+    for path in _DENIED_WRITE:
+        for tool in ("Edit", "Write"):
+            assert f"{tool}({path})" in claude_cmd
+
+
+def test_run_session_passes_claude_auth_env(tmp_path, monkeypatch):
+    """Claude auth vars that build_git_env() strips must reach the subprocess."""
+    workspace = _make_workspace(tmp_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-123")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+
+    _, claude_kwargs = next((c, k) for c, k in calls if c[0] == "claude")
+    assert claude_kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-test-123"
+    assert claude_kwargs["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+
+def test_run_session_missing_binary_does_not_crash(tmp_path, monkeypatch):
+    """A missing claude binary is handled gracefully (parity with kiro)."""
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "claude":
+            raise FileNotFoundError(cmd[0])
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+    assert result.duration >= 0
+
+
+def test_run_session_keyboard_interrupt_does_not_crash(tmp_path, monkeypatch):
+    """Ctrl-C during a session is swallowed, not propagated (parity with kiro)."""
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "claude":
+            raise KeyboardInterrupt
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+    assert result.duration >= 0
+
+
+def test_run_session_interactive_omits_print(tmp_path, monkeypatch):
+    workspace = _make_workspace(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, True)
+
+    claude_cmd = next(c for c in calls if c[0] == "claude")
+    assert "-p" not in claude_cmd
+    assert claude_cmd[claude_cmd.index("--permission-mode") + 1] == "default"
+
+
+def test_run_session_timeout_returns_unresolved(tmp_path, monkeypatch):
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+
+    result = ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 1, False)
+    assert result.resolved is False
+    assert result.duration >= 0
+
+
+@pytest.mark.parametrize("porcelain,expected", [
+    ("", True),
+    (" M crypto/foo.c\n", True),
+    ("UU crypto/foo.c\n", False),
+    ("AU crypto/foo.c\n", False),
+])
+def test_check_resolution(tmp_path, monkeypatch, porcelain, expected):
+    workspace = _make_workspace(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return _completed(cmd, stdout=porcelain)
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", fake_run)
+    assert ClaudeBackend()._check_resolution(workspace) is expected

--- a/tests/agent/test_claude_backend.py
+++ b/tests/agent/test_claude_backend.py
@@ -3,10 +3,12 @@
 """Tests for the Claude Code (`claude` CLI) AI backend."""
 import signal
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+import cve_agent
 from cve_agent.backend import available_backends, get_backend
 from cve_agent.claude_backend import (
     _DENIED_READ_WRITE,
@@ -72,6 +74,19 @@ def test_claude_backend_registered():
     backend = get_backend("claude")
     assert backend.name == "claude"
     assert isinstance(backend, ClaudeBackend)
+
+
+def test_claude_backend_module_imports_standalone():
+    """Regression: importing cve_agent.claude_backend BEFORE cve_agent.backend
+    used to raise ImportError — backend.py's module-bottom registration import
+    re-entered the partially initialized claude_backend module. A fresh
+    interpreter is the only reliable way to test import order.
+    """
+    project_root = Path(cve_agent.__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "-c", "import cve_agent.claude_backend"],
+        capture_output=True, text=True, check=False, cwd=project_root)
+    assert result.returncode == 0, result.stderr
 
 
 def test_is_available_true(monkeypatch):
@@ -178,6 +193,36 @@ def test_run_session_passes_claude_auth_env(tmp_path, monkeypatch):
     _, claude_kwargs = popen_calls[0]
     assert claude_kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-test-123"
     assert claude_kwargs["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+
+def test_run_session_excludes_unrelated_secrets(tmp_path, monkeypatch):
+    """Restoring Claude auth vars must not reopen the filtered environment:
+    secrets outside the Claude/cloud allow-set stay out of the session env.
+    (The inverse of test_run_session_passes_claude_auth_env.)
+    """
+    workspace = _make_workspace(tmp_path)
+    secrets = {
+        "GITHUB_TOKEN": "ghp_secret",
+        "OPENAI_API_KEY": "sk-other-vendor",
+        "GPG_PASSPHRASE": "hunter2",
+        "DATABASE_URL": "postgres://user:pass@host/db",
+        "MY_APP_SECRET": "s3cr3t",
+    }
+    for key, value in secrets.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-123")
+    popen_calls = []
+
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.Popen",
+                        _popen_ctor(popen_calls))
+    monkeypatch.setattr("cve_agent.claude_backend.subprocess.run", _git_stub())
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+
+    _, claude_kwargs = popen_calls[0]
+    session_env = claude_kwargs["env"]
+    for key in secrets:
+        assert key not in session_env
+    assert session_env["ANTHROPIC_API_KEY"] == "sk-test-123"
 
 
 def test_run_session_missing_binary_does_not_crash(tmp_path, monkeypatch):

--- a/tests/agent/test_claude_cli_contract.py
+++ b/tests/agent/test_claude_cli_contract.py
@@ -1,0 +1,157 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Contract tests for the Claude backend using a stub ``claude`` CLI.
+
+The unit tests in test_claude_backend.py mock ``subprocess.Popen`` and so
+verify the command list we *build*. These tests instead spawn a real
+subprocess — a stub ``claude`` executable that records the argv, environment,
+and working directory it actually receives — verifying the full spawn path
+(PATH lookup, argument encoding, environment filtering) without needing the
+real binary or an API key.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cve_agent.claude_backend import (
+    _ALLOWED_TOOLS,
+    _CLAUDE_ENV_PREFIXES,
+    _CLAUDE_ENV_VARS,
+    ClaudeBackend,
+)
+
+
+@pytest.fixture
+def fake_claude(tmp_path, monkeypatch):
+    """Install a stub ``claude`` on PATH recording argv/env/cwd; returns dir.
+
+    argv is recorded NUL-separated so multi-word arguments (the prompt)
+    survive round-tripping exactly as the process received them.
+
+    Real Claude/cloud credentials are scrubbed first: the stub dumps the
+    child environment to a plaintext file under tmp_path, and a developer's
+    genuine ANTHROPIC_API_KEY must never be recorded there. Tests that
+    assert on auth passthrough set their own dummy values.
+    """
+    for key in list(os.environ):
+        if key in _CLAUDE_ENV_VARS or key.startswith(_CLAUDE_ENV_PREFIXES):
+            monkeypatch.delenv(key, raising=False)
+    record_dir = tmp_path / "claude-record"
+    record_dir.mkdir()
+    bin_dir = tmp_path / "fake-bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "claude"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\0' \"$@\" > '{record_dir}/argv'\n"
+        f"env > '{record_dir}/env'\n"
+        f"pwd > '{record_dir}/cwd'\n"
+        "exit 0\n",
+        encoding="utf-8")
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    return record_dir
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    """Create a devtool-style workspace: <build>/workspace/sources/<recipe>."""
+    workspace = tmp_path / "workspace" / "sources" / "openssl"
+    workspace.mkdir(parents=True)
+    return workspace
+
+
+def _recorded_argv(record_dir: Path) -> list[str]:
+    raw = (record_dir / "argv").read_text(encoding="utf-8")
+    return raw.split("\0")[:-1]  # drop trailing empty field after final NUL
+
+
+def _recorded_env(record_dir: Path) -> dict[str, str]:
+    env = {}
+    for line in (record_dir / "env").read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            env[key] = value
+    return env
+
+
+def test_stub_receives_expected_argv(fake_claude, tmp_path):
+    """The spawned process sees flags, mapped model, and an intact prompt."""
+    workspace = _make_workspace(tmp_path)
+    prompt = "Read the context file and resolve the conflict in tasn_dec.c."
+
+    result = ClaudeBackend().run_session(
+        prompt, workspace, {"crypto/foo.c"}, "claude-sonnet-4.6", 60, False)
+
+    argv = _recorded_argv(fake_claude)
+    assert argv[0] == "-p"
+    assert argv[argv.index("--model") + 1] == "sonnet"
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+    assert "--append-system-prompt" in argv
+    assert "--add-dir" in argv
+
+    # The multi-word prompt must arrive as ONE argument after "--" — this is
+    # exactly the encoding bug a mocked Popen cannot catch.
+    assert argv[-2] == "--"
+    assert argv[-1] == prompt
+
+    # Every allowed tool must survive the spawn as its own argument.
+    for tool in _ALLOWED_TOOLS:
+        assert tool in argv
+
+    # Stub exits 0 with no git repo present: rev-parse/status fail closed.
+    assert result.duration >= 0
+
+
+def test_stub_env_has_auth_but_not_secrets(fake_claude, tmp_path, monkeypatch):
+    """The real child env keeps Claude/cloud auth and drops other secrets."""
+    workspace = _make_workspace(tmp_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-123")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-other-vendor")
+    monkeypatch.setenv("MY_APP_SECRET", "hunter2")
+
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+
+    env = _recorded_env(fake_claude)
+    assert env.get("ANTHROPIC_API_KEY") == "sk-test-123"
+    assert env.get("CLAUDE_CODE_USE_BEDROCK") == "1"
+    assert "GITHUB_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "MY_APP_SECRET" not in env
+
+
+def test_stub_runs_in_workspace_cwd(fake_claude, tmp_path):
+    """claude must be spawned inside the recipe workspace directory."""
+    workspace = _make_workspace(tmp_path)
+
+    ClaudeBackend().run_session("prompt", workspace, set(), "sonnet", 60, False)
+
+    recorded = Path((fake_claude / "cwd").read_text(encoding="utf-8").strip())
+    assert recorded.resolve() == workspace.resolve()
+
+
+@pytest.mark.integration
+def test_resolution_verdict_from_real_git_state(fake_claude, tmp_path):
+    """End-to-end through a real spawn AND real git: a clean committed
+    workspace yields resolved=True from actual `git status` output, not a
+    mocked porcelain string."""
+    workspace = _make_workspace(tmp_path)
+    env = os.environ.copy()
+    env.update({"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"})
+    subprocess.run(["git", "init"], cwd=workspace, check=True,
+                   capture_output=True, env=env)
+    (workspace / "file.c").write_text("int x = 1;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=workspace, check=True,
+                   capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=workspace, check=True,
+                   capture_output=True, env=env)
+
+    result = ClaudeBackend().run_session(
+        "prompt", workspace, set(), "sonnet", 60, False)
+
+    assert result.resolved is True
+    assert result.duration >= 0

--- a/tests/agent/test_claude_kiro_parity.py
+++ b/tests/agent/test_claude_kiro_parity.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Guard-parity tests between the Claude backend and the kiro agent manifest.
+
+ClaudeBackend's ``--allowedTools`` / ``--disallowedTools`` lists are documented
+as mirrors of ``cve_agent/agents/yocto-cve-backport.json``. Until now only a
+comment enforced that. These tests load the manifest and fail whenever either
+side drifts: a command allowed to kiro but not claude (capability gap), a
+command allowed to claude but not kiro (privilege escalation), or a path kiro
+denies that claude does not.
+"""
+import json
+from pathlib import Path
+
+import cve_agent
+from cve_agent.claude_backend import (
+    _ALLOWED_TOOLS,
+    _DENIED_READ_WRITE,
+    _DENIED_WRITE,
+)
+
+_MANIFEST_PATH = (Path(cve_agent.__file__).resolve().parent
+                  / "agents" / "yocto-cve-backport.json")
+
+
+def _manifest() -> dict:
+    return json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _kiro_allowed_commands() -> list[str]:
+    settings = _manifest()["toolsSettings"]
+    return settings["execute_bash"]["allowedCommands"]
+
+
+def _kiro_denied_paths() -> list[str]:
+    settings = _manifest()["toolsSettings"]
+    return settings["fs_write"]["deniedPaths"]
+
+
+def _claude_bash_prefixes() -> list[str]:
+    """Extract command prefixes from Bash(<prefix>:*) allow entries."""
+    return [tool[len("Bash("):-len(":*)")] for tool in _ALLOWED_TOOLS
+            if tool.startswith("Bash(") and tool.endswith(":*)")]
+
+
+def _base_command(command: str) -> str:
+    """Normalize a kiro allowedCommands entry: strip trailing glob."""
+    return command.rstrip("*").strip()
+
+
+def _to_claude_path(kiro_path: str) -> str:
+    """Map a kiro deniedPaths entry to Claude Code's path-rule form.
+
+    Claude Code spells absolute paths with a leading ``//``; home-relative
+    and workspace-relative globs are identical in both.
+    """
+    return "/" + kiro_path if kiro_path.startswith("/") else kiro_path
+
+
+def test_manifest_exists_and_parses():
+    assert _MANIFEST_PATH.is_file()
+    assert _kiro_allowed_commands()
+    assert _kiro_denied_paths()
+
+
+def test_every_kiro_command_is_allowed_for_claude():
+    """No capability gap: each command the kiro agent may run must be covered
+    by some Bash(<prefix>:*) entry in the Claude allow-list."""
+    prefixes = _claude_bash_prefixes()
+    for command in _kiro_allowed_commands():
+        base = _base_command(command)
+        covered = any(base == prefix or base.startswith(prefix + " ")
+                      for prefix in prefixes)
+        assert covered, (
+            f"kiro allows {command!r} but no Claude Bash allow rule covers it")
+
+
+def test_no_claude_bash_rule_beyond_kiro_allowlist():
+    """No privilege escalation: each Claude Bash allow prefix must trace back
+    to at least one command in the kiro manifest.
+
+    Prefix rules are inherently broader than kiro's exact patterns —
+    ``Bash(git cherry-pick:*)`` also permits ``git cherry-pick <sha>``, not
+    just ``--continue``/``--abort``. This test locks the command *families*;
+    the git pre-commit hook remains the authoritative file-scope guard.
+    """
+    kiro_bases = [_base_command(c) for c in _kiro_allowed_commands()]
+    for prefix in _claude_bash_prefixes():
+        justified = any(base == prefix or base.startswith(prefix + " ")
+                        for base in kiro_bases)
+        assert justified, (
+            f"Claude allows Bash({prefix}:*) but the kiro manifest has no "
+            f"matching allowedCommands entry")
+
+
+def test_every_kiro_denied_path_is_write_denied_for_claude():
+    """Each path kiro denies writes to must appear in a Claude deny list
+    (in Claude's ``//`` absolute-path spelling where applicable)."""
+    claude_denied = set(_DENIED_WRITE) | set(_DENIED_READ_WRITE)
+    for kiro_path in _kiro_denied_paths():
+        assert _to_claude_path(kiro_path) in claude_denied, (
+            f"kiro denies writes to {kiro_path!r} but Claude does not")
+
+
+def test_claude_denies_reads_on_sensitive_paths():
+    """Claude goes beyond kiro by also denying reads of secret/system paths;
+    ensure the read-deny list keeps covering the sensitive subset."""
+    sensitive = {"//etc/**", "~/.ssh/**", "~/.aws/**", "~/.netrc",
+                 "~/.gitconfig", "~/.kiro/**"}
+    assert sensitive <= set(_DENIED_READ_WRITE)

--- a/tests/agent/test_claude_live.py
+++ b/tests/agent/test_claude_live.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Live smoke tests against a real, installed ``claude`` CLI.
+
+These catch what mocked tests cannot: drift between the flags ClaudeBackend
+emits and what the installed Claude Code release actually accepts, and
+whether a real session can resolve a real cherry-pick conflict end to end.
+No Yocto build environment is needed.
+
+They are doubly opt-in — skipped unless BOTH hold:
+
+- a ``claude`` binary is on PATH (already authenticated), and
+- ``CLAUDE_LIVE_TESTS=1`` is set (a live session spends real tokens).
+
+Run with::
+
+    CLAUDE_LIVE_TESTS=1 pytest -m live -v
+
+``CLAUDE_LIVE_MODEL`` overrides the model (default: sonnet).
+"""
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cve_agent import get_agent_dir
+from cve_agent.claude_backend import ClaudeBackend, _claude_auth_env
+from shared import build_git_env
+
+_MODEL = os.environ.get("CLAUDE_LIVE_MODEL", "sonnet")
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.integration,
+    pytest.mark.skipif(shutil.which("claude") is None,
+                       reason="claude CLI not on PATH"),
+    pytest.mark.skipif(os.environ.get("CLAUDE_LIVE_TESTS") != "1",
+                       reason="set CLAUDE_LIVE_TESTS=1 to run live claude tests"),
+]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    env = build_git_env()
+    env.update({"GIT_AUTHOR_NAME": "live-test", "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "live-test", "GIT_COMMITTER_EMAIL": "t@t"})
+    subprocess.run(["git", *args], cwd=cwd, env=env, check=True,
+                   capture_output=True, text=True)
+
+
+def _git_stdout(cwd: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, env=build_git_env(),
+                            capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def test_cli_accepts_every_emitted_flag(tmp_path):
+    """Run the exact command ClaudeBackend builds, with a trivial prompt.
+
+    If any flag we emit (--permission-mode, --append-system-prompt,
+    --allowedTools/--disallowedTools, the "--" end-of-options marker...) is
+    renamed or removed in a Claude Code release, this fails immediately with
+    the CLI's own error message — the mocked suite would keep passing.
+    """
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    cmd = ClaudeBackend()._build_command(
+        "Reply with exactly: FLAGCHECK-OK", agent_dir, _MODEL, interactive=False)
+    env = build_git_env()
+    env.update(_claude_auth_env())
+
+    proc = subprocess.run(cmd, cwd=tmp_path, env=env, capture_output=True,
+                          text=True, timeout=240)
+
+    assert proc.returncode == 0, (
+        f"claude rejected the emitted command:\n{proc.stderr}")
+    assert "FLAGCHECK-OK" in proc.stdout
+
+
+def test_resolves_real_cherry_pick_conflict(tmp_path):
+    """Full production shape: conflicted cherry-pick, context file in the
+    agent dir (exercises --add-dir), run_session drives a real claude, and
+    the verdict comes from real git state."""
+    workspace = tmp_path / "workspace" / "sources" / "demo"
+    workspace.mkdir(parents=True)
+
+    _git(workspace, "init", "-b", "main")
+    conflict_file = workspace / "file.c"
+    conflict_file.write_text("int value = 1;\n", encoding="utf-8")
+    _git(workspace, "add", "-A")
+    _git(workspace, "commit", "-m", "base")
+
+    # Upstream fix on a branch: changes the same line as the local patch.
+    _git(workspace, "checkout", "-b", "fix")
+    conflict_file.write_text("int value = 2;  /* upstream CVE fix */\n",
+                             encoding="utf-8")
+    _git(workspace, "commit", "-am", "Fix CVE: bound value")
+    fix_sha = _git_stdout(workspace, "rev-parse", "HEAD")
+
+    _git(workspace, "checkout", "main")
+    conflict_file.write_text("int value = 3;  /* local patch */\n",
+                             encoding="utf-8")
+    _git(workspace, "commit", "-am", "Local patch")
+    pre_head = _git_stdout(workspace, "rev-parse", "HEAD")
+
+    result = subprocess.run(["git", "cherry-pick", fix_sha], cwd=workspace,
+                            env=build_git_env(), capture_output=True, text=True)
+    assert result.returncode != 0, "expected a cherry-pick conflict"
+
+    agent_dir = get_agent_dir(workspace)
+    context_file = agent_dir / "context.md"
+    context_file.write_text(
+        "# CVE Backport Context\n\n"
+        "A cherry-pick of the upstream CVE fix is in progress and file.c has "
+        "a conflict.\n\n"
+        "## Allowed Files\n\n- file.c\n\n"
+        "## Task\n\n"
+        "Resolve the conflict keeping the upstream fix (`int value = 2;`), "
+        "then run `git add file.c` and `git cherry-pick --continue`. "
+        "Do not modify any other file.\n",
+        encoding="utf-8")
+
+    session = ClaudeBackend().run_session(
+        f"Read the file {context_file} and follow it.",
+        workspace, {"file.c"}, _MODEL, timeout=600, interactive=False)
+
+    content = conflict_file.read_text(encoding="utf-8")
+    assert session.resolved is True
+    assert "<<<<<<<" not in content and ">>>>>>>" not in content
+    assert "int value = 2;" in content
+    assert _git_stdout(workspace, "rev-parse", "HEAD") != pre_head, (
+        "cherry-pick was never committed")

--- a/tests/agent/test_interactive.py
+++ b/tests/agent/test_interactive.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from cve_agent import AgentConfig
-from cve_agent.backend import KiroBackend
+from cve_agent.kiro_backend import KiroBackend
 
 _kiro = KiroBackend()
 

--- a/tests/agent/test_security.py
+++ b/tests/agent/test_security.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cve_agent.backend import KiroBackend
+from cve_agent.kiro_backend import KiroBackend
 from shared import GIT_ENV_ALLOWLIST, build_git_env
 
 _kiro = KiroBackend()

--- a/tests/agent/test_session_full.py
+++ b/tests/agent/test_session_full.py
@@ -5,7 +5,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cve_agent.backend import KiroBackend, SessionResult
+from cve_agent.backend import SessionResult
+from cve_agent.kiro_backend import KiroBackend
 from cve_agent.session import (
     _build_deviation_section,
     _extract_diff_hunks,
@@ -169,7 +170,7 @@ class TestGuardedKiroSession:
     @patch("cve_agent.session._write_audit_log")
     @patch("cve_agent.session.revert_unauthorized_changes")
     @patch("cve_agent.session.remove_scope_hook")
-    @patch("cve_agent.backend.KiroBackend.run_session",
+    @patch("cve_agent.kiro_backend.KiroBackend.run_session",
            return_value=SessionResult(resolved=True, duration=1.0))
     @patch("cve_agent.session.install_scope_hook")
     @patch("cve_agent.session.run_git_stdout", return_value="")
@@ -185,7 +186,7 @@ class TestGuardedKiroSession:
         assert result.resolved is True
 
     @patch("cve_agent.session.remove_scope_hook")
-    @patch("cve_agent.backend.KiroBackend.run_session",
+    @patch("cve_agent.kiro_backend.KiroBackend.run_session",
            return_value=SessionResult(resolved=False, duration=1.0))
     @patch("cve_agent.session.install_scope_hook")
     @patch("cve_agent.session.run_git_stdout", return_value="")

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -21,6 +21,8 @@ export MIRROR_DIR=/path/to/upstream-git     # Git mirrors of upstream repos
 Optional:
 ```bash
 export BUILDTOOLS_ENV=/path/to/environment-setup-x86_64-pokysdk-linux
+export AGENT_BACKEND=claude    # AI backend for agent cases (default: kiro)
+export AGENT_MODEL=sonnet      # model override for the chosen backend
 ```
 
 ## Running
@@ -31,6 +33,22 @@ export BUILDTOOLS_ENV=/path/to/environment-setup-x86_64-pokysdk-linux
 
 # Single test
 ./test_cve_corrector_cases.sh --test 2
+
+# Agent cases (6, 7, 11, 13) with the Claude Code backend
+# (requires an authenticated `claude` CLI on PATH)
+AGENT_BACKEND=claude ./test_cve_corrector_cases.sh --test 6
+```
+
+The agent test cases run whichever backend `AGENT_BACKEND` selects; any
+backend registered with `cve_agent` works (`kiro`, `claude`, or a plugin
+from `extra/`). `cve-agent` itself verifies the backend CLI is available
+before starting and exits with a clear error if not.
+
+For live pytest smoke tests of the Claude backend that do **not** need a
+Yocto build environment, see `tests/agent/test_claude_live.py`:
+
+```bash
+CLAUDE_LIVE_TESTS=1 pytest -m live -v
 ```
 
 ## Test Cases

--- a/tests/integration/test_cve_corrector_cases.sh
+++ b/tests/integration/test_cve_corrector_cases.sh
@@ -28,6 +28,12 @@ LOG_DIR="${SCRIPT_DIR}/test-results/cases_$(date +%Y%m%d_%H%M%S)"
 RESULTS_FILE="${LOG_DIR}/results.txt"
 RUN_TEST=""
 
+# AI backend for the agent test cases (6, 7, 11, 13). Any backend registered
+# with cve_agent works: kiro (default), claude, or a plugin from extra/.
+# AGENT_MODEL optionally overrides the model passed to the backend.
+AGENT_BACKEND="${AGENT_BACKEND:-kiro}"
+AGENT_MODEL="${AGENT_MODEL:-}"
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --test) shift; RUN_TEST="$1" ;;
@@ -172,12 +178,17 @@ run_test() {
     log "  [$TEST_NUM] Running $runner..."
     local exit_code=0
     if [[ "$runner" == "agent" ]]; then
+        local backend_flags=(--backend "${AGENT_BACKEND}")
+        if [[ -n "$AGENT_MODEL" ]]; then
+            backend_flags+=(--model "${AGENT_MODEL}")
+        fi
         echo "y" | python3 -m cve_agent \
             --cve-info "$metadata_file" \
             --cve-id "$cve_id" \
             --mirror-dir "$MIRROR_DIR" \
             --trust \
             --clean \
+            "${backend_flags[@]}" \
             $extra_flags \
             >> "$log_file" 2>&1 || exit_code=$?
     else
@@ -244,6 +255,7 @@ log "OE_DIR:     $OE_DIR"
 log "BUILD_DIR:  $BUILD_DIR"
 log "BBPATH:     ${BBPATH:-(not set)}"
 log "MIRROR_DIR: $MIRROR_DIR"
+log "BACKEND:    $AGENT_BACKEND${AGENT_MODEL:+ (model: $AGENT_MODEL)}"
 log "Results:    $LOG_DIR"
 echo
 


### PR DESCRIPTION
Adds [Claude Code](https://code.claude.com) as a first-class `cve-agent` AI
backend, selectable with `--backend claude`. `kiro` remains the default and is
unchanged.

The backend is offered upstream rather than kept as an `extra/` plugin so that
more than one person maintains it, and so the two backends stay in step: the
tests here fail if they ever drift apart.

## What it does

`ClaudeBackend` drives the `claude` CLI directly, mirroring `KiroBackend`:

- Headless `claude -p` session in the recipe workspace, model aliases mapped
  (`claude-sonnet-4.6` → `sonnet`; full model ids pass through).
- The packaged `AGENT_INSTRUCTIONS.md` is injected as the system prompt, so both
  backends follow the same backport rules.
- `--allowedTools` / `--disallowedTools` mirror
  `cve_agent/agents/yocto-cve-backport.json` as defense in depth. The git
  pre-commit hook and the post-session revert remain the authoritative
  file-scope guard, exactly as with kiro.
- Anthropic/Bedrock/Vertex auth vars are restored after `build_git_env()`
  filtering; unrelated secrets stay filtered out.
- Timeouts kill the whole process group, so a grandchild `git` cannot keep
  mutating the workspace while the resolution check reads git state.

No new runtime dependencies.

## Resolution semantics

A killed session is only credited as resolved if `HEAD` actually moved. A
timeout means the process did not exit in time — not that its work was lost: if
it committed just before the kill signal, that is a real resolution; if it hung
before touching git, a clean tree must not be mistaken for success. Both cases
are covered by tests.

## Tests

Three layers, all in `tests/agent/`:

1. **Unit** (mocked `Popen`) — command construction, deny-list emission, auth
   env passthrough and secret exclusion, timeout/interrupt/kill semantics.
2. **Contract** (`test_claude_cli_contract.py`) — a stub `claude` on `PATH`
   records argv/env/cwd, exercising the real spawn path: PATH lookup, argument
   encoding across `exec` (the multi-word prompt must survive as one argument
   after `--`), env filtering in both directions. **No `claude` binary or API
   key needed, so this runs in CI.**
3. **Parity** (`test_claude_kiro_parity.py`) — loads the kiro agent manifest and
   fails if the two guard configurations drift in either direction: a command
   kiro permits that claude does not (capability gap), or a claude rule with no
   kiro counterpart (privilege widening).

Plus **opt-in live tests** (`test_claude_live.py`, new `live` marker), skipped
unless a `claude` binary is on `PATH` **and** `CLAUDE_LIVE_TESTS=1` is set, since
a live session spends real tokens:

```bash
CLAUDE_LIVE_TESTS=1 pytest -m live
```

They catch what mocks cannot — drift between the flags we emit and what the
installed Claude Code release accepts — and drive a real cherry-pick conflict to
resolution. No Yocto build environment required.

Finally, the integration runner now honours `AGENT_BACKEND` / `AGENT_MODEL`, so
the existing agent cases can run against any registered backend:

```bash
AGENT_BACKEND=claude ./test_cve_corrector_cases.sh --test 11
```

## Verification

- `ruff` clean, `mypy` clean, **718 passed**, coverage **75%** (floor 65%).
- Live tests pass against a real `claude` CLI (2/2).
- **Integration case 11 (CVE-2024-39894 / openssh) passes end to end with
  `AGENT_BACKEND=claude`** on a real scarthgap build: the cherry-pick conflicted
  in `clientloop.c`, a live claude session resolved it (the conflict was the
  `$OpenBSD$` tag; the fix itself applied cleanly), `devtool build openssh`
  succeeded, and the patch landed with the correct
  `Upstream-Status: Backport [...]` tag. Agent log:
  `conflict_resolved | 215.9s | Resolved via claude`.

## Notes for review

- One commit here is a bug fix with a reproducing test, per CONTRIBUTING:
  `cve_agent.claude_backend` could not be imported before `cve_agent.backend`
  (module-bottom registration re-entered a partially initialized module).
  Built-in backends now register on first use. `extra/` plugin override
  semantics are preserved — a plugin registered under the same name still wins.
- The README and CONTRIBUTING backend sections are updated to describe both
  backends.
- Commits are GPG-signed and carry `Assisted-by` / `Signed-off-by` per the
  generative-AI policy in CONTRIBUTING.md.

An independent fix to `tests/integration/test_common.sh` (the `oe-init-build-env`
lookup, which affects poky and oe-core layouts alike) is sent as a separate PR to
keep this one to a single logical change.
