### PR TITLE
Adopt Ericsson OSPO SECURITY.md template with explicit scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,43 +1,55 @@
 <!-- SPDX-License-Identifier: MIT -->
 # Security Policy
 
+If you believe you have found a security vulnerability in an Ericsson-managed
+repository, please report it to us as described below.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, pull request, or discussion for a security
+problem.**
+
+Instead, use the "Report a vulnerability" button on this repository's Security
+tab, or go directly to:
+
+<https://github.com/Ericsson/yocto-security-tools/security/advisories/new>
+
+This keeps the report private, lets us collaborate with you on a draft
+advisory, and supports private patch development.
+
+We aim to acknowledge reports within 5 business days and to coordinate a
+disclosure timeline with you, targeting remediation within 90 days.
+
+### What to include
+
+* Affected project, component, and version(s)
+* Environment (OS, architecture, platform, configuration)
+* Reproduction steps; proof-of-concept or screenshots if available
+* Impact and how the issue could be exploited
+* Any embargo/disclosure timing you would like us to honor
+* Whether and how you wish to be credited
+
 ## Supported Versions
 
-| Version | Supported          |
-|---------|--------------------|
-| 1.0.x   | :white_check_mark: |
+Only the **latest released version** of `yocto-security-tools` (as published
+on [PyPI](https://pypi.org/project/yocto-security-tools/)) is supported with
+security updates. Older releases do not receive backported patches.
 
-## Reporting a Vulnerability
+Archived repositories are not supported and do not receive security updates
+anymore.
 
-If you discover a security vulnerability in this project, please report it
-responsibly. **Do not open a public GitHub issue.**
+## Scope
 
-### How to Report
+This policy covers the `yocto-security-tools` repository itself.
 
-Please use the "Report a vulnerability" button on this repository's Security
-tab.
+**Out of scope:**
 
-Include:
-- Description of the vulnerability
-- Steps to reproduce
-- Affected version(s)
-- Potential impact
-
-### What to Expect
-
-- Acknowledgment within 5 business days
-- Status update within 15 business days
-- We will coordinate disclosure timing with you
-
-### Scope
-
-This policy covers the `yocto-security-tools` repository. Vulnerabilities in
-upstream dependencies (requests, packaging) should be reported to their
-respective maintainers.
-
-### Plugin Security
-
-Plugins loaded from `extra/` or via `CVE_EXTRA_SOURCES_DIR` execute with full
-process privileges. See [extra/README.md](extra/README.md) for the security
-model. We do not accept vulnerability reports for malicious plugins that a user
-explicitly installed.
+* **Vulnerabilities in `requests` or `packaging`** (the only two runtime
+  dependencies) — please report these to their respective upstream
+  maintainers.
+* **Malicious or untrusted plugins** loaded from `extra/` or via
+  `CVE_EXTRA_SOURCES_DIR` / `CVE_EXTRA_BACKENDS_DIR`. Plugins execute with
+  the full privileges of the host process by design — there is no
+  sandboxing. This is a documented trust boundary (see
+  [extra/README.md](extra/README.md)); we do not accept reports describing
+  what a deliberately installed, untrusted plugin can do.


### PR DESCRIPTION
OpenSSF Scorecard flagged this repo's security policy (Medium severity, Security-Policy check) for missing a discoverable, machine-detectable vulnerability reporting channel. The scorecard awards points for:

- a valid http(s)/email link for reporting (6/10)
- free-form guidance beyond the link itself (3/10)
- explicit vulnerability/disclosure language with a numeric timeline, e.g. "30 days" (1/10)

The previous policy only described GitHub's "Report a vulnerability" button in prose without an actual URL, so Scorecard's link-detection regex found nothing to credit.

Replace it with Ericsson OSPO's standard SECURITY.md template, adapted for this repo:

- Add the direct advisories URL alongside the button description so the report channel is machine-detectable, not just human-readable.
- Add a one-line disclosure commitment (5 business day acknowledgment, 90-day remediation target) to satisfy the timeline-language check.
- State that only the latest released version (per PyPI) receives security updates, replacing the stale "1.0.x" version table that would otherwise need manual upkeep on every release.
- Add an explicit Scope section marking dependency vulnerabilities (requests, packaging - our only two runtime deps) and untrusted plugin behavior as out of scope. Plugins loaded from extra/ or via CVE_EXTRA_SOURCES_DIR/CVE_EXTRA_BACKENDS_DIR run with full process privileges by design (see extra/README.md); this avoids triaging reports that just restate the documented trust boundary. Other scope boundaries (e.g. upstream recipe CVEs, AI backend binaries, compromised build environments) were considered but deferred until we see real reports that need them.

This aligns the policy with Ericsson's org-wide OSPO template while keeping the OpenSSF Scorecard Security-Policy check fully satisfied.