### PR TITLE
Revise vulnerability reporting method in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,8 @@ responsibly. **Do not open a public GitHub issue.**
 
 ### How to Report
 
-Email: [daniel.turull@ericsson.com](mailto:daniel.turull@ericsson.com)
+Please use the "Report a vulnerability" button on this repository's Security
+tab.
 
 Include:
 - Description of the vulnerability


### PR DESCRIPTION
Updated vulnerability reporting instructions to use the 'Report a vulnerability' button instead of email.