### PR TITLE
agent: decouple AGENT_INSTRUCTIONS.md from package location

### DIFF
--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -46,7 +46,36 @@ DEFAULT_KNOWLEDGE_PATH = data_dir() / 'knowledge.json'
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_SESSION_TIMEOUT = 600
 CORRECTOR_CMD = [sys.executable, '-m', 'cve_corrector']
-AGENT_INSTRUCTIONS = Path(__file__).resolve().parent / 'AGENT_INSTRUCTIONS.md'
+
+
+def resolve_agent_instructions() -> Path:
+    """Resolve the agent prompt file, preferring the stable synced copy.
+
+    ``cve_agent.setup.sync_agent_instructions()`` copies the packaged
+    AGENT_INSTRUCTIONS.md to a stable, package-location-independent path
+    under data_dir() whenever agents are (re)installed. Prefer that copy so
+    behavior stays consistent with what the kiro agent JSON's ``prompt``
+    field points at; fall back to the packaged file if the sync hasn't run
+    yet (e.g. before the first ``ensure_agents()`` call, or when running the
+    ``claude`` backend, which doesn't install kiro agents).
+
+    Resolved fresh on each call (not cached) so a sync that happens after
+    this module was first imported — e.g. ``ensure_agents()`` running later
+    in the same process as ``main()`` does — is picked up.
+    """
+    from .setup import PACKAGED_AGENT_INSTRUCTIONS, STABLE_AGENT_INSTRUCTIONS
+    if STABLE_AGENT_INSTRUCTIONS.is_file():
+        return STABLE_AGENT_INSTRUCTIONS
+    return PACKAGED_AGENT_INSTRUCTIONS
+
+
+# Kept for backward compatibility (existing tests/callers patch this
+# constant directly). Computed once at import time; DO NOT use in new code —
+# call resolve_agent_instructions() instead, which re-checks the stable
+# synced copy on every call and picks up a sync that happens later in the
+# same process (e.g. ensure_agents() runs before context building in the
+# real CLI flow).
+AGENT_INSTRUCTIONS = resolve_agent_instructions()
 
 
 class ResultStatus(Enum):
@@ -128,7 +157,7 @@ __all__ = [
     'AgentConfig', 'CveResult', 'ResultStatus',
     'RECOVERABLE_EXITS', 'UNRECOVERABLE_EXITS',
     'DEFAULT_KNOWLEDGE_PATH', 'DEFAULT_MAX_RETRIES', 'DEFAULT_SESSION_TIMEOUT',
-    'CORRECTOR_CMD', 'AGENT_INSTRUCTIONS',
+    'CORRECTOR_CMD', 'AGENT_INSTRUCTIONS', 'resolve_agent_instructions',
     'get_build_dir', 'get_agent_dir',
     'EXIT_SUCCESS', 'EXIT_CONFLICT', 'EXIT_CHECKOUT_ERROR', 'EXIT_PTEST_ERROR',
     'EXIT_BUILD_ERROR', 'EXIT_PATCH_ERROR', 'EXIT_METADATA_ERROR', 'EXIT_GIT_ERROR',

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -25,9 +25,13 @@ from shared import build_git_env
 from .backend import AIBackend, SessionResult
 from .git import has_in_progress_operation
 
-# Packaged agent instructions, injected as the Claude system prompt for parity
-# with the kiro agent (whose ``prompt`` field points at the same file).
-_AGENT_INSTRUCTIONS = Path(__file__).resolve().parent / "AGENT_INSTRUCTIONS.md"
+# Agent instructions injected as the Claude system prompt for parity with
+# the kiro agent (whose ``prompt`` field points at the same content, synced
+# via cve_agent.setup.sync_agent_instructions()). Resolved lazily in
+# _build_command() via cve_agent.resolve_agent_instructions() rather than
+# frozen at import time, so a sync that happens later in the same process
+# (ensure_agents(), called from __main__.main() before this runs) is picked
+# up instead of a stale value from before the sync.
 
 # Map kiro-style model names to Claude Code aliases. Valid Claude aliases and
 # full model IDs pass through unchanged; an empty value falls back to "sonnet".
@@ -116,6 +120,8 @@ class ClaudeBackend(AIBackend):
 
     def _build_command(self, prompt: str, agent_dir: Path,
                        model: str, interactive: bool) -> list[str]:
+        from . import resolve_agent_instructions
+
         cmd = ["claude"]
         if not interactive:
             cmd.append("-p")
@@ -123,14 +129,15 @@ class ClaudeBackend(AIBackend):
         cmd += ["--permission-mode", "acceptEdits" if not interactive else "default"]
         # The context file and agent artifacts live outside the session cwd.
         cmd += ["--add-dir", str(agent_dir)]
-        if _AGENT_INSTRUCTIONS.is_file():
+        agent_instructions = resolve_agent_instructions()
+        if agent_instructions.is_file():
             cmd += ["--append-system-prompt",
-                    _AGENT_INSTRUCTIONS.read_text(encoding="utf-8")]
+                    agent_instructions.read_text(encoding="utf-8")]
         else:
             logging.warning(
                 "Agent instructions not found (%s); running without a system "
                 "prompt. File scope is still enforced by the pre-commit hook.",
-                _AGENT_INSTRUCTIONS)
+                agent_instructions)
         for tool in _ALLOWED_TOOLS:
             cmd += ["--allowedTools", tool]
         for path in _DENIED_READ_WRITE:

--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     from .knowledge import KnowledgeBase
 
 from . import (
-    AGENT_INSTRUCTIONS,
     EXIT_BUILD_ERROR,
     EXIT_CONFLICT,
     EXIT_PTEST_ERROR,
     get_agent_dir,
     get_build_dir,
+    resolve_agent_instructions,
 )
 from .git import get_all_upstream_shas, get_upstream_sha, run_git_stdout
 
@@ -166,9 +166,10 @@ def _build_header(cve_id: str, recipe: str, exit_code: int,
 
 def _build_phase_instructions() -> str:
     """Load agent instructions from AGENT_INSTRUCTIONS.md."""
-    if not AGENT_INSTRUCTIONS.exists():
+    instructions_path = resolve_agent_instructions()
+    if not instructions_path.exists():
         return "## Instructions\n\nSee cve_agent/AGENT_INSTRUCTIONS.md for workflow details."
-    return AGENT_INSTRUCTIONS.read_text(encoding='utf-8')
+    return instructions_path.read_text(encoding='utf-8')
 
 
 def _gather_context_for_exit_code(workspace_path: Path, exit_code: int,

--- a/cve_agent/setup.py
+++ b/cve_agent/setup.py
@@ -5,11 +5,14 @@
 Checks that required kiro-cli agents are installed (symlinked into
 ~/.kiro/agents/) and offers to install them if missing.
 """
+import json
+import os
 import shutil
 import sys
 from pathlib import Path
 
 from shared.exit_codes import EXIT_AGENT_ERROR
+from shared.paths import data_dir
 
 # Agents required by cve_agent, defined in this package's .kiro/agents/
 REQUIRED_AGENTS = ("yocto-cve-backport", "yocto-cve-backport-interactive")
@@ -23,18 +26,109 @@ AGENT_SOURCE_DIR = _PROJECT_AGENT_DIR if _PROJECT_AGENT_DIR.is_dir() else _PACKA
 # Global kiro-cli agent directory
 KIRO_AGENTS_DIR = Path.home() / ".kiro" / "agents"
 
+# Packaged copy of the agent prompt, shipped alongside this module.
+PACKAGED_AGENT_INSTRUCTIONS = Path(__file__).resolve().parent / "AGENT_INSTRUCTIONS.md"
+
+# Stable, package-location-independent copy of the agent prompt. The kiro
+# agent JSON's ``prompt`` field is pointed here (not at PACKAGED_AGENT_INSTRUCTIONS)
+# so it keeps working across editable-install moves, reinstalls into a
+# different venv/site-packages path, or package upgrades/uninstalls.
+STABLE_AGENT_INSTRUCTIONS = data_dir() / "AGENT_INSTRUCTIONS.md"
+
+
+def sync_agent_instructions() -> Path:
+    """Copy the packaged AGENT_INSTRUCTIONS.md to the stable data_dir() path.
+
+    The kiro agent JSON's ``prompt`` field points at this stable copy rather
+    than at the package's own copy, so the prompt keeps resolving correctly
+    even if the project/package is later moved, reinstalled into a different
+    environment, or upgraded — none of which change the XDG data directory.
+
+    Always overwrites the destination so upgrades to the packaged file
+    propagate on the next install. Writes to a temporary sibling file and
+    ``os.replace()``s it into place (same pattern as ``shared/json_cache.py``)
+    so a crash mid-copy can never leave a truncated/corrupt stable copy.
+
+    Returns:
+        Path to the synced, stable copy.
+
+    Raises:
+        FileNotFoundError: If the packaged AGENT_INSTRUCTIONS.md is missing.
+    """
+    if not PACKAGED_AGENT_INSTRUCTIONS.is_file():
+        raise FileNotFoundError(
+            f"Packaged agent instructions not found: {PACKAGED_AGENT_INSTRUCTIONS}")
+    STABLE_AGENT_INSTRUCTIONS.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = STABLE_AGENT_INSTRUCTIONS.with_suffix(
+        STABLE_AGENT_INSTRUCTIONS.suffix + '.tmp')
+    shutil.copyfile(PACKAGED_AGENT_INSTRUCTIONS, tmp_path)
+    os.replace(tmp_path, STABLE_AGENT_INSTRUCTIONS)
+    return STABLE_AGENT_INSTRUCTIONS
+
+
+def _prompt_file_path(agent_json: Path) -> tuple[bool, Path | None]:
+    """Extract the local filesystem path from an agent JSON's file:// prompt URI.
+
+    Uses the same simple prefix-stripping convention as ``install_agents()``
+    (not ``urllib.parse.urlparse``, which misparses relative ``file://``
+    URIs by treating the first path segment as a netloc).
+
+    Returns:
+        A ``(readable, path)`` tuple. ``readable`` is False if the JSON
+        could not be parsed at all (malformed/unreadable file). ``path`` is
+        the file:// prompt's Path if present, else None (valid JSON with no
+        file:// prompt, or unreadable JSON).
+    """
+    try:
+        data = json.loads(agent_json.read_text(encoding='utf-8'))
+    except (json.JSONDecodeError, OSError):
+        return False, None
+    prompt = data.get('prompt', '')
+    if not isinstance(prompt, str) or not prompt.startswith('file://'):
+        return True, None
+    return True, Path(prompt[len('file://'):])
+
+
+def _is_stale_install(agent_json: Path) -> bool:
+    """Check whether an installed agent JSON is stale and should be reinstalled.
+
+    An install is considered stale if:
+      - the JSON file is malformed/unreadable (fail closed — reinstall
+        rather than silently keep a broken config), or
+      - its ``prompt`` is a ``file://`` URI with an absolute path that no
+        longer resolves to an existing file (e.g. the project was relocated,
+        or reinstalled into a different venv/site-packages path).
+
+    Only absolute prompt paths are checked: ``install_agents()`` always
+    rewrites the prompt to an absolute path on install, so an installed
+    JSON with a relative path is not one this tool produced (or is
+    unresolvable without knowing the intended base) — leave it alone rather
+    than risk false positives.
+    """
+    readable, prompt_path = _prompt_file_path(agent_json)
+    if not readable:
+        return True
+    if prompt_path is None or not prompt_path.is_absolute():
+        return False
+    return not prompt_path.is_file()
+
 
 def get_missing_agents() -> list[str]:
     """Return list of required agents not installed in ~/.kiro/agents/.
 
+    An agent counts as missing if its JSON config file is absent, or if its
+    ``prompt`` field is a ``file://`` URI pointing at a file that no longer
+    exists (a stale install left behind by a moved/relocated project or a
+    reinstall into a different environment).
+
     Returns:
-        List of agent names whose JSON configs are missing from the
+        List of agent names whose JSON configs are missing or stale in the
         global kiro-cli agents directory.
     """
     missing = []
     for name in REQUIRED_AGENTS:
         target = KIRO_AGENTS_DIR / f"{name}.json"
-        if not target.exists():
+        if not target.exists() or _is_stale_install(target):
             missing.append(name)
     return missing
 
@@ -53,7 +147,9 @@ def install_agents(missing: list[str]) -> bool:
 
     Copies agent JSON files (rather than symlinking) so that relative file://
     URIs in the 'prompt' field are rewritten to absolute paths that kiro-cli
-    can resolve regardless of working directory.
+    can resolve regardless of working directory. The prompt is pointed at
+    the stable data_dir() copy (synced from the packaged file here), not at
+    the package's own copy, so it survives moves/reinstalls/upgrades.
 
     Args:
         missing: List of agent names to install.
@@ -61,10 +157,13 @@ def install_agents(missing: list[str]) -> bool:
     Returns:
         True if all agents were installed successfully.
     """
-    import json
+    try:
+        sync_agent_instructions()
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return False
 
     KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-    project_root = AGENT_SOURCE_DIR.parent.parent  # security/ directory
 
     for name in missing:
         source = AGENT_SOURCE_DIR / f"{name}.json"
@@ -74,12 +173,11 @@ def install_agents(missing: list[str]) -> bool:
             print(f"Error: Agent source not found: {source}", file=sys.stderr)
             return False
 
-        # Load and rewrite file:// URIs to absolute paths
+        # Load and rewrite file:// URIs to the stable, package-independent path
         data = json.loads(source.read_text(encoding='utf-8'))
         prompt_target = None
         if 'prompt' in data and data['prompt'].startswith('file://'):
-            rel_path = data['prompt'][len('file://'):]
-            prompt_target = (project_root / rel_path).resolve()
+            prompt_target = STABLE_AGENT_INSTRUCTIONS
             data['prompt'] = f"file://{prompt_target}"
 
         # Remove stale symlink/file before writing
@@ -111,6 +209,11 @@ def ensure_agents(interactive: bool = True) -> None:
     In interactive mode, prompts the user before installing.
     Exits with error if prerequisites cannot be met.
 
+    Always re-syncs the stable AGENT_INSTRUCTIONS.md copy (data_dir()) from
+    the packaged file, even if the agent JSONs themselves are already
+    installed — so content upgrades to the packaged instructions propagate
+    on every run, not just on (re)install.
+
     Args:
         interactive: If True, prompt user for approval before installing.
     """
@@ -120,6 +223,12 @@ def ensure_agents(interactive: bool = True) -> None:
             "Install it from: https://kiro.dev/docs/install",
             file=sys.stderr,
         )
+        sys.exit(EXIT_AGENT_ERROR)
+
+    try:
+        sync_agent_instructions()
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(EXIT_AGENT_ERROR)
 
     missing = get_missing_agents()

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -9,13 +9,13 @@ from cve_agent.context import _build_phase_instructions
 def test_build_phase_instructions_file_exists(tmp_path):
     instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
     instructions.write_text("# Instructions\nDo the thing.")
-    with mock_patch("cve_agent.context.AGENT_INSTRUCTIONS", instructions):
+    with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
         result = _build_phase_instructions()
     assert "Do the thing" in result
 
 
 def test_build_phase_instructions_missing(tmp_path):
     missing = tmp_path / "nonexistent.md"
-    with mock_patch("cve_agent.context.AGENT_INSTRUCTIONS", missing):
+    with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=missing):
         result = _build_phase_instructions()
     assert "AGENT_INSTRUCTIONS.md" in result

--- a/tests/agent/test_context_full.py
+++ b/tests/agent/test_context_full.py
@@ -77,11 +77,12 @@ class TestBuildPhaseInstructions:
     def test_file_exists(self, tmp_path):
         instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
         instructions.write_text("# Do stuff")
-        with patch("cve_agent.context.AGENT_INSTRUCTIONS", instructions):
+        with patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
             assert "Do stuff" in _build_phase_instructions()
 
     def test_file_missing(self, tmp_path):
-        with patch("cve_agent.context.AGENT_INSTRUCTIONS", tmp_path / "nope"):
+        with patch("cve_agent.context.resolve_agent_instructions",
+                  return_value=tmp_path / "nope"):
             result = _build_phase_instructions()
             assert "AGENT_INSTRUCTIONS.md" in result
 

--- a/tests/agent/test_init.py
+++ b/tests/agent/test_init.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for cve_agent — data classes, config, and helpers."""
 from pathlib import Path
+from unittest.mock import patch
 
 from cve_agent import (
     EXIT_NOT_APPLICABLE,
@@ -10,6 +11,7 @@ from cve_agent import (
     AgentConfig,
     ResultStatus,
     get_agent_dir,
+    resolve_agent_instructions,
 )
 
 
@@ -51,3 +53,27 @@ def test_exit_code_sets():
 def test_exit_not_applicable_in_unrecoverable():
     assert EXIT_NOT_APPLICABLE in UNRECOVERABLE_EXITS
     assert EXIT_NOT_APPLICABLE not in RECOVERABLE_EXITS
+
+
+def test_resolve_agent_instructions_prefers_stable_copy(tmp_path):
+    stable = tmp_path / "stable" / "AGENT_INSTRUCTIONS.md"
+    packaged = tmp_path / "packaged" / "AGENT_INSTRUCTIONS.md"
+    stable.parent.mkdir()
+    packaged.parent.mkdir()
+    stable.write_text("stable")
+    packaged.write_text("packaged")
+
+    with patch("cve_agent.setup.STABLE_AGENT_INSTRUCTIONS", stable), \
+         patch("cve_agent.setup.PACKAGED_AGENT_INSTRUCTIONS", packaged):
+        assert resolve_agent_instructions() == stable
+
+
+def test_resolve_agent_instructions_falls_back_to_packaged(tmp_path):
+    stable = tmp_path / "stable" / "AGENT_INSTRUCTIONS.md"  # never created
+    packaged = tmp_path / "packaged" / "AGENT_INSTRUCTIONS.md"
+    packaged.parent.mkdir()
+    packaged.write_text("packaged")
+
+    with patch("cve_agent.setup.STABLE_AGENT_INSTRUCTIONS", stable), \
+         patch("cve_agent.setup.PACKAGED_AGENT_INSTRUCTIONS", packaged):
+        assert resolve_agent_instructions() == packaged

--- a/tests/agent/test_setup.py
+++ b/tests/agent/test_setup.py
@@ -1,27 +1,41 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 """Tests for cve_agent.setup — agent verification and installation."""
+import json
 from unittest.mock import patch
 
 import pytest
 
+import cve_agent.setup as setup
 from cve_agent.setup import (
     REQUIRED_AGENTS,
     check_kiro_cli,
     ensure_agents,
     get_missing_agents,
     install_agents,
+    sync_agent_instructions,
     verify_agents_installed,
 )
 
 
 @pytest.fixture
 def fake_dirs(tmp_path, monkeypatch):
-    """Set up fake source and target agent directories."""
-    source = tmp_path / "source"
+    """Set up fake source, target, and stable-instructions directories.
+
+    Mirrors the real project layout so install_agents()'s prompt rewriting
+    matches production behavior, and patches PACKAGED_AGENT_INSTRUCTIONS /
+    STABLE_AGENT_INSTRUCTIONS so sync_agent_instructions() stays confined to
+    tmp_path instead of touching the real packaged file or data_dir().
+    """
+    project_root = tmp_path / "project_root"
+    source = project_root / "cve_agent" / "agents"
     target = tmp_path / "target"
-    source.mkdir()
+    stable_dir = tmp_path / "stable_data_dir"
+    source.mkdir(parents=True)
     target.mkdir()
+    packaged_instructions = project_root / "cve_agent" / "AGENT_INSTRUCTIONS.md"
+    packaged_instructions.write_text("instructions")
+    stable_instructions = stable_dir / "AGENT_INSTRUCTIONS.md"
 
     # Create source agent JSONs with a file:// prompt URI
     for name in REQUIRED_AGENTS:
@@ -30,6 +44,8 @@ def fake_dirs(tmp_path, monkeypatch):
 
     monkeypatch.setattr("cve_agent.setup.AGENT_SOURCE_DIR", source)
     monkeypatch.setattr("cve_agent.setup.KIRO_AGENTS_DIR", target)
+    monkeypatch.setattr("cve_agent.setup.PACKAGED_AGENT_INSTRUCTIONS", packaged_instructions)
+    monkeypatch.setattr("cve_agent.setup.STABLE_AGENT_INSTRUCTIONS", stable_instructions)
     return source, target
 
 
@@ -44,6 +60,72 @@ def test_get_missing_agents_none_missing(fake_dirs):
     for name in REQUIRED_AGENTS:
         (target / f"{name}.json").symlink_to(source / f"{name}.json")
     assert get_missing_agents() == []
+
+
+def test_get_missing_agents_detects_stale_prompt_path(fake_dirs, tmp_path):
+    """An installed agent whose prompt file:// URI no longer resolves (e.g.
+    the project was relocated after install) must be treated as missing so
+    it gets reinstalled with a corrected path, reproducing the bug where a
+    stale install was silently treated as already present."""
+    source, target = fake_dirs
+    stale_prompt = tmp_path / "old-location" / "AGENT_INSTRUCTIONS.md"
+    assert not stale_prompt.exists()
+
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://{stale_prompt}"}}')
+
+    # Bug: file exists on disk, so a pure existence check would miss this.
+    for name in REQUIRED_AGENTS:
+        assert (target / f"{name}.json").exists()
+
+    missing = get_missing_agents()
+    assert set(missing) == set(REQUIRED_AGENTS)
+
+
+def test_get_missing_agents_valid_prompt_path_not_missing(fake_dirs, tmp_path):
+    """An installed agent whose prompt file:// URI resolves to a real file
+    must not be reported as missing."""
+    source, target = fake_dirs
+    real_prompt = tmp_path / "AGENT_INSTRUCTIONS.md"
+    real_prompt.write_text("instructions")
+
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://{real_prompt}"}}')
+
+    assert get_missing_agents() == []
+
+
+def test_get_missing_agents_malformed_json_treated_as_missing(fake_dirs):
+    """Malformed JSON in an installed agent file must not crash detection
+    and should be treated as missing (safe default)."""
+    source, target = fake_dirs
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text("{not valid json")
+
+    missing = get_missing_agents()
+    assert set(missing) == set(REQUIRED_AGENTS)
+
+
+def test_ensure_agents_reinstalls_stale_prompt_path(fake_dirs, tmp_path, monkeypatch):
+    """Regression test: ensure_agents() must reinstall (not silently accept)
+    an agent whose prompt path is stale, fixing it non-interactively."""
+    source, target = fake_dirs
+    stale_prompt = tmp_path / "old-location" / "AGENT_INSTRUCTIONS.md"
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://{stale_prompt}"}}')
+
+    monkeypatch.setattr("cve_agent.setup.check_kiro_cli", lambda: True)
+    ensure_agents(interactive=False)
+
+    assert verify_agents_installed() is True
+    for name in REQUIRED_AGENTS:
+        data = json.loads((target / f"{name}.json").read_text())
+        assert data['prompt'].startswith('file:///')
+        assert data['prompt'] == f"file://{setup.STABLE_AGENT_INSTRUCTIONS}"
+        assert str(stale_prompt) not in data['prompt']
 
 
 def test_verify_agents_installed_false(fake_dirs):
@@ -65,11 +147,10 @@ def test_install_agents_creates_symlinks(fake_dirs):
         installed = target / f"{name}.json"
         assert installed.exists()
         assert not installed.is_symlink()
-        import json
         data = json.loads(installed.read_text())
         assert data['name'] == name
         assert data['prompt'].startswith('file:///')
-        assert 'cve_agent/AGENT_INSTRUCTIONS.md' in data['prompt']
+        assert data['prompt'] == f"file://{setup.STABLE_AGENT_INSTRUCTIONS}"
 
 
 def test_install_agents_missing_source(fake_dirs):
@@ -82,15 +163,26 @@ def test_install_agents_missing_source(fake_dirs):
 def test_install_agents_creates_target_dir(tmp_path, monkeypatch):
     source = tmp_path / "source"
     target = tmp_path / "nonexistent" / "agents"
+    packaged_instructions = tmp_path / "packaged" / "AGENT_INSTRUCTIONS.md"
+    stable_instructions = tmp_path / "stable_data_dir" / "AGENT_INSTRUCTIONS.md"
     source.mkdir()
-    (source / f"{REQUIRED_AGENTS[0]}.json").write_text("{}")
+    packaged_instructions.parent.mkdir()
+    packaged_instructions.write_text("instructions")
+    (source / f"{REQUIRED_AGENTS[0]}.json").write_text(
+        '{"prompt": "file://cve_agent/AGENT_INSTRUCTIONS.md"}')
 
     monkeypatch.setattr("cve_agent.setup.AGENT_SOURCE_DIR", source)
     monkeypatch.setattr("cve_agent.setup.KIRO_AGENTS_DIR", target)
+    monkeypatch.setattr("cve_agent.setup.PACKAGED_AGENT_INSTRUCTIONS", packaged_instructions)
+    monkeypatch.setattr("cve_agent.setup.STABLE_AGENT_INSTRUCTIONS", stable_instructions)
 
     result = install_agents([REQUIRED_AGENTS[0]])
     assert result is True
     assert target.exists()
+
+    data = json.loads((target / f"{REQUIRED_AGENTS[0]}.json").read_text())
+    assert data['prompt'] == f"file://{stable_instructions}"
+    assert stable_instructions.is_file()
 
 
 def test_check_kiro_cli_found():
@@ -101,6 +193,85 @@ def test_check_kiro_cli_found():
 def test_check_kiro_cli_not_found():
     with patch("shutil.which", return_value=None):
         assert check_kiro_cli() is False
+
+
+def test_sync_agent_instructions_copies_to_stable_path(fake_dirs):
+    result = sync_agent_instructions()
+    assert result == setup.STABLE_AGENT_INSTRUCTIONS
+    assert setup.STABLE_AGENT_INSTRUCTIONS.is_file()
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+
+
+def test_sync_agent_instructions_overwrites_existing_stable_copy(fake_dirs):
+    setup.STABLE_AGENT_INSTRUCTIONS.parent.mkdir(parents=True, exist_ok=True)
+    setup.STABLE_AGENT_INSTRUCTIONS.write_text("old content")
+
+    sync_agent_instructions()
+
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+
+
+def test_sync_agent_instructions_propagates_content_upgrades(fake_dirs):
+    """A newer packaged AGENT_INSTRUCTIONS.md must overwrite the stable copy
+    on re-sync, so content upgrades reach the kiro agent's prompt."""
+    sync_agent_instructions()
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+
+    setup.PACKAGED_AGENT_INSTRUCTIONS.write_text("updated instructions v2")
+    sync_agent_instructions()
+
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "updated instructions v2"
+
+
+def test_sync_agent_instructions_missing_packaged_file_raises(fake_dirs):
+    setup.PACKAGED_AGENT_INSTRUCTIONS.unlink()
+    with pytest.raises(FileNotFoundError):
+        sync_agent_instructions()
+
+
+def test_sync_agent_instructions_stable_path_independent_of_package_location(
+        fake_dirs, tmp_path, monkeypatch):
+    """Simulate the packaged file moving to a different location entirely
+    (e.g. project relocated, or reinstalled into a different venv). Once
+    synced, the stable copy and its content remain unaffected — this is the
+    property that decouples the kiro agent's prompt from source location."""
+    sync_agent_instructions()
+    original_stable_mtime_content = setup.STABLE_AGENT_INSTRUCTIONS.read_text()
+
+    # "Move" the package: point PACKAGED_AGENT_INSTRUCTIONS somewhere else.
+    new_location = tmp_path / "new_package_location" / "AGENT_INSTRUCTIONS.md"
+    new_location.parent.mkdir(parents=True)
+    new_location.write_text(original_stable_mtime_content)
+    monkeypatch.setattr("cve_agent.setup.PACKAGED_AGENT_INSTRUCTIONS", new_location)
+
+    # STABLE_AGENT_INSTRUCTIONS path itself never changes and still resolves.
+    assert setup.STABLE_AGENT_INSTRUCTIONS.is_file()
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == original_stable_mtime_content
+
+
+def test_ensure_agents_syncs_instructions_even_when_already_installed(fake_dirs, monkeypatch):
+    """ensure_agents() must re-sync AGENT_INSTRUCTIONS.md even when no agent
+    JSON needs reinstalling, so packaged content upgrades still propagate."""
+    source, target = fake_dirs
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://{setup.STABLE_AGENT_INSTRUCTIONS}"}}')
+    setup.STABLE_AGENT_INSTRUCTIONS.parent.mkdir(parents=True, exist_ok=True)
+    setup.STABLE_AGENT_INSTRUCTIONS.write_text("stale content")
+
+    monkeypatch.setattr("cve_agent.setup.check_kiro_cli", lambda: True)
+    assert verify_agents_installed() is True  # nothing to reinstall
+
+    ensure_agents(interactive=False)
+
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+
+
+def test_ensure_agents_exits_when_packaged_instructions_missing(fake_dirs, monkeypatch):
+    setup.PACKAGED_AGENT_INSTRUCTIONS.unlink()
+    monkeypatch.setattr("cve_agent.setup.check_kiro_cli", lambda: True)
+    with pytest.raises(SystemExit):
+        ensure_agents(interactive=False)
 
 
 def test_ensure_agents_exits_without_kiro_cli(monkeypatch):


### PR DESCRIPTION
The kiro agent JSON's prompt field was pointed at the installed package's own copy of AGENT_INSTRUCTIONS.md, resolved from the project/site-packages path at install time. Moving the checkout or reinstalling into a different venv left the prompt pointing at a stale, nonexistent path.

Sync the packaged file to a fixed XDG data_dir() location on every ensure_agents() call and point the agent JSON's prompt there instead. The stable path no longer depends on where the package lives, so it survives moves, reinstalls, and upgrades.

- setup.py: add PACKAGED_AGENT_INSTRUCTIONS / STABLE_AGENT_INSTRUCTIONS and sync_agent_instructions() (atomic tmp+replace write); install_agents() points the prompt at the stable copy; ensure_agents() syncs unconditionally so content upgrades propagate even when no agent JSON needs reinstalling.
- __init__.py: add resolve_agent_instructions() (prefers the stable copy, falls back to the packaged file); keep AGENT_INSTRUCTIONS for backward compatibility only.
- context.py / claude_backend.py: resolve the instructions path live via resolve_agent_instructions() instead of a frozen import-time constant.
- tests: cover sync behavior, stale-path detection, and content-upgrade propagation; isolate PACKAGED/STABLE_AGENT_INSTRUCTIONS from the real filesystem in fixtures.

Assisted-by: claude-code:claude-sonnet-5