### PR TITLE
feat(corrector): tag exported patches with release corename

### DIFF
--- a/cve_corrector/bitbake_ops.py
+++ b/cve_corrector/bitbake_ops.py
@@ -131,6 +131,27 @@ def deduce_meta_layer_from_recipe(recipe: str) -> Optional[Path]:
     return None
 
 
+def get_layerseries_corename() -> Optional[str]:
+    """Get the release corename from ``LAYERSERIES_CORENAMES``.
+
+    Used as the ``git format-patch --subject-prefix`` when exporting a patch
+    for mailing-list submission, e.g. ``scarthgap][PATCH``, so reviewers can
+    immediately tell which stable branch the patch targets (see the Yocto
+    Project submit-changes guide). ``LAYERSERIES_CORENAMES`` may list more
+    than one corename (space-separated) for compatibility; the last one is
+    the current release name.
+
+    Returns:
+        The current release corename (e.g. ``"scarthgap"``), or None if it
+        cannot be determined (missing BBPATH, bitbake-getvar failure, etc).
+    """
+    result = run_cmd_capture(['bitbake-getvar', 'LAYERSERIES_CORENAMES', '--value'])
+    if result.returncode != 0:
+        return None
+    corenames = result.stdout.strip().split()
+    return corenames[-1] if corenames else None
+
+
 def get_recipe_src_uri_git(recipe: str) -> Optional[str]:
     """Extract git repository URL from recipe's SRC_URI.
 

--- a/cve_corrector/meta_layer.py
+++ b/cve_corrector/meta_layer.py
@@ -9,19 +9,30 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional
 
-from .bitbake_ops import get_build_path
+from .bitbake_ops import get_build_path, get_layerseries_corename
 from .git_ops import get_git_user_info
 from .recipe_ops import _append_src_uri_entries
 from .utils import logger, run_cmd, run_cmd_capture
 
 
 def _export_commit_patch(meta_layer: Path) -> None:
-    """Export the latest commit as a patch file under BBPATH/patches/."""
+    """Export the latest commit as a patch file under BBPATH/patches/.
+
+    The patch subject is prefixed with the release corename (from
+    ``LAYERSERIES_CORENAMES``), e.g. ``[scarthgap][PATCH]``, following the
+    Yocto Project convention for submitting fixes to a stable branch (see
+    "Submitting Changes to Stable Release Branches" in the Yocto Project
+    contributor guide). This lets mailing-list reviewers immediately see
+    which release the patch targets. If the corename can't be determined,
+    the patch is exported without a subject prefix.
+    """
     patches_dir = get_build_path() / 'patches'
     patches_dir.mkdir(parents=True, exist_ok=True)
-    result = run_cmd_capture(
-        ['git', 'format-patch', '-1', 'HEAD', '-o', str(patches_dir)],
-        cwd=meta_layer)
+    cmd = ['git', 'format-patch', '-1', 'HEAD', '-o', str(patches_dir)]
+    corename = get_layerseries_corename()
+    if corename:
+        cmd += ['--subject-prefix', f'{corename}][PATCH']
+    result = run_cmd_capture(cmd, cwd=meta_layer)
     if result.returncode == 0 and result.stdout.strip():
         logger.info("Exported patch: %s", result.stdout.strip())
     else:

--- a/tests/corrector/test_meta_layer_export.py
+++ b/tests/corrector/test_meta_layer_export.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for cve_corrector.meta_layer._export_commit_patch and the
+LAYERSERIES_CORENAMES-based --subject-prefix used when exporting a patch
+for mailing-list submission.
+"""
+from unittest.mock import MagicMock, patch
+
+from cve_corrector.bitbake_ops import get_layerseries_corename
+from cve_corrector.meta_layer import _export_commit_patch
+
+
+class TestGetLayerseriesCorename:
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_returns_corename(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="scarthgap\n")
+        assert get_layerseries_corename() == "scarthgap"
+        mock_run.assert_called_once_with(
+            ['bitbake-getvar', 'LAYERSERIES_CORENAMES', '--value'])
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_multiple_corenames_uses_last(self, mock_run):
+        """LAYERSERIES_CORENAMES may list multiple names; the current
+        release is the last one."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="kirkstone scarthgap\n")
+        assert get_layerseries_corename() == "scarthgap"
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_command_failure_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert get_layerseries_corename() is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_empty_output_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="\n")
+        assert get_layerseries_corename() is None
+
+
+class TestExportCommitPatch:
+    @patch("cve_corrector.meta_layer.get_layerseries_corename")
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("cve_corrector.meta_layer.run_cmd_capture")
+    def test_includes_subject_prefix_when_corename_available(
+            self, mock_run, mock_bp, mock_corename, tmp_path):
+        mock_bp.return_value = tmp_path
+        mock_corename.return_value = "scarthgap"
+        mock_run.return_value = MagicMock(returncode=0, stdout="0001-fix.patch\n")
+
+        meta = tmp_path / "meta"
+        _export_commit_patch(meta)
+
+        args, kwargs = mock_run.call_args
+        cmd = args[0]
+        assert '--subject-prefix' in cmd
+        idx = cmd.index('--subject-prefix')
+        assert cmd[idx + 1] == 'scarthgap][PATCH'
+        assert kwargs.get("cwd") == meta
+
+    @patch("cve_corrector.meta_layer.get_layerseries_corename")
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("cve_corrector.meta_layer.run_cmd_capture")
+    def test_omits_subject_prefix_when_corename_unavailable(
+            self, mock_run, mock_bp, mock_corename, tmp_path):
+        mock_bp.return_value = tmp_path
+        mock_corename.return_value = None
+        mock_run.return_value = MagicMock(returncode=0, stdout="0001-fix.patch\n")
+
+        meta = tmp_path / "meta"
+        _export_commit_patch(meta)
+
+        args, _ = mock_run.call_args
+        cmd = args[0]
+        assert '--subject-prefix' not in cmd
+
+    @patch("cve_corrector.meta_layer.get_layerseries_corename")
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("cve_corrector.meta_layer.run_cmd_capture")
+    def test_logs_warning_on_format_patch_failure(
+            self, mock_run, mock_bp, mock_corename, tmp_path, caplog):
+        import logging
+        mock_bp.return_value = tmp_path
+        mock_corename.return_value = "scarthgap"
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+
+        meta = tmp_path / "meta"
+        with caplog.at_level(logging.WARNING, logger="cve_corrector"):
+            _export_commit_patch(meta)
+        assert any("Failed to export patch" in r.message for r in caplog.records)


### PR DESCRIPTION
_export_commit_patch() now passes --subject-prefix '<corename>][PATCH' to git format-patch, using LAYERSERIES_CORENAMES (queried via bitbake-getvar --value) as the corename. This follows the Yocto Project convention for submitting fixes to a stable release branch, so mailing-list reviewers can immediately see which release a patch targets.

Falls back to no subject prefix if the corename can't be determined (e.g. missing BBPATH or bitbake-getvar failure).

Adds get_layerseries_corename() to bitbake_ops.py and tests covering both the corename lookup and the subject-prefix behavior.

Assisted-by: claude-code:claude-sonnet-5