### PR TITLE
corrector: add --skip-source to ignore fix commits by source

### DIFF
--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -6,7 +6,7 @@ Wraps cve_corrector and spawns AI sessions to resolve conflicts, build errors,
 and test failures during CVE backporting.
 """
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -78,6 +78,7 @@ class AgentConfig:
     fix_url: Optional[str] = None
     recipe: Optional[str] = None
     backend: str = "kiro"
+    skip_sources: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -210,6 +210,10 @@ def _parse_args() -> argparse.Namespace:
                         help='URL of fix commit or pull request')
     input_group.add_argument('--recipe',
                         help='Recipe name (required with --fix-url without --cve-info)')
+    input_group.add_argument('--skip-source', action='append', default=[],
+                        metavar='SOURCE', dest='skip_sources',
+                        help='Ignore fix commits from this source (repeatable). '
+                             'Commits also reported by a non-skipped source are kept.')
 
     # --- AI session ---
     ai_group = parser.add_argument_group('AI session')
@@ -282,6 +286,7 @@ def _config_from_args(args: argparse.Namespace,
         fix_url=args.fix_url,
         recipe=args.recipe,
         backend=args.backend,
+        skip_sources=args.skip_sources,
     )
 
 

--- a/cve_agent/corrector.py
+++ b/cve_agent/corrector.py
@@ -60,6 +60,8 @@ def run_corrector(config: AgentConfig, continue_mode: bool = False,
             cmd.append('--bbappend')
         if config.skip_cve_applicability:
             cmd.append('--skip-cve-applicability')
+        for source in config.skip_sources:
+            cmd += ['--skip-source', source]
 
     output_lines = []
     with subprocess.Popen(

--- a/cve_corrector/__init__.py
+++ b/cve_corrector/__init__.py
@@ -23,6 +23,7 @@ from .state import (
 from .workflow import (
                     WorkflowConfig,
                     continue_from_conflict,
+                    filter_by_skip_sources,
                     finish_cve_workflow,
                     initialize_cve_workflow,
 )
@@ -36,4 +37,5 @@ __all__ = [
     'initialize_cve_workflow', 'finish_cve_workflow',
     'continue_from_conflict', 'WorkflowConfig', 'find_mirror_repo',
     'deduce_meta_layer_from_recipe', 'resolve_meta_layer',
+    'filter_by_skip_sources',
 ]

--- a/cve_corrector/__main__.py
+++ b/cve_corrector/__main__.py
@@ -88,6 +88,10 @@ def main():
                         help='URL of fix commit or pull request')
     input_group.add_argument('--recipe',
                         help='Recipe name (required with --fix-url without --cve-info)')
+    input_group.add_argument('--skip-source', action='append', default=[],
+                        metavar='SOURCE', dest='skip_sources',
+                        help='Ignore fix commits from this source (repeatable). '
+                             'Commits also reported by a non-skipped source are kept.')
 
     # --- Workflow mode ---
     mode_group = parser.add_argument_group('workflow mode')
@@ -180,6 +184,10 @@ def main():
         print("Recipe name not found", file=sys.stderr)
         sys.exit(EXIT_METADATA_ERROR)
     cve_info['name'] = recipe_name
+    if args.skip_sources:
+        from . import filter_by_skip_sources
+        cve_info = filter_by_skip_sources(cve_info, args.skip_sources)
+        cve_data[args.cve_id] = cve_info
     if not cve_info.get('hashes') and not cve_info.get('series'):
         print(f"CVE {args.cve_id} missing fix commits or series", file=sys.stderr)
         sys.exit(EXIT_METADATA_ERROR)

--- a/cve_corrector/meta_layer.py
+++ b/cve_corrector/meta_layer.py
@@ -216,7 +216,7 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
                     if 'file://' in candidate.read_text(encoding='utf-8'):
                         target = candidate
                         break
-                except OSError:
+                except (OSError, UnicodeDecodeError):
                     continue
             if target:
                 break

--- a/cve_corrector/recipe_ops.py
+++ b/cve_corrector/recipe_ops.py
@@ -70,7 +70,7 @@ def update_recipe_patch(recipe: str, new_patch_name: str, original_patch_name: s
         for pattern in ('**/*.bbappend', '**/*.bb', '**/*.inc'):
             for f in meta_layer.glob(pattern):
                 try:
-                    if original_patch_name in f.read_text(encoding='utf-8'):
+                    if original_patch_name in f.read_text(encoding='utf-8', errors='ignore'):
                         recipe_files.append(f)
                 except OSError:
                     pass
@@ -163,7 +163,7 @@ def _split_src_uri_line(cve_id: str, meta_layer: Path) -> None:
                         *meta_layer.glob('**/*.bbappend')):
         try:
             content = recipe_file.read_text(encoding='utf-8')
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         if f'file://{cve_id}' not in content:
             continue
@@ -200,7 +200,7 @@ def sort_cve_lines_in_recipe(cve_id: str, meta_layer: Path) -> None:
                         *meta_layer.glob('**/*.bbappend')):
         try:
             content = recipe_file.read_text(encoding='utf-8')
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         if f'file://{cve_id}-' not in content:
             continue

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -52,6 +52,73 @@ from .utils import logger, run_cmd, run_cmd_capture
 from .workspace import prepare_cve_branch, setup_devtool_workspace, setup_upstream_remote
 
 
+def _sources_of(detail: dict) -> list[str]:
+    """Return the normalized source list for a hash_details entry.
+
+    The ``source`` field may be a single name or a comma-joined string
+    (e.g. ``"debian, osv"``) when the same commit was reported by several
+    feeds. Returns lowercased, stripped source names.
+    """
+    return [s.strip().lower()
+            for s in (detail.get('source') or '').split(',')
+            if s.strip()]
+
+
+def filter_by_skip_sources(cve_info: dict, skip_sources: list[str]) -> dict:
+    """Drop fix commits uniquely attributed to skipped sources.
+
+    Lenient (AND) semantics: a commit is removed only when *every* source
+    that reported it is in ``skip_sources``. A commit corroborated by at
+    least one non-skipped source is kept — so ``--skip-source osv`` will not
+    discard a hash that Debian also vouched for.
+
+    Filtering is driven by ``hash_details`` (the only field carrying source
+    attribution); the flat ``hashes`` list is rebuilt from the survivors.
+    A commit is dropped from ``hashes`` only when it appears in
+    ``hash_details`` and all of its sources are skipped — hashes with no
+    ``hash_details`` entry are left untouched (we cannot attribute them).
+
+    Series are not filtered: series entries carry only ``pull_url`` and no
+    reliable source field, so their provenance cannot be determined here.
+
+    Args:
+        cve_info: Per-CVE metadata dict (not mutated).
+        skip_sources: Source names to skip (case-insensitive).
+
+    Returns:
+        A new cve_info dict with filtered ``hashes``/``hash_details``.
+    """
+    if not skip_sources:
+        return cve_info
+
+    skip = {s.strip().lower() for s in skip_sources if s.strip()}
+    if not skip:
+        return cve_info
+
+    hash_details = cve_info.get('hash_details', []) or []
+
+    kept_details = []
+    dropped_hashes = set()
+    for detail in hash_details:
+        srcs = _sources_of(detail)
+        # Drop only when every attributed source is skipped (and at least
+        # one source is known — unattributed commits are always kept).
+        if srcs and all(s in skip for s in srcs):
+            if detail.get('hash'):
+                dropped_hashes.add(detail['hash'])
+            logger.info("Skipping commit %s (source: %s)",
+                        (detail.get('hash') or '?')[:12],
+                        detail.get('source') or 'unknown')
+            continue
+        kept_details.append(detail)
+
+    new_info = dict(cve_info)
+    new_info['hash_details'] = kept_details
+    new_info['hashes'] = [h for h in (cve_info.get('hashes', []) or [])
+                          if h not in dropped_hashes]
+    return new_info
+
+
 def _kill_bitbake_server() -> None:
     """Kill any running bitbake server and all child processes."""
     import os

--- a/tests/agent/test_main_cli.py
+++ b/tests/agent/test_main_cli.py
@@ -51,6 +51,26 @@ class TestParseArgs:
         args = _parse_args()
         assert args.skip_ptest is True
 
+    def test_skip_source_single(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-1', '--cve-info', '/tmp/c.json',
+            '--skip-source', 'osv'])
+        args = _parse_args()
+        assert args.skip_sources == ['osv']
+
+    def test_skip_source_repeatable(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-1', '--cve-info', '/tmp/c.json',
+            '--skip-source', 'osv', '--skip-source', 'ubuntu'])
+        args = _parse_args()
+        assert args.skip_sources == ['osv', 'ubuntu']
+
+    def test_skip_source_default_empty(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-1', '--cve-info', '/tmp/c.json'])
+        args = _parse_args()
+        assert args.skip_sources == []
+
 
 class TestConfigFromArgs:
     def test_creates_config(self, monkeypatch):
@@ -61,6 +81,15 @@ class TestConfigFromArgs:
         config = _config_from_args(args, 'CVE-2025-0001')
         assert config.cve_id == 'CVE-2025-0001'
         assert config.max_retries == 5
+
+    def test_skip_sources_passthrough(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', '/tmp/cve.json',
+            '--skip-source', 'osv', '--skip-source', 'ubuntu'])
+        args = _parse_args()
+        config = _config_from_args(args, 'CVE-2025-0001')
+        assert config.skip_sources == ['osv', 'ubuntu']
 
 
 class TestReadCveList:

--- a/tests/agent/test_security.py
+++ b/tests/agent/test_security.py
@@ -156,3 +156,46 @@ class TestConclusionSpecialChars:
             cmd = mock_popen.call_args[0][0]
             # The dangerous string is a separate list element, not shell-interpolated
             assert '"; rm -rf / #' in cmd
+
+
+class TestSkipSourceForwarding:
+    def test_skip_sources_forwarded_to_corrector(self):
+        """--skip-source values are forwarded as repeated corrector flags."""
+        from cve_agent import AgentConfig
+        from cve_agent.corrector import run_corrector
+        config = AgentConfig(cve_id='CVE-2025-0001',
+                             cve_info_path=Path('/tmp/c.json'),
+                             skip_sources=['osv', 'ubuntu'])
+        with patch('subprocess.Popen') as mock_popen:
+            proc = MagicMock()
+            proc.stdout = iter([])
+            proc.wait.return_value = None
+            proc.returncode = 0
+            proc.__enter__ = lambda s: s
+            proc.__exit__ = MagicMock(return_value=False)
+            mock_popen.return_value = proc
+            run_corrector(config)
+            cmd = mock_popen.call_args[0][0]
+            assert cmd.count('--skip-source') == 2
+            osv_idx = cmd.index('osv')
+            ubuntu_idx = cmd.index('ubuntu')
+            assert cmd[osv_idx - 1] == '--skip-source'
+            assert cmd[ubuntu_idx - 1] == '--skip-source'
+
+    def test_no_skip_sources_omits_flag(self):
+        """Empty skip_sources adds no --skip-source flag."""
+        from cve_agent import AgentConfig
+        from cve_agent.corrector import run_corrector
+        config = AgentConfig(cve_id='CVE-2025-0001',
+                             cve_info_path=Path('/tmp/c.json'))
+        with patch('subprocess.Popen') as mock_popen:
+            proc = MagicMock()
+            proc.stdout = iter([])
+            proc.wait.return_value = None
+            proc.returncode = 0
+            proc.__enter__ = lambda s: s
+            proc.__exit__ = MagicMock(return_value=False)
+            mock_popen.return_value = proc
+            run_corrector(config)
+            cmd = mock_popen.call_args[0][0]
+            assert '--skip-source' not in cmd

--- a/tests/corrector/test_main_cli.py
+++ b/tests/corrector/test_main_cli.py
@@ -66,3 +66,52 @@ class TestMainCli:
         with patch('shutil.which', return_value='/usr/bin/bitbake-layers'):
             with pytest.raises(SystemExit):
                 main()
+
+    def test_skip_source_removes_only_matching(self, tmp_path, monkeypatch):
+        """--skip-source drops the osv-only commit but keeps the debian one."""
+        cve_info = tmp_path / 'cve.json'
+        cve_info.write_text(json.dumps({
+            'CVE-2025-0001': {
+                'name': 'foo',
+                'hashes': ['deb1', 'osv1'],
+                'hash_details': [
+                    {'hash': 'deb1', 'source': 'debian'},
+                    {'hash': 'osv1', 'source': 'osv'},
+                ],
+            }
+        }))
+        captured = {}
+        monkeypatch.setattr('sys.argv', [
+            'cve-corrector', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', str(cve_info), '--dry-run',
+            '--skip-source', 'osv', '--meta-layer', str(tmp_path)])
+
+        real_print = print
+
+        def _capture_print(*a, **k):
+            captured.setdefault('lines', []).append(' '.join(str(x) for x in a))
+            real_print(*a, **k)
+
+        with patch('builtins.print', _capture_print):
+            main()  # should not raise
+
+        joined = '\n'.join(captured['lines'])
+        assert 'Commits:    1' in joined
+
+    def test_skip_source_all_removed_is_metadata_error(self, tmp_path, monkeypatch):
+        """Skipping the only source leaves no fix commits -> metadata error."""
+        cve_info = tmp_path / 'cve.json'
+        cve_info.write_text(json.dumps({
+            'CVE-2025-0001': {
+                'name': 'foo',
+                'hashes': ['osv1'],
+                'hash_details': [{'hash': 'osv1', 'source': 'osv'}],
+            }
+        }))
+        monkeypatch.setattr('sys.argv', [
+            'cve-corrector', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', str(cve_info), '--dry-run',
+            '--skip-source', 'osv', '--meta-layer', str(tmp_path)])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 6  # EXIT_METADATA_ERROR

--- a/tests/corrector/test_workflow.py
+++ b/tests/corrector/test_workflow.py
@@ -8,6 +8,7 @@ import pytest
 from cve_corrector.ptest import compare_ptest_results
 from cve_corrector.recipe_ops import sort_cve_lines_in_recipe
 from cve_corrector.state import MetadataError, load_cve_metadata
+from cve_corrector.workflow import filter_by_skip_sources
 
 # --- compare_ptest_results ---
 
@@ -95,3 +96,88 @@ def test_load_cve_metadata_invalid_json(tmp_path):
     f.write_text("{invalid json")
     with pytest.raises(MetadataError):
         load_cve_metadata(f)
+
+
+# --- filter_by_skip_sources ---
+
+def test_skip_sources_empty_is_noop():
+    info = {'hashes': ['a'], 'hash_details': [{'hash': 'a', 'source': 'osv'}]}
+    assert filter_by_skip_sources(info, []) is info
+
+
+def test_skip_sources_drops_unique_source():
+    """A commit reported only by the skipped source is removed."""
+    info = {
+        'hashes': ['deb1', 'osv1'],
+        'hash_details': [
+            {'hash': 'deb1', 'url': 'u1', 'source': 'debian'},
+            {'hash': 'osv1', 'url': 'u2', 'source': 'osv'},
+        ],
+    }
+    out = filter_by_skip_sources(info, ['osv'])
+    assert out['hashes'] == ['deb1']
+    assert [d['hash'] for d in out['hash_details']] == ['deb1']
+
+
+def test_skip_sources_keeps_corroborated_commit():
+    """A commit also reported by a non-skipped source is kept (lenient AND)."""
+    info = {
+        'hashes': ['shared'],
+        'hash_details': [{'hash': 'shared', 'url': 'u', 'source': 'debian, osv'}],
+    }
+    out = filter_by_skip_sources(info, ['osv'])
+    assert out['hashes'] == ['shared']
+    assert len(out['hash_details']) == 1
+
+
+def test_skip_sources_case_insensitive():
+    info = {
+        'hashes': ['osv1'],
+        'hash_details': [{'hash': 'osv1', 'source': 'OSV'}],
+    }
+    out = filter_by_skip_sources(info, ['osv'])
+    assert out['hashes'] == []
+
+
+def test_skip_sources_repeatable_multiple():
+    info = {
+        'hashes': ['deb1', 'osv1', 'ubu1'],
+        'hash_details': [
+            {'hash': 'deb1', 'source': 'debian'},
+            {'hash': 'osv1', 'source': 'osv'},
+            {'hash': 'ubu1', 'source': 'ubuntu'},
+        ],
+    }
+    out = filter_by_skip_sources(info, ['osv', 'ubuntu'])
+    assert out['hashes'] == ['deb1']
+
+
+def test_skip_sources_unattributed_hash_kept():
+    """A hash with no matching hash_details entry cannot be attributed, so kept."""
+    info = {
+        'hashes': ['bare', 'osv1'],
+        'hash_details': [{'hash': 'osv1', 'source': 'osv'}],
+    }
+    out = filter_by_skip_sources(info, ['osv'])
+    assert out['hashes'] == ['bare']
+
+
+def test_skip_sources_does_not_mutate_input():
+    info = {
+        'hashes': ['osv1'],
+        'hash_details': [{'hash': 'osv1', 'source': 'osv'}],
+    }
+    filter_by_skip_sources(info, ['osv'])
+    assert info['hashes'] == ['osv1']
+    assert len(info['hash_details']) == 1
+
+
+def test_skip_sources_series_untouched():
+    """Series carry no source attribution and must be left as-is."""
+    info = {
+        'hashes': ['osv1'],
+        'hash_details': [{'hash': 'osv1', 'source': 'osv'}],
+        'series': [{'pull_url': 'https://x/pull/1', 'commits': ['c1']}],
+    }
+    out = filter_by_skip_sources(info, ['osv'])
+    assert out['series'] == info['series']


### PR DESCRIPTION
## Summary
Some CVE data sources occasionally point to the wrong fix commit. When
that happens, the corrector can apply an incorrect commit alongside the
correct one from another source.

This adds an opt-in, repeatable `--skip-source` flag to filter fix commits
by their reporting source before applying.

## Behavior
- **Opt-in**: off by default; multi-source coverage is unchanged for
  normal runs.
- **Repeatable**: `--skip-source osv --skip-source ubuntu`.
- **Lenient (AND) semantics**: a commit is dropped only when *every*
  source that reported it is skipped. A commit corroborated by a
  non-skipped source is kept, so a distrusted source can't discard a
  hash another source also vouched for.
- **Series untouched**: PR series carry no reliable source attribution,
  so they are not filtered.

The same flag is plumbed through `cve-agent` as a passthrough to the
corrector subprocess, keeping the filtering logic in one place.

## Testing
- New unit tests for `filter_by_skip_sources` (unique-source drop,
  corroborated-keep, case-insensitivity, multi-skip, unattributed-kept,
  no-mutation, series-untouched).
- New CLI tests for both corrector and agent (arg parsing, config
  passthrough, corrector command forwarding).
- Full suite: 691 passed, coverage 74.8%. `ruff` and `mypy` clean.


