### PR TITLE
feat(agent): harden backend invocation, add interdiff review, and improve backport safety

### DIFF
--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -103,7 +103,8 @@ Required:
 
 Options:
   --trust                 Auto-approve AI changes (no human review)
-  --interactive           Use interactive AI agent (human-in-the-loop)
+  -i, --interactive       Use interactive AI agent (human-in-the-loop);
+                          omit for non-interactive/CI use (default)
   --backend NAME          AI backend to use (default: kiro)
   --model NAME            AI model (default: claude-sonnet-5)
   --max-retries N         Per-step retry limit (default: 3)

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -105,7 +105,7 @@ Options:
   --trust                 Auto-approve AI changes (no human review)
   --interactive           Use interactive AI agent (human-in-the-loop)
   --backend NAME          AI backend to use (default: kiro)
-  --model NAME            AI model (default: claude-sonnet-4.6)
+  --model NAME            AI model (default: claude-sonnet-5)
   --max-retries N         Per-step retry limit (default: 3)
   --session-timeout SECS  AI session timeout (default: 600)
   --skip-ptest            Skip ptest verification

--- a/.kiro/agents/yocto-cve-backport-interactive.json
+++ b/.kiro/agents/yocto-cve-backport-interactive.json
@@ -7,28 +7,31 @@
   "toolsSettings": {
     "execute_bash": {
       "allowedCommands": [
-        "git status",
-        "git status --porcelain",
-        "git diff",
-        "git diff *",
-        "git log *",
-        "git show *",
-        "git add *",
-        "git cherry-pick --continue",
-        "git cherry-pick --abort",
-        "git am --continue",
-        "git am --abort",
-        "git checkout -- *",
-        "git rev-parse *",
-        "git merge-base *",
-        "git format-patch *",
-        "devtool build *",
-        "cat *",
-        "head *",
-        "tail *",
-        "find . *",
-        "grep *"
-      ]
+        "^git status$",
+        "^git status --porcelain$",
+        "^git diff$",
+        "^git diff .*$",
+        "^git log .*$",
+        "^git show .*$",
+        "^git add .*$",
+        "^git cherry-pick --continue$",
+        "^git cherry-pick --no-edit --continue$",
+        "^git cherry-pick --abort$",
+        "^git cherry-pick [^;&|]+$",
+        "^git am --continue$",
+        "^git am --abort$",
+        "^git checkout -- .*$",
+        "^git rev-parse .*$",
+        "^git merge-base .*$",
+        "^git format-patch .*$",
+        "^devtool build .*$",
+        "^cat .*$",
+        "^head .*$",
+        "^tail .*$",
+        "^find \\. .*$",
+        "^grep .*$"
+      ],
+      "denyByDefault": true
     },
     "fs_write": {
       "deniedPaths": [

--- a/.kiro/agents/yocto-cve-backport.json
+++ b/.kiro/agents/yocto-cve-backport.json
@@ -3,28 +3,31 @@
   "description": "CVE backport agent for Yocto/OE — resolves conflicts, build errors, and test failures in cherry-picked upstream fixes",
   "prompt": "file://cve_agent/AGENT_INSTRUCTIONS.md",
   "tools": ["fs_read", "fs_write", "execute_bash"],
-  "allowedTools": ["fs_read", "fs_write", "execute_bash"],
+  "allowedTools": ["fs_read", "fs_write"],
   "toolsSettings": {
     "execute_bash": {
       "allowedCommands": [
-        "git status",
-        "git status --porcelain",
-        "git diff",
-        "git diff *",
-        "git log *",
-        "git show *",
-        "git add *",
-        "git cherry-pick --continue",
-        "git cherry-pick --abort",
-        "git am --continue",
-        "git am --abort",
-        "git rev-parse *",
-        "git merge-base *",
-        "devtool build *",
-        "cat *",
-        "head *",
-        "tail *"
-      ]
+        "^git status$",
+        "^git status --porcelain$",
+        "^git diff$",
+        "^git diff .*$",
+        "^git log .*$",
+        "^git show .*$",
+        "^git add .*$",
+        "^git cherry-pick --continue$",
+        "^git cherry-pick --no-edit --continue$",
+        "^git cherry-pick --abort$",
+        "^git cherry-pick [^;&|]+$",
+        "^git am --continue$",
+        "^git am --abort$",
+        "^git rev-parse .*$",
+        "^git merge-base .*$",
+        "^devtool build .*$",
+        "^cat .*$",
+        "^head .*$",
+        "^tail .*$"
+      ],
+      "denyByDefault": true
     },
     "fs_write": {
       "deniedPaths": [

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Standalone CVE management tools for Yocto/OpenEmbedded Linux distributions.
 - Git
 - For `cve-corrector` / `cve-agent`: a sourced Yocto build environment (`BBPATH` set)
 - For `cve-agent`: an AI backend — [kiro-cli](https://github.com/aws/kiro-cli) (default) or [Claude Code](https://code.claude.com) (`--backend claude`), or a custom backend plugin
+- Optional, for `cve-agent`: [`patchutils`](https://cyberelk.net/tim/software/patchutils/) (provides `interdiff`) — when installed, cve-agent enriches its review diff, console output, and AI context with a concise upstream-vs-backport adaptation delta. When absent, cve-agent falls back to its existing behavior unchanged.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The Claude Code backend needs a recent `claude` on `PATH`, already authenticated
 (Anthropic API key, or Bedrock/Vertex), supporting `-p`, `--permission-mode`,
 `--allowedTools`/`--disallowedTools`, `--append-system-prompt`, and `--add-dir`.
 Pass `--model sonnet|opus|haiku` (or a full model id); the default
-`claude-sonnet-4.6` is mapped to `sonnet`. Both backends run under the same
+`claude-sonnet-5` is mapped to `sonnet`. Both backends run under the same
 file-scope guard, so the AI can only modify the files the upstream fix touches.
 
 ## How It Works

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -1,6 +1,41 @@
 <!-- SPDX-License-Identifier: MIT -->
 # CVE Backport Agent Instructions
 
+## Available Tools
+
+You have file read/inspection tools and a bash-equivalent command runner —
+the exact tool names depend on your runtime and are described in the
+preamble that precedes these instructions. The rules below apply regardless
+of tool names:
+
+- Use your file/directory inspection tool for ALL file and directory
+  inspection — reading `context.md`, checking whether a file exists,
+  listing a directory, viewing build logs, etc. Do NOT shell out to `ls`,
+  `find`, or `cat` for this; it is already fully trusted and works for
+  every path you need.
+- Your bash-equivalent runner is restricted to a fixed allow-list (git
+  plumbing, `devtool build`, and log tailing). Commands not on that list
+  are rejected outright with no prompt — there is no fallback, so don't
+  try variations or guess at alternate commands. If a task seems to
+  require something outside the allow-list below, stop and flag it
+  rather than probing for a workaround.
+- Run each command **bare and exactly as listed** — the allow-list matches
+  whole commands. Your shell already runs inside the workspace, so do NOT
+  prefix `cd <path>` and do NOT chain commands with `&&`, `;`, or `|`. For
+  example `git status` is accepted, but `cd /path && git status` is rejected
+  because the `cd ... &&` wrapper is not on the list.
+
+Bash commands you CAN run: `git status`, `git status --porcelain`, `git
+diff[ *]`, `git log *`, `git show *`, `git add *`, `git cherry-pick <sha>`
+(start a fresh cherry-pick, e.g. `git cherry-pick -x <sha>` for a
+prerequisite), `git cherry-pick --continue|--abort`, `git am
+--continue|--abort`, `git rev-parse *`, `git merge-base *`, `devtool build
+*`, `cat *`, `head *`, `tail *`.
+
+The context file path given to you at session start (e.g. `context.md`
+under the agent dir) is always valid — read it directly rather than
+listing the directory first to confirm it exists.
+
 ## Scope Rules
 
 You may ONLY modify files listed in the **Allowed Files** section of the context header.
@@ -137,12 +172,16 @@ flag for human review. Document which tests failed and what code change
 fixed them in the commit message.
 
 ### 5. Build Verification (mandatory after every change)
+Run the build as a **single command on ONE line** — do NOT split it across
+lines and do NOT wrap it in a `BUILD_LOG=` variable. A multi-line submission
+matches no allowed command and is rejected outright:
 ```bash
-BUILD_LOG="<agent_dir>/build_$$.log"
-devtool build <recipe> > "$BUILD_LOG" 2>&1
-echo "Exit code: $?"
+devtool build <recipe> > <agent_dir>/build.log 2>&1; echo "Exit code: $?"
 ```
-On failure: `tail -50 "$BUILD_LOG"`, fix, `git commit --amend --no-edit`, retry.
+Substitute `<recipe>` and `<agent_dir>` with the values from the context
+header (keep it all on one physical line).
+On failure: `tail -50 <agent_dir>/build.log`, fix, `git commit --amend
+--no-edit`, retry.
 If `devtool build` logs are insufficient, check Yocto task logs at:
 `<yocto_tmp>/work/<arch>/<recipe>/*/temp/log.do_compile`
 (paths are in the context header).

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -9,18 +9,67 @@ A git pre-commit hook enforces this — commits with unauthorized files will be 
 **NEVER do any of these:**
 - `git add .` or `git add -A`
 - `git commit --no-verify` or `git cherry-pick --no-verify`
-- Cherry-pick additional upstream commits beyond what cve_corrector already applied
+- Cherry-pick, squash, or inline changes that reach files **outside** the
+  Allowed Files list (see **Prerequisite / dependency handling** for how to
+  bring in an in-scope prerequisite, or when to escalate instead)
 - Create or rename files not in the Allowed Files list
 - Modify `.gitignore` or any file not in the Allowed Files list
 - Run `cve_corrector.py` (the agent handles workflow progression)
 - Read files outside the workspace directory
-- Use the `glob` tool
+- Use a file-glob / fuzzy-file-discovery tool
 
-**Prerequisite commits**: If the upstream fix depends on a prior commit, do NOT
-cherry-pick it separately. Instead, manually adapt the conflicting code to work
-without the prerequisite — inline the necessary changes into the files already
-being modified. The generated patch must only contain the upstream fix commit's
-changes, adapted for the stable branch.
+### Prerequisite / dependency handling
+
+When the fix references code that is missing or conflicts, first decide WHICH
+situation you are in — **most cases are adaptation, not a real dependency.**
+
+**Step 1 — does the referenced symbol already EXIST in the stable branch under
+a different name, signature, or location?**
+If a function was renamed, a signature changed, a struct member renamed, or a
+function moved, the functionality is already present — this is *adaptation, not
+a prerequisite*. Adapt the fix in place to match the stable name/shape and do
+**NOT** cherry-pick anything. See **Common Conflict Patterns** below. This is
+the common case.
+
+**Step 2 — only if the referenced code genuinely does NOT exist in the stable
+branch in any form is it a real prerequisite.** Then choose one of:
+
+- **(C) Trivial inline.** The missing piece is a small, self-contained helper,
+  macro, or struct field (roughly a few lines). Run `git show <prereq_sha>`
+  first to read the real code — never reconstruct it from the commit message —
+  then inline just the needed lines into a file already in the Allowed Files
+  list. Record the source SHA in your `Conflicts Resolved:` notes.
+
+- **(A) Separate prerequisite patch — the default for anything non-trivial.**
+  The missing code is more than a few lines but touches **only files already in
+  the Allowed Files list**. Cherry-pick the prerequisite as its own commit
+  *before* the fix, recording its upstream origin:
+  ```bash
+  git show <prereq_sha>            # confirm exactly what it changes and where
+  git cherry-pick -x <prereq_sha>  # -x records the upstream SHA in the message
+  ```
+  Keep it as a **separate commit** — do NOT squash it into the fix.
+  cve_corrector emits each commit as its own patch file. A prerequisite is not
+  itself a CVE fix, so cve_corrector tags it `Upstream-Status: Backport` only
+  (no `CVE:` tag); leave its commit message intact. If the cherry-pick
+  conflicts, resolve it the same way you resolve the fix's conflicts.
+
+- **(E) Escalate to human review.** Make **NO** code changes and stop if any of
+  these hold:
+  - the prerequisite touches files **outside** the Allowed Files list (the
+    pre-commit hook will reject the commit — do not try to work around it);
+  - it is a large or structural change (a refactor or API redesign);
+  - it itself depends on further prerequisites (a dependency chain).
+
+  Write an escalation conclusion and stop — do not mark the CVE not-applicable,
+  because it *is* applicable, just not safe to automate:
+  ```bash
+  cat > "<agent_dir>/conclusion.json" <<'EOF'
+  {"needs_human": true, "reason": "<why this prerequisite can't be safely automated, naming the prerequisite SHA and what it changes>"}
+  EOF
+  ```
+  Replace `<agent_dir>` with the actual agent dir path from the context header.
+  After writing the file, **stop — make no other changes.**
 
 **Files not in the baseline**: If the upstream commit adds a NEW file that is
 in the Allowed Files list, include it — `git cherry-pick` will stage it

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -175,6 +175,14 @@ file contains the original upstream commit subject and body. You MUST keep it
 intact and only **append** your backport notes after it. Never replace or rewrite
 the original message.
 
+**If this is a retry** (e.g. a build or ptest failure triggered another
+session after conflicts were already resolved), run `git log -1 --format=%B`
+first. If it already contains a `Conflicts Resolved:` block from a previous
+attempt, **update that existing block in place** — amend it to reflect the
+current state of the resolution — rather than appending a second block. The
+final commit message must contain exactly one `Conflicts Resolved:` block
+and one `Assisted-by:` trailer.
+
 Only append notes if you adapted the patch. Use EXACTLY this markdown format — no
 alternative headers like "Conflict resolution notes:" or "Backport changes:".
 
@@ -182,9 +190,6 @@ Append the following block after the original commit message (separated by a
 blank line):
 
 ```
-Backport Resolution: <One or two sentences explaining what the upstream commit does — the functional
-change, not the conflict details.>
-
 Conflicts Resolved:
 
 <file> (<N> conflict[s]):
@@ -197,10 +202,12 @@ Conflicts Resolved:
 Rules:
 - **Never delete or rewrite the original subject line or body** from `.git/MERGE_MSG`
 - Append your notes after the existing message, separated by a blank line
-- Start with a summary of the upstream fix's purpose (what it changes, why)
-- List ONLY files that had conflicts or required adaptation — skip clean files
-- For each file, state the conflict count and describe each adaptation
-- Mention specific function names, types, APIs, and why the stable branch differs
+- `Conflicts Resolved` owns all technical detail: list ONLY files that had
+  conflicts or required adaptation (skip clean files); for each, state the
+  conflict count and describe the adaptation with specific function names,
+  types, APIs, and why the stable branch differs
+- **No duplication**: each fact (what changed, in which function, why) must
+  appear exactly once
 - Omitted files: `<file>: omitted (not in branch)`
 - Do NOT add a "Changes from upstream" section (the agent generates that)
 - If you adapted the patch (not a verbatim cherry-pick), add a trailer line

--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -99,7 +99,7 @@ class AgentConfig:
     meta_layer: Optional[Path] = None
     skip_ptest: bool = False
     clean: bool = False
-    model: str = "claude-sonnet-4.6"
+    model: str = "claude-sonnet-5"
     session_timeout: int = DEFAULT_SESSION_TIMEOUT
     interactive: bool = False
     bbappend: bool = False

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -215,7 +215,7 @@ def _parse_args() -> argparse.Namespace:
     ai_group = parser.add_argument_group('AI session')
     ai_group.add_argument('--backend', default='kiro',
                         help='AI backend: kiro or claude (default: %(default)s)')
-    ai_group.add_argument('--model', default='claude-sonnet-4.6',
+    ai_group.add_argument('--model', default='claude-sonnet-5',
                         help='Model for AI sessions; the claude backend also '
                              'accepts aliases like sonnet/opus (default: %(default)s)')
     ai_group.add_argument('--max-retries', type=int, default=DEFAULT_MAX_RETRIES,

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -225,8 +225,9 @@ def _parse_args() -> argparse.Namespace:
                         help='Timeout per session in seconds (default: %(default)s)')
     ai_group.add_argument('--trust', action='store_true',
                         help='Skip human review (NOT recommended)')
-    ai_group.add_argument('--interactive', action='store_true',
-                        help='Enable interactive mode')
+    ai_group.add_argument('-i', '--interactive', action='store_true',
+                        help='Enable interactive mode (human-in-the-loop). '
+                             'Omit for non-interactive/CI use (default).')
 
     # --- Build control ---
     build_group = parser.add_argument_group('build control')

--- a/cve_agent/agents/yocto-cve-backport-interactive.json
+++ b/cve_agent/agents/yocto-cve-backport-interactive.json
@@ -7,28 +7,31 @@
   "toolsSettings": {
     "execute_bash": {
       "allowedCommands": [
-        "git status",
-        "git status --porcelain",
-        "git diff",
-        "git diff *",
-        "git log *",
-        "git show *",
-        "git add *",
-        "git cherry-pick --continue",
-        "git cherry-pick --abort",
-        "git am --continue",
-        "git am --abort",
-        "git checkout -- *",
-        "git rev-parse *",
-        "git merge-base *",
-        "git format-patch *",
-        "devtool build *",
-        "cat *",
-        "head *",
-        "tail *",
-        "find . *",
-        "grep *"
-      ]
+        "^git status$",
+        "^git status --porcelain$",
+        "^git diff$",
+        "^git diff .*$",
+        "^git log .*$",
+        "^git show .*$",
+        "^git add .*$",
+        "^git cherry-pick --continue$",
+        "^git cherry-pick --no-edit --continue$",
+        "^git cherry-pick --abort$",
+        "^git cherry-pick [^;&|]+$",
+        "^git am --continue$",
+        "^git am --abort$",
+        "^git checkout -- .*$",
+        "^git rev-parse .*$",
+        "^git merge-base .*$",
+        "^git format-patch .*$",
+        "^devtool build .*$",
+        "^cat .*$",
+        "^head .*$",
+        "^tail .*$",
+        "^find \\. .*$",
+        "^grep .*$"
+      ],
+      "denyByDefault": true
     },
     "fs_write": {
       "deniedPaths": [

--- a/cve_agent/agents/yocto-cve-backport.json
+++ b/cve_agent/agents/yocto-cve-backport.json
@@ -3,28 +3,31 @@
   "description": "CVE backport agent for Yocto/OE — resolves conflicts, build errors, and test failures in cherry-picked upstream fixes",
   "prompt": "file://cve_agent/AGENT_INSTRUCTIONS.md",
   "tools": ["fs_read", "fs_write", "execute_bash"],
-  "allowedTools": ["fs_read", "fs_write", "execute_bash"],
+  "allowedTools": ["fs_read", "fs_write"],
   "toolsSettings": {
     "execute_bash": {
       "allowedCommands": [
-        "git status",
-        "git status --porcelain",
-        "git diff",
-        "git diff *",
-        "git log *",
-        "git show *",
-        "git add *",
-        "git cherry-pick --continue",
-        "git cherry-pick --abort",
-        "git am --continue",
-        "git am --abort",
-        "git rev-parse *",
-        "git merge-base *",
-        "devtool build *",
-        "cat *",
-        "head *",
-        "tail *"
-      ]
+        "^git status$",
+        "^git status --porcelain$",
+        "^git diff$",
+        "^git diff .*$",
+        "^git log .*$",
+        "^git show .*$",
+        "^git add .*$",
+        "^git cherry-pick --continue$",
+        "^git cherry-pick --no-edit --continue$",
+        "^git cherry-pick --abort$",
+        "^git cherry-pick [^;&|]+$",
+        "^git am --continue$",
+        "^git am --abort$",
+        "^git rev-parse .*$",
+        "^git merge-base .*$",
+        "^devtool build .*$",
+        "^cat .*$",
+        "^head .*$",
+        "^tail .*$"
+      ],
+      "denyByDefault": true
     },
     "fs_write": {
       "deniedPaths": [

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -37,6 +37,20 @@ class AIBackend:
     def setup(self, **kwargs) -> None:
         """Perform any one-time setup."""
 
+    def tool_preamble(self) -> str:
+        """Backend-specific tool-name guidance to prepend to AGENT_INSTRUCTIONS.md.
+
+        AGENT_INSTRUCTIONS.md is shared verbatim across backends and
+        intentionally avoids naming concrete tools (different backends
+        expose different tool names for file I/O and shell execution).
+        Override this to supply that mapping — e.g. "use `fs_read` for file
+        inspection" for kiro-cli, "use `Read`/`Bash` for file inspection"
+        for Claude Code. Returns "" by default (no preamble), which is fine
+        for backends whose runtime already documents its own tool names to
+        the model independently of these instructions.
+        """
+        return ""
+
 
 _BACKENDS: dict[str, AIBackend] = {}
 

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -36,6 +36,7 @@ from .git import has_in_progress_operation
 # Map kiro-style model names to Claude Code aliases. Valid Claude aliases and
 # full model IDs pass through unchanged; an empty value falls back to "sonnet".
 _MODEL_ALIASES = {
+    "claude-sonnet-5": "sonnet",
     "claude-sonnet-4.6": "sonnet",
     "claude-sonnet-4-6": "sonnet",
     "claude-opus-4.6": "opus",

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -113,6 +113,19 @@ class ClaudeBackend(AIBackend):
     def is_available(self) -> bool:
         return shutil.which("claude") is not None
 
+    def tool_preamble(self) -> str:
+        """Claude Code's Read/Write/Edit/Bash tool-name mapping.
+
+        See :meth:`AIBackend.tool_preamble`. Mirrors the tool names in
+        ``_ALLOWED_TOOLS``/``_DENIED_READ_WRITE``/``_DENIED_WRITE`` above.
+        """
+        return (
+            "Your file/directory inspection and editing tools are `Read`, "
+            "`Edit`, `Write`, and `MultiEdit`; your bash-equivalent command "
+            "runner is `Bash`. Do not use `Glob` for file discovery — "
+            "everything you need is in the context file.\n\n"
+        )
+
     def _map_model(self, model: str) -> str:
         if not model:
             return "sonnet"
@@ -132,8 +145,9 @@ class ClaudeBackend(AIBackend):
         cmd += ["--add-dir", str(agent_dir)]
         agent_instructions = resolve_agent_instructions()
         if agent_instructions.is_file():
-            cmd += ["--append-system-prompt",
-                    agent_instructions.read_text(encoding="utf-8")]
+            system_prompt = (self.tool_preamble()
+                            + agent_instructions.read_text(encoding="utf-8"))
+            cmd += ["--append-system-prompt", system_prompt]
         else:
             logging.warning(
                 "Agent instructions not found (%s); running without a system "

--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -24,6 +24,7 @@ from . import (
     resolve_agent_instructions,
 )
 from .git import get_all_upstream_shas, get_upstream_sha, run_git_stdout
+from .interdiff import generate_interdiff
 
 
 def build_context(workspace_path: Path, exit_code: int, cve_id: str,
@@ -53,6 +54,11 @@ def build_context(workspace_path: Path, exit_code: int, cve_id: str,
         _build_phase_instructions(),
         _gather_context_for_exit_code(workspace_path, exit_code, cve_info),
     ]
+
+    if exit_code != EXIT_CONFLICT:
+        interdiff_section = _gather_interdiff(workspace_path, cve_info)
+        if interdiff_section:
+            sections.append(interdiff_section)
 
     similar_patterns = _gather_knowledge(knowledge_base, recipe, workspace_path)
     if similar_patterns:
@@ -355,6 +361,43 @@ def _gather_analysis_context(workspace_path: Path, cve_info: dict) -> str:
         f"{upstream_info}\n\n"
         f"Analyse the applied commits. If incompatible with the stable base, "
         f"adapt and document changes in the commit message."
+    )
+
+
+def _gather_interdiff(workspace_path: Path, cve_info: dict) -> str:
+    """Build an optional interdiff section showing the adaptation delta.
+
+    Computes the diff-of-diffs between the upstream commit and the
+    backported change on HEAD, so the AI sees precisely how the backport
+    already deviates from upstream. Returns an empty string whenever a
+    concise delta can't be produced (e.g. the ``interdiff`` binary isn't
+    installed) — callers should skip appending it in that case.
+
+    Args:
+        workspace_path: Path to workspace with an applied backport commit.
+        cve_info: CVE metadata dict (used to resolve upstream SHA).
+
+    Returns:
+        Formatted interdiff section, or empty string if unavailable.
+    """
+    upstream_sha = get_upstream_sha(cve_info, workspace_path)
+    if not upstream_sha or upstream_sha == "unknown":
+        return ""
+
+    upstream_diff = run_git_stdout(['show', upstream_sha], cwd=workspace_path)
+    backport_diff = run_git_stdout(
+        ['diff', 'original-version..HEAD'], cwd=workspace_path
+    )
+    interdiff = generate_interdiff(upstream_diff, backport_diff)
+    if not interdiff:
+        return ""
+
+    return (
+        f"## Interdiff (upstream \u2192 backport)\n\n"
+        f"The following shows only the lines that differ between the "
+        f"upstream patch and the current backport — i.e. how the backport "
+        f"already deviates from upstream.\n\n"
+        f"```diff\n{interdiff}\n```"
     )
 
 

--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -161,7 +161,11 @@ def _build_header(cve_id: str, recipe: str, exit_code: int,
         f"- **Backend**: {backend}\n"
         f"- **Model**: {model}\n"
         f"- **Workspace**: `{workspace_path}`\n"
-        f"- **Working directory**: `cd {workspace_path}`\n"
+        f"- **Working directory**: your shell ALREADY runs inside the "
+        f"workspace above. Run every command **bare** (e.g. `git status`) — "
+        f"do NOT prefix `cd` and do NOT chain with `&&`, `;`, or `|`. The "
+        f"command allow-list matches whole commands, so `cd ... && git "
+        f"status` is rejected while a plain `git status` is accepted.\n"
         f"- **Upstream SHA(s)**: {sha_display}\n"
         f"{log_lines}\n\n"
         f"## Allowed Files (ONLY these may be staged with `git add`)\n\n"
@@ -171,11 +175,23 @@ def _build_header(cve_id: str, recipe: str, exit_code: int,
 
 
 def _build_phase_instructions() -> str:
-    """Load agent instructions from AGENT_INSTRUCTIONS.md."""
+    """Reference agent instructions without re-embedding their full text.
+
+    The full AGENT_INSTRUCTIONS.md content already reaches the model via the
+    session's system prompt (the kiro-cli agent's ``prompt: file://...``
+    field, or the ``claude`` CLI's ``--append-system-prompt``; see
+    ``cve_agent.kiro_backend`` / ``cve_agent.claude_backend``). Embedding it
+    again here would just pay its token cost a second (or third) time on
+    every context.md this function contributes to, including retries, with
+    no new information. A short pointer is enough since the workflow steps
+    are already active in the model's system prompt.
+    """
     instructions_path = resolve_agent_instructions()
     if not instructions_path.exists():
         return "## Instructions\n\nSee cve_agent/AGENT_INSTRUCTIONS.md for workflow details."
-    return instructions_path.read_text(encoding='utf-8')
+    return ("## Instructions\n\nFollow the workflow, scope rules, and commit "
+            "message format from AGENT_INSTRUCTIONS.md (already provided as "
+            "your system prompt / agent instructions for this session).")
 
 
 def _gather_context_for_exit_code(workspace_path: Path, exit_code: int,

--- a/cve_agent/interdiff.py
+++ b/cve_agent/interdiff.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Optional interdiff (patchutils) integration.
+
+Computes a diff-of-diffs between the upstream patch and the backported
+patch so reviewers and the AI backend see only the adaptation delta,
+instead of two unrelated full patches. Purely additive: when the
+``interdiff`` binary (from the ``patchutils`` system package) is not
+installed, callers must fall back to their existing behavior unchanged.
+
+Note: ``interdiff`` aligns hunks by matching surrounding context lines.
+When the recipe's base file has diverged significantly from the upstream
+commit's base (e.g. missing refactors, different function signatures),
+context lines won't line up well and the output can be nearly as large
+as the full backport diff — this is expected behavior for distant
+patches, not a bug. Treat a large interdiff as a signal that the two
+patches don't align well and warrant closer manual review.
+"""
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+def generate_interdiff(upstream_patch: str, backport_patch: str) -> Optional[str]:
+    """Compute the diff-of-diffs between an upstream patch and its backport.
+
+    Pure helper: takes the two already-computed patch texts and shells out
+    to the ``interdiff`` binary. Returns ``None`` whenever a concise delta
+    cannot be produced (binary missing, empty input, non-zero exit, or any
+    subprocess/OS failure) so callers can silently fall back to their
+    current behavior.
+
+    Args:
+        upstream_patch: Full diff text of the original upstream commit.
+        backport_patch: Full diff text of the backported change.
+
+    Returns:
+        The interdiff output (adaptation delta) on success, or ``None``.
+    """
+    if not shutil.which('interdiff'):
+        return None
+    if not upstream_patch.strip() or not backport_patch.strip():
+        return None
+
+    old_path: Optional[str] = None
+    new_path: Optional[str] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.patch', delete=False, encoding='utf-8'
+        ) as old_file:
+            old_file.write(_ensure_trailing_newline(upstream_patch))
+            old_path = old_file.name
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.patch', delete=False, encoding='utf-8'
+        ) as new_file:
+            new_file.write(_ensure_trailing_newline(backport_patch))
+            new_path = new_file.name
+
+        result = subprocess.run(
+            ['interdiff', old_path, new_path],
+            capture_output=True, text=True, check=False
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        return result.stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    finally:
+        for path in (old_path, new_path):
+            if path:
+                Path(path).unlink(missing_ok=True)
+
+
+def _ensure_trailing_newline(patch_text: str) -> str:
+    """Ensure a unified diff ends with exactly one trailing newline.
+
+    Callers typically source patch text from helpers (e.g.
+    ``run_git_stdout``) that strip trailing whitespace for display
+    purposes. A unified diff whose final hunk line lacks a trailing
+    newline is invalid input for ``interdiff``'s parser and produces
+    corrupted output (stray control characters, spurious
+    ``\\ No newline at end of file`` markers). Normalize before writing
+    to the temp files passed to the ``interdiff`` binary.
+
+    Args:
+        patch_text: Patch text, possibly missing a trailing newline.
+
+    Returns:
+        Patch text guaranteed to end with exactly one ``\\n``.
+    """
+    return patch_text if patch_text.endswith('\n') else patch_text + '\n'

--- a/cve_agent/interdiff.py
+++ b/cve_agent/interdiff.py
@@ -16,14 +16,41 @@ as the full backport diff — this is expected behavior for distant
 patches, not a bug. Treat a large interdiff as a signal that the two
 patches don't align well and warrant closer manual review.
 """
+import shlex
 import shutil
 import subprocess
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 
-def generate_interdiff(upstream_patch: str, backport_patch: str) -> Optional[str]:
+@dataclass(frozen=True)
+class InterdiffArtifacts:
+    """Persisted inputs/outputs of an ``interdiff`` run.
+
+    Returned by :func:`generate_interdiff` when ``keep_files_dir`` is
+    given, so callers that log the interdiff output (e.g. the review
+    diff file) can also record the exact patch files and command used,
+    letting a reviewer reproduce the delta outside the tool.
+
+    Attributes:
+        output: The interdiff output (adaptation delta).
+        command: The exact argv used to invoke ``interdiff``, already
+            shell-quoted and joined into a single copy-pasteable string.
+        old_patch_path: Path to the persisted upstream ("old") patch file.
+        new_patch_path: Path to the persisted backport ("new") patch file.
+    """
+    output: str
+    command: str
+    old_patch_path: Path
+    new_patch_path: Path
+
+
+def generate_interdiff(
+    upstream_patch: str, backport_patch: str,
+    keep_files_dir: Optional[Path] = None,
+) -> Optional[str]:
     """Compute the diff-of-diffs between an upstream patch and its backport.
 
     Pure helper: takes the two already-computed patch texts and shells out
@@ -35,42 +62,96 @@ def generate_interdiff(upstream_patch: str, backport_patch: str) -> Optional[str
     Args:
         upstream_patch: Full diff text of the original upstream commit.
         backport_patch: Full diff text of the backported change.
+        keep_files_dir: If given, persist the two patch files fed to
+            ``interdiff`` in this directory instead of a temp dir, and
+            use ``generate_interdiff_artifacts`` under the hood so the
+            reproduction command is available. Prefer calling
+            :func:`generate_interdiff_artifacts` directly when the
+            command/paths are also needed by the caller.
 
     Returns:
         The interdiff output (adaptation delta) on success, or ``None``.
+    """
+    artifacts = generate_interdiff_artifacts(
+        upstream_patch, backport_patch, keep_files_dir=keep_files_dir
+    )
+    return artifacts.output if artifacts else None
+
+
+def generate_interdiff_artifacts(
+    upstream_patch: str, backport_patch: str,
+    keep_files_dir: Optional[Path] = None,
+) -> Optional[InterdiffArtifacts]:
+    """Compute the diff-of-diffs and optionally persist inputs/command.
+
+    Same computation as :func:`generate_interdiff`, but returns the
+    output alongside the exact ``interdiff`` command and the paths of
+    the two patch files it was run against. When ``keep_files_dir`` is
+    ``None`` (default), the patch files are written to a temp dir and
+    removed before returning — matching the original pure-helper
+    behavior — but the paths in the returned artifacts will no longer
+    exist on disk. Pass ``keep_files_dir`` to persist them for later
+    inspection or standalone reproduction.
+
+    Args:
+        upstream_patch: Full diff text of the original upstream commit.
+        backport_patch: Full diff text of the backported change.
+        keep_files_dir: Directory to persist the ``old.patch`` /
+            ``new.patch`` files into. Created if missing. When omitted,
+            the files are written to a temp dir and deleted afterwards.
+
+    Returns:
+        :class:`InterdiffArtifacts` on success, or ``None`` whenever a
+        concise delta cannot be produced (binary missing, empty input,
+        non-zero exit, or any subprocess/OS failure).
     """
     if not shutil.which('interdiff'):
         return None
     if not upstream_patch.strip() or not backport_patch.strip():
         return None
 
-    old_path: Optional[str] = None
-    new_path: Optional[str] = None
+    persist = keep_files_dir is not None
+    old_path: Optional[Path] = None
+    new_path: Optional[Path] = None
     try:
-        with tempfile.NamedTemporaryFile(
-            mode='w', suffix='.patch', delete=False, encoding='utf-8'
-        ) as old_file:
-            old_file.write(_ensure_trailing_newline(upstream_patch))
-            old_path = old_file.name
-        with tempfile.NamedTemporaryFile(
-            mode='w', suffix='.patch', delete=False, encoding='utf-8'
-        ) as new_file:
-            new_file.write(_ensure_trailing_newline(backport_patch))
-            new_path = new_file.name
+        if persist:
+            assert keep_files_dir is not None
+            keep_files_dir.mkdir(parents=True, exist_ok=True)
+            old_path = keep_files_dir / 'upstream.patch'
+            new_path = keep_files_dir / 'backport.patch'
+            old_path.write_text(_ensure_trailing_newline(upstream_patch), encoding='utf-8')
+            new_path.write_text(_ensure_trailing_newline(backport_patch), encoding='utf-8')
+        else:
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.patch', delete=False, encoding='utf-8'
+            ) as old_file:
+                old_file.write(_ensure_trailing_newline(upstream_patch))
+                old_path = Path(old_file.name)
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.patch', delete=False, encoding='utf-8'
+            ) as new_file:
+                new_file.write(_ensure_trailing_newline(backport_patch))
+                new_path = Path(new_file.name)
 
+        argv = ['interdiff', str(old_path), str(new_path)]
         result = subprocess.run(
-            ['interdiff', old_path, new_path],
-            capture_output=True, text=True, check=False
+            argv, capture_output=True, text=True, check=False
         )
         if result.returncode != 0 or not result.stdout.strip():
             return None
-        return result.stdout
+        return InterdiffArtifacts(
+            output=result.stdout,
+            command=shlex.join(argv),
+            old_patch_path=old_path,
+            new_patch_path=new_path,
+        )
     except (OSError, subprocess.SubprocessError):
         return None
     finally:
-        for path in (old_path, new_path):
-            if path:
-                Path(path).unlink(missing_ok=True)
+        if not persist:
+            for path in (old_path, new_path):
+                if path:
+                    path.unlink(missing_ok=True)
 
 
 def _ensure_trailing_newline(patch_text: str) -> str:

--- a/cve_agent/kiro_backend.py
+++ b/cve_agent/kiro_backend.py
@@ -7,9 +7,12 @@ the default backend; :mod:`cve_agent.claude_backend` mirrors its behaviour
 for the ``claude`` CLI.
 """
 import logging
+import shlex
+import shutil
 import subprocess
 import time
 from pathlib import Path
+from typing import Optional
 
 from shared import build_git_env
 
@@ -22,25 +25,41 @@ class KiroBackend(AIBackend):
     name = "kiro"
 
     def is_available(self) -> bool:
-        import shutil
         return shutil.which("kiro-cli") is not None
+
+    def tool_preamble(self) -> str:
+        """kiro-cli's fs_read/fs_write/execute_bash tool-name mapping.
+
+        See :meth:`AIBackend.tool_preamble`. Mirrors the tool names
+        configured in ``cve_agent/agents/yocto-cve-backport*.json``.
+        """
+        return (
+            "Your file/directory inspection tool is `fs_read`; your "
+            "bash-equivalent command runner is `execute_bash`.\n\n"
+        )
 
     def run_session(self, prompt: str, workspace_path: Path,
                    allowed_files: set, model: str,
                    timeout: int, interactive: bool) -> SessionResult:
-        agent_name = ('yocto-cve-backport-interactive' if interactive
-                      else 'yocto-cve-backport')
+        cmd = self._build_kiro_cmd(prompt, agent_name=None, model=model,
+                                  interactive=interactive)
         env = build_git_env()
-        cmd = ['kiro-cli', 'chat', '--agent', agent_name, '--model', model]
-        if not interactive:
-            cmd.append('--no-interactive')
-            cmd.append('--trust-tools=fs_read,fs_write,execute_bash')
-        cmd.append(prompt)
+
+        transcript_path: Optional[Path] = None
+        run_cmd: list = cmd
+        if interactive:
+            transcript_path = self._transcript_path(workspace_path)
+            if transcript_path is not None:
+                wrapped = self._wrap_with_script(cmd, transcript_path)
+                if wrapped is None:
+                    transcript_path = None
+                else:
+                    run_cmd = wrapped
 
         start = time.monotonic()
         timed_out = False
         try:
-            subprocess.run(cmd, cwd=workspace_path, env=env,
+            subprocess.run(run_cmd, cwd=workspace_path, env=env,
                          check=False, timeout=timeout)
         except subprocess.TimeoutExpired:
             timed_out = True
@@ -51,10 +70,106 @@ class KiroBackend(AIBackend):
 
         duration = time.monotonic() - start
         if timed_out:
-            return SessionResult(resolved=False, duration=duration)
+            return SessionResult(resolved=False, duration=duration,
+                                transcript_path=transcript_path)
 
         resolved = self._check_resolution(workspace_path)
-        return SessionResult(resolved=resolved, duration=duration)
+        return SessionResult(resolved=resolved, duration=duration,
+                            transcript_path=transcript_path)
+
+    @staticmethod
+    def _build_kiro_cmd(prompt: str, agent_name: Optional[str], model: str,
+                        interactive: bool) -> list:
+        """Build the plain (unwrapped) kiro-cli argv list.
+
+        Tool trust is defined entirely in the agent config JSON
+        (``allowedTools`` / ``toolsSettings.execute_bash.allowedCommands``)
+        — no ``--trust-tools``/``--trust-all-tools`` flag is passed here.
+        That keeps permissions in one place: passing ``--trust-tools`` would
+        only be redundant for tools already in the agent's ``allowedTools``,
+        and passing it for ``execute_bash`` would bypass the JSON's
+        per-command ``allowedCommands`` allow-list entirely (session-level
+        tool trust outranks it), which is exactly the gating this agent
+        relies on for unattended CI runs.
+        """
+        if agent_name is None:
+            agent_name = ('yocto-cve-backport-interactive' if interactive
+                          else 'yocto-cve-backport')
+        cmd = ['kiro-cli', 'chat', '--agent', agent_name, '--model', model]
+        if not interactive:
+            cmd.append('--no-interactive')
+            prompt = KiroBackend._with_agent_instructions(prompt)
+        cmd.append(prompt)
+        return cmd
+
+    @staticmethod
+    def _with_agent_instructions(prompt: str) -> str:
+        """Prepend AGENT_INSTRUCTIONS.md content (with the kiro tool preamble)
+        to the prompt.
+
+        ``kiro-cli chat`` has no ``--append-system-prompt`` equivalent (unlike
+        the ``claude`` CLI backend, see :meth:`ClaudeBackend._build_command`),
+        so the agent's ``prompt: file://...`` field is normally the only way
+        instructions reach the model — and that static file is synced via
+        :func:`cve_agent.setup.sync_agent_instructions`, which also prepends
+        the same tool preamble. In ``--no-interactive`` (CI) runs there is no
+        human to notice if that file:// prompt failed to resolve, so inline
+        the instructions directly into the query text as a second, explicit
+        path — redundant with the agent config, but that redundancy is the
+        point for unattended runs.
+        """
+        from . import resolve_agent_instructions
+        instructions_path = resolve_agent_instructions()
+        if not instructions_path.is_file():
+            logging.warning(
+                "Agent instructions not found (%s); running with only the "
+                "agent config's file:// prompt.", instructions_path)
+            return prompt
+        instructions = instructions_path.read_text(encoding="utf-8")
+        preamble = KiroBackend().tool_preamble()
+        return f"{preamble}{instructions}\n\n---\n\n{prompt}"
+
+    @staticmethod
+    def _transcript_path(workspace_path: Path) -> Optional[Path]:
+        """Build a per-session transcript file path under the agent dir.
+
+        Returns None (no transcript) if the directory can't be created,
+        e.g. under a read-only or nonexistent workspace path.
+        """
+        from . import get_agent_dir
+        try:
+            agent_dir = get_agent_dir(workspace_path)
+        except OSError as exc:
+            logging.warning(
+                "Could not create transcript directory under %s (%s); "
+                "interactive session will not be transcribed.",
+                workspace_path, exc)
+            return None
+        return agent_dir / f"kiro-session-{int(time.time())}.log"
+
+    @staticmethod
+    def _wrap_with_script(cmd: list, transcript_path: Path) -> Optional[list]:
+        """Wrap ``cmd`` with ``script`` to capture stdin+stdout to a file.
+
+        Interactive kiro-cli is a full-screen TUI that needs a real
+        controlling TTY, so its own stdio can't be redirected to pipes
+        without breaking the session. ``script`` allocates a pseudo-terminal
+        for the child, keeps the real TTY attached for the user, and tees
+        everything (both what the user types and what kiro-cli prints) into
+        ``transcript_path``. Falls back to running ``cmd`` unwrapped (no
+        transcript) if ``script`` isn't installed.
+        """
+        if shutil.which("script") is None:
+            logging.warning(
+                "'script' not found on PATH; interactive session will not "
+                "be transcribed to a log file.")
+            return None
+        # -q: no start/done banner polluting the transcript
+        # -e: propagate the wrapped command's exit code
+        # -B: log both stdin and stdout (combined) to the transcript
+        # -c: command to run instead of an interactive shell
+        return ["script", "-qe", "-B", str(transcript_path),
+                "-c", shlex.join(cmd)]
 
     def _check_resolution(self, workspace_path: Path) -> bool:
         if has_in_progress_operation(workspace_path):

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -62,6 +62,27 @@ def _read_conclusion(workspace_path: Path) -> Optional[str]:
     return None
 
 
+def _read_escalation(workspace_path: Path) -> Optional[str]:
+    """Read the agent conclusion file if it asked for human review.
+
+    Distinct from :func:`_read_conclusion`: a ``needs_human`` conclusion means
+    the CVE *is* applicable but can't be safely auto-backported (e.g. a
+    prerequisite that reaches outside the allowed files, or a structural
+    dependency). It must escalate to a human — NOT be marked not-applicable,
+    which would wrongly report the vulnerability as a non-issue.
+    """
+    try:
+        conclusion_file = get_agent_dir(workspace_path) / 'conclusion.json'
+        if not conclusion_file.exists():
+            return None
+        data = json.loads(conclusion_file.read_text(encoding='utf-8'))
+        if data.get('needs_human'):
+            return data.get('reason', 'Agent requested human review (no details)')
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
 def _is_empty_cherry_pick(workspace_path: Path, cve_info: dict) -> bool:
     """Check if the upstream commit produced no actual changes in the workspace."""
     upstream_sha = get_upstream_sha(cve_info, workspace_path)
@@ -159,6 +180,15 @@ def _run_single_resolution_attempt(
         return _AttemptOutcome(result=_make_result(
             config.cve_id, ResultStatus.SKIPPED,
             attempt, start_time, conclusion_reason
+        ))
+
+    escalation_reason = _read_escalation(workspace_path)
+    if escalation_reason:
+        print("\n\u26a0 Agent escalated to human review:")
+        print(f"  {escalation_reason}")
+        return _AttemptOutcome(result=_make_result(
+            config.cve_id, ResultStatus.ESCALATED,
+            attempt, start_time, escalation_reason
         ))
 
     if not workspace_path.exists():

--- a/cve_agent/review.py
+++ b/cve_agent/review.py
@@ -12,6 +12,7 @@ from shared import build_git_env
 
 from . import AgentConfig, get_agent_dir
 from .git import get_changed_files, run_git_display, run_git_stdout
+from .interdiff import generate_interdiff
 
 
 def request_approval(workspace_path: Path, upstream_sha: str,
@@ -244,13 +245,19 @@ def _save_review_diff(workspace_path: Path, upstream_sha: str) -> Path:
             encoding='utf-8',
         )
     else:
-        diff_path.write_text(
+        content = (
             f"=== UPSTREAM COMMIT {upstream_sha} ===\n\n"
             f"{upstream_diff}\n\n"
             f"=== BACKPORTED DIFF (original-version..HEAD) ===\n\n"
-            f"{backport_diff}\n",
-            encoding='utf-8',
+            f"{backport_diff}\n"
         )
+        interdiff = generate_interdiff(upstream_diff, backport_diff)
+        if interdiff:
+            content += (
+                f"\n=== INTERDIFF (upstream \u2192 backport) ===\n\n"
+                f"{interdiff}\n"
+            )
+        diff_path.write_text(content, encoding='utf-8')
     return diff_path
 
 
@@ -299,6 +306,15 @@ def _display_changes(workspace_path: Path, upstream_sha: str,
 
         print("\n--- Changes from upstream ---")
         print(summary)
+
+        upstream_diff = run_git_stdout(['show', upstream_sha], workspace_path)
+        interdiff = generate_interdiff(upstream_diff, applied_diff)
+        print("\n--- Interdiff (upstream \u2192 backport) ---")
+        if interdiff:
+            print(interdiff)
+        else:
+            print("(interdiff unavailable — install patchutils for a "
+                  "concise adaptation diff)")
 
         print("\n--- Final commit ---")
         run_git_display(['log', '-1', '--format=%B', 'HEAD'], workspace_path)

--- a/cve_agent/review.py
+++ b/cve_agent/review.py
@@ -12,7 +12,7 @@ from shared import build_git_env
 
 from . import AgentConfig, get_agent_dir
 from .git import get_changed_files, run_git_display, run_git_stdout
-from .interdiff import generate_interdiff
+from .interdiff import generate_interdiff, generate_interdiff_artifacts
 
 
 def request_approval(workspace_path: Path, upstream_sha: str,
@@ -214,6 +214,12 @@ def amend_commit_with_summary(workspace_path: Path, upstream_sha: str,
 def _save_review_diff(workspace_path: Path, upstream_sha: str) -> Path:
     """Save a combined diff file for external review.
 
+    When the ``interdiff`` binary is available, also persists the two
+    patch files it was run against (upstream commit patch and the final
+    backported patch) under ``cve_agent/<recipe>/interdiff-<sha>/``, and
+    appends the exact ``interdiff`` command to the diff file so the
+    delta can be reproduced standalone, outside this tool.
+
     Args:
         workspace_path: Path to workspace.
         upstream_sha: Upstream commit SHA.
@@ -251,11 +257,18 @@ def _save_review_diff(workspace_path: Path, upstream_sha: str) -> Path:
             f"=== BACKPORTED DIFF (original-version..HEAD) ===\n\n"
             f"{backport_diff}\n"
         )
-        interdiff = generate_interdiff(upstream_diff, backport_diff)
-        if interdiff:
+        interdiff_files_dir = agent_dir / f"interdiff-{upstream_sha[:12]}"
+        artifacts = generate_interdiff_artifacts(
+            upstream_diff, backport_diff, keep_files_dir=interdiff_files_dir
+        )
+        if artifacts:
             content += (
                 f"\n=== INTERDIFF (upstream \u2192 backport) ===\n\n"
-                f"{interdiff}\n"
+                f"{artifacts.output}\n"
+                f"--- Reproduce outside this tool ---\n"
+                f"Original upstream patch : {artifacts.old_patch_path}\n"
+                f"Final backported patch  : {artifacts.new_patch_path}\n"
+                f"Command                 : {artifacts.command}\n"
             )
         diff_path.write_text(content, encoding='utf-8')
     return diff_path

--- a/cve_agent/review.py
+++ b/cve_agent/review.py
@@ -43,7 +43,8 @@ def request_approval(workspace_path: Path, upstream_sha: str,
 
     while True:
         response = input(
-            "\nApprove? [y]es / [n]o (fix manually) / [e]dit (re-enter kiro-cli): "
+            f"\nApprove? [y]es / [n]o (fix manually) / "
+            f"[e]dit (re-enter {config.backend}): "
         ).strip().lower()
         if response in ('y', 'yes'):
             amend_commit_with_summary(workspace_path, upstream_sha, summary)
@@ -59,7 +60,7 @@ def request_approval(workspace_path: Path, upstream_sha: str,
                   f" --cve-info {config.cve_info_path}")
             return "rejected", ""
         if response in ('e', 'edit'):
-            feedback = input("What should kiro change? > ").strip()
+            feedback = input(f"What should the {config.backend} agent change? > ").strip()
             return "edit", feedback
         print("Invalid input. Enter y, n, or e.")
 
@@ -102,6 +103,47 @@ def build_change_summary(workspace_path: Path, upstream_sha: str) -> str:
     return '\n'.join(lines)
 
 
+_AGENT_NOTE_MARKERS = (
+    'Conflicts Resolved:',
+    '## ', '### Conflicts Resolved',
+)
+
+
+def _dedupe_agent_notes(commit_msg: str) -> str:
+    """Collapse repeated AI backport-note blocks into a single block.
+
+    Across resolution retries (e.g. conflict fixed, then a later ptest/build
+    failure triggers another AI session), the AI backend may append a
+    fresh ``Conflicts Resolved:`` block on top of one already present from
+    an earlier attempt instead of updating it in place. This strips all but
+    the last such block, keeping the most recent (most complete) resolution
+    notes.
+
+    Args:
+        commit_msg: Full commit message, possibly with duplicated note
+            blocks.
+
+    Returns:
+        Commit message with only the final note block retained.
+    """
+    lines = commit_msg.splitlines()
+    block_starts = [
+        i for i, line in enumerate(lines)
+        if line.strip().startswith(_AGENT_NOTE_MARKERS)
+    ]
+    if len(block_starts) <= 1:
+        return commit_msg
+
+    # Keep everything before the first block, then only the last block
+    # onward — earlier blocks are superseded duplicates.
+    kept = lines[:block_starts[0]] + lines[block_starts[-1]:]
+
+    result = '\n'.join(kept)
+    if commit_msg.endswith('\n') and not result.endswith('\n'):
+        result += '\n'
+    return result
+
+
 def amend_commit_with_summary(workspace_path: Path, upstream_sha: str,
                               summary: str) -> None:
     """Amend the HEAD commit message to append the change summary.
@@ -119,74 +161,61 @@ def amend_commit_with_summary(workspace_path: Path, upstream_sha: str,
     if f"Changes from upstream commit {upstream_sha[:12]}" in current_msg:
         return
 
+    current_msg = _dedupe_agent_notes(current_msg)
     lines = current_msg.rstrip().splitlines()
 
-    has_kiro_notes = any(
-        line.strip().startswith((
-            'Backport-Resolution:', 'Backport changes:',
-            'Conflict resolution notes:',
-            '## ', '### Conflicts Resolved',
-        ))
-        for line in lines
+    has_agent_notes = any(
+        line.strip().startswith(_AGENT_NOTE_MARKERS) for line in lines
     )
 
-    # Detect if 'Backport Resolution:' is the start of the message body
-    # (AI replaced original instead of appending).
-    kiro_note_markers = ('Backport Resolution:', 'Backport-Resolution:',
-                         'Backport changes:', 'Conflict resolution notes:')
-    if not has_kiro_notes:
-        has_kiro_notes = any(
-            line.strip().startswith(kiro_note_markers) for line in lines
-        )
-
     # Check if original upstream message body was preserved.
-    # If the first non-blank line after the subject is a kiro note marker,
-    # or the subject itself is a kiro note, the AI replaced the body.
+    # If the first non-blank line after the subject is a note marker,
+    # or the subject itself is a note, the AI replaced the body.
     original_subject = run_git_stdout(
         ['log', '-1', '--format=%s', upstream_sha], workspace_path
     ).strip()
 
     body_preserved = True
-    if has_kiro_notes and original_subject:
-        # Case 1: subject itself is a kiro marker (entire message replaced)
-        if lines and lines[0].strip().startswith(kiro_note_markers):
+    if has_agent_notes and original_subject:
+        # Case 1: subject itself is a marker (entire message replaced)
+        if lines and lines[0].strip().startswith(_AGENT_NOTE_MARKERS):
             body_preserved = False
         else:
-            # Case 2: subject kept but body starts with kiro note
+            # Case 2: subject kept but body starts with a note
             body_start = 1
             while body_start < len(lines) and not lines[body_start].strip():
                 body_start += 1
             if body_start < len(lines) and lines[body_start].strip().startswith(
-                kiro_note_markers
+                _AGENT_NOTE_MARKERS
             ):
                 body_preserved = False
 
-    if has_kiro_notes and not body_preserved and original_subject:
-        # AI replaced the body — restore original and append kiro notes
+    if has_agent_notes and not body_preserved and original_subject:
+        # AI replaced the body — restore original and append notes
         original_body = run_git_stdout(
             ['log', '-1', '--format=%b', upstream_sha], workspace_path
         ).rstrip()
 
-        # Extract kiro notes from current message
-        kiro_start = None
+        # Extract notes from current message
+        note_start = None
         for i, line in enumerate(lines):
-            if line.strip().startswith(kiro_note_markers):
-                kiro_start = i
+            if line.strip().startswith(_AGENT_NOTE_MARKERS):
+                note_start = i
                 break
-        kiro_notes = '\n'.join(lines[kiro_start:]) if kiro_start is not None else ''
+        agent_notes = '\n'.join(lines[note_start:]) if note_start is not None else ''
 
-        # Reconstruct: original subject + body + kiro notes + summary
+        # Reconstruct: original subject + body + notes + summary
         new_msg = original_subject + '\n'
         if original_body:
             new_msg += '\n' + original_body + '\n'
-        if kiro_notes:
-            new_msg += '\n' + kiro_notes + '\n'
+        if agent_notes:
+            new_msg += '\n' + agent_notes + '\n'
         new_msg += '\n' + summary + '\n'
-    elif has_kiro_notes:
-        # Original message preserved with kiro notes — just append summary
+    elif has_agent_notes:
+        # Original message preserved with notes — just append summary
         new_msg = '\n'.join(lines).strip() + f'\n\n{summary}\n'
     else:
-        # No kiro notes — strip trailing CVE block and append summary
+        # No notes — strip trailing CVE block and append summary
         last_cve_idx = None
         for i in range(len(lines) - 1, -1, -1):
             if lines[i].startswith('CVE:'):

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -119,6 +119,14 @@ def guarded_session(context_file: Path, workspace_path: Path,
     # to handle cases where upstream SHA paths differ from workspace layout
     allowed = _expand_path_variants(allowed, workspace_path)
 
+    # The allowed set is the hard scope boundary for the whole session. It
+    # intentionally permits the agent to bring in an in-scope prerequisite
+    # (Strategy A in AGENT_INSTRUCTIONS.md): a `git cherry-pick` of a
+    # prerequisite commit whose files are all within `allowed` passes the
+    # pre-commit hook and survives revert_unauthorized_changes as its own
+    # commit. A prerequisite reaching files OUTSIDE `allowed` is rejected by
+    # the hook (and stripped post-session), which is the mechanical signal
+    # for the agent to fall back to human review rather than widen its scope.
     install_scope_hook(workspace_path, allowed)
     print(f"\n=== Allowed files for this session ({len(allowed)}) ===")
     for f in sorted(allowed):

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -215,13 +215,24 @@ def _split_diff_by_file(diff: str) -> dict[str, str]:
 
 
 def _get_backport_note(workspace_path: Path) -> str:
-    """Extract the first backport-related line from the HEAD commit message."""
+    """Extract a representative backport-rationale line from HEAD's message.
+
+    ``Conflicts Resolved:`` is just a bare section header with no content
+    of its own, so this returns the first ``- <detail>`` bullet under it —
+    the closest thing to a one-line rationale in the current format.
+    """
     commit_msg = run_git_stdout(['log', '-1', '--format=%B'], cwd=workspace_path)
-    for line in commit_msg.splitlines():
-        if ('Backport-Resolution' in line
-                or 'Backport Resolution' in line
-                or 'Conflicts Resolved' in line
-                or 'backport' in line.lower()):
+    lines = commit_msg.splitlines()
+    in_conflicts_block = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('Conflicts Resolved:'):
+            in_conflicts_block = True
+            continue
+        if in_conflicts_block and stripped.startswith('- '):
+            return stripped
+    for line in lines:
+        if 'backport' in line.lower():
             return line.strip()
     return ''
 

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -80,7 +80,7 @@ def _expand_path_variants(allowed: set[str], workspace_path: Path) -> set[str]:
 
 def guarded_session(context_file: Path, workspace_path: Path,
                     upstream_sha: str, cve_info: dict,
-                    model: str = "claude-sonnet-4.6",
+                    model: str = "claude-sonnet-5",
                     timeout: int = 300,
                     cve_id: str = "",
                     interactive: bool = False,

--- a/cve_agent/setup.py
+++ b/cve_agent/setup.py
@@ -37,12 +37,22 @@ STABLE_AGENT_INSTRUCTIONS = data_dir() / "AGENT_INSTRUCTIONS.md"
 
 
 def sync_agent_instructions() -> Path:
-    """Copy the packaged AGENT_INSTRUCTIONS.md to the stable data_dir() path.
+    """Write the kiro-preamble + packaged AGENT_INSTRUCTIONS.md to the
+    stable data_dir() path.
 
     The kiro agent JSON's ``prompt`` field points at this stable copy rather
     than at the package's own copy, so the prompt keeps resolving correctly
     even if the project/package is later moved, reinstalled into a different
     environment, or upgraded — none of which change the XDG data directory.
+
+    AGENT_INSTRUCTIONS.md itself is shared verbatim across AI backends and
+    intentionally avoids naming concrete tools (kiro-cli and Claude Code
+    expose different tool names). Because kiro-cli's ``prompt: file://...``
+    field is a static file reference with no runtime templating, the
+    kiro-specific tool-name mapping (:meth:`cve_agent.kiro_backend.KiroBackend.
+    tool_preamble`) is prepended here at sync time — mirroring how
+    :class:`cve_agent.claude_backend.ClaudeBackend` prepends its own
+    preamble in Python via ``--append-system-prompt``.
 
     Always overwrites the destination so upgrades to the packaged file
     propagate on the next install. Writes to a temporary sibling file and
@@ -58,10 +68,13 @@ def sync_agent_instructions() -> Path:
     if not PACKAGED_AGENT_INSTRUCTIONS.is_file():
         raise FileNotFoundError(
             f"Packaged agent instructions not found: {PACKAGED_AGENT_INSTRUCTIONS}")
+    from .kiro_backend import KiroBackend
+    content = (KiroBackend().tool_preamble()
+              + PACKAGED_AGENT_INSTRUCTIONS.read_text(encoding='utf-8'))
     STABLE_AGENT_INSTRUCTIONS.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = STABLE_AGENT_INSTRUCTIONS.with_suffix(
         STABLE_AGENT_INSTRUCTIONS.suffix + '.tmp')
-    shutil.copyfile(PACKAGED_AGENT_INSTRUCTIONS, tmp_path)
+    tmp_path.write_text(content, encoding='utf-8')
     os.replace(tmp_path, STABLE_AGENT_INSTRUCTIONS)
     return STABLE_AGENT_INSTRUCTIONS
 
@@ -142,8 +155,8 @@ def verify_agents_installed() -> bool:
     return len(get_missing_agents()) == 0
 
 
-def install_agents(missing: list[str]) -> bool:
-    """Install missing agents by copying into ~/.kiro/agents/ with resolved paths.
+def install_agents(missing: list[str], quiet: bool = False) -> bool:
+    """Install (overwrite) agents by copying into ~/.kiro/agents/ with resolved paths.
 
     Copies agent JSON files (rather than symlinking) so that relative file://
     URIs in the 'prompt' field are rewritten to absolute paths that kiro-cli
@@ -151,8 +164,13 @@ def install_agents(missing: list[str]) -> bool:
     the stable data_dir() copy (synced from the packaged file here), not at
     the package's own copy, so it survives moves/reinstalls/upgrades.
 
+    Always overwrites the destination JSONs so packaged config changes (e.g.
+    ``execute_bash.allowedCommands``) propagate on every install.
+
     Args:
         missing: List of agent names to install.
+        quiet: When True, suppress the per-agent "Installed:" lines (used for
+            the routine refresh of already-present agents).
 
     Returns:
         True if all agents were installed successfully.
@@ -185,10 +203,11 @@ def install_agents(missing: list[str]) -> bool:
             target.unlink()
 
         target.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
-        if prompt_target:
-            print(f"  Installed: {name} (prompt -> {prompt_target})")
-        else:
-            print(f"  Installed: {name}")
+        if not quiet:
+            if prompt_target:
+                print(f"  Installed: {name} (prompt -> {prompt_target})")
+            else:
+                print(f"  Installed: {name}")
 
     return True
 
@@ -210,9 +229,13 @@ def ensure_agents(interactive: bool = True) -> None:
     Exits with error if prerequisites cannot be met.
 
     Always re-syncs the stable AGENT_INSTRUCTIONS.md copy (data_dir()) from
-    the packaged file, even if the agent JSONs themselves are already
-    installed — so content upgrades to the packaged instructions propagate
-    on every run, not just on (re)install.
+    the packaged file AND overwrites the installed agent JSONs from the
+    packaged sources, even if they are already present — so content upgrades
+    to the instructions or the agent configs (e.g. new
+    ``execute_bash.allowedCommands``) propagate on every run, not just on
+    first install. Already-present agents are refreshed quietly; genuinely
+    missing agents still trigger the informative (and, when interactive,
+    consented) install path.
 
     Args:
         interactive: If True, prompt user for approval before installing.
@@ -232,6 +255,15 @@ def ensure_agents(interactive: bool = True) -> None:
         sys.exit(EXIT_AGENT_ERROR)
 
     missing = get_missing_agents()
+    present = [name for name in REQUIRED_AGENTS if name not in missing]
+
+    # Refresh already-installed agents in place so packaged config changes
+    # propagate every run (mirrors sync_agent_instructions()). Quiet, since
+    # it's a routine overwrite, not a first-time install.
+    if present and not install_agents(present, quiet=True):
+        print("Error: Failed to refresh installed agents.", file=sys.stderr)
+        sys.exit(EXIT_AGENT_ERROR)
+
     if not missing:
         return
 

--- a/cve_corrector/patch_ops.py
+++ b/cve_corrector/patch_ops.py
@@ -8,6 +8,7 @@ and SRC_URI updates after devtool finish.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -21,18 +22,36 @@ if TYPE_CHECKING:
     from .state import WorkflowState
 
 
-def modify_patch(patch_file: Path, cve_id: str, original_url: str) -> None:
-    """Add CVE tag and Upstream-Status to patch."""
+def modify_patch(patch_file: Path, cve_id: str, original_url: str,
+                 include_cve_tag: bool = True) -> None:
+    """Add CVE and/or Upstream-Status metadata to a patch.
+
+    Args:
+        patch_file: Path to the patch file to annotate.
+        cve_id: CVE identifier for the ``CVE:`` tag.
+        original_url: Upstream commit URL for ``Upstream-Status: Backport``.
+        include_cve_tag: When True (default) the patch is the actual CVE fix
+            and gets a ``CVE: <cve_id>`` tag. When False the patch is a
+            prerequisite the fix depends on — it does not itself fix the CVE,
+            so it gets ``Upstream-Status: Backport`` **only**. The ``CVE:``
+            tag drives ``sbom-cve-check``; tagging a prerequisite with it
+            would falsely report that patch as the fix.
+    """
     text = patch_file.read_text(encoding="utf-8")
 
-    if f"CVE: {cve_id}" in text and "Upstream-Status:" in text:
+    # Idempotence: skip if the patch already carries the metadata it needs.
+    # The fix patch needs both tags; a prerequisite needs only Upstream-Status.
+    has_upstream = "Upstream-Status:" in text
+    has_cve = f"CVE: {cve_id}" in text
+    if has_upstream and (has_cve or not include_cve_tag):
         return
 
     author, email = get_git_user_info()
 
+    cve_line = f"CVE: {cve_id}\n" if include_cve_tag else ""
     block = (
         "\n"
-        f"CVE: {cve_id}\n"
+        f"{cve_line}"
         f"Upstream-Status: Backport [{original_url}]\n\n"
         f"Signed-off-by: {author} <{email}>\n"
     )
@@ -60,6 +79,93 @@ def modify_patch(patch_file: Path, cve_id: str, original_url: str) -> None:
     except Exception:
         os.unlink(tmp_path)
         raise
+
+
+def _extract_patch_subject(patch_text: str) -> str:
+    """Extract the unwrapped ``Subject:`` line from a format-patch file.
+
+    Handles RFC-822 folded subjects (continuation lines start with
+    whitespace) and strips the leading ``[PATCH ...]`` prefix so the result
+    can be compared against a plain ``git log --format=%s`` subject.
+    """
+    lines = patch_text.splitlines()
+    parts: list[str] = []
+    capturing = False
+    for line in lines:
+        if not capturing:
+            if line.startswith("Subject:"):
+                parts.append(line[len("Subject:"):].strip())
+                capturing = True
+            continue
+        # Folded continuation lines are indented and non-empty.
+        if line[:1] in (" ", "\t") and line.strip():
+            parts.append(line.strip())
+        else:
+            break
+    subject = " ".join(parts)
+    subject = re.sub(r"^\[PATCH[^\]]*\]\s*", "", subject)
+    return subject.strip()
+
+
+def _normalize_subject(subject: str) -> str:
+    """Collapse whitespace and lowercase a subject for robust comparison."""
+    return " ".join(subject.split()).lower()
+
+
+def _git_commit_subject(workspace_path: Path, commit_hash: str) -> str | None:
+    """Return the subject line of ``commit_hash``, or None if unavailable."""
+    if not commit_hash:
+        return None
+    result = run_cmd_capture(
+        ["git", "log", "-1", "--format=%s", commit_hash], cwd=workspace_path)
+    if result.returncode != 0:
+        return None
+    subject = result.stdout.strip()
+    return subject or None
+
+
+def _cherry_picked_sha(patch_text: str) -> str | None:
+    """Extract the upstream SHA from a ``(cherry picked from commit ...)`` line."""
+    match = re.search(r"cherry picked from commit ([0-9a-f]{7,40})", patch_text)
+    return match.group(1) if match else None
+
+
+def _compute_cve_tag_flags(state: WorkflowState, patches: list[str]) -> list[bool]:
+    """Decide which generated patches should carry the ``CVE:`` tag.
+
+    Only the patch corresponding to the fix commit gets the ``CVE:`` tag;
+    prerequisite commits the agent added get ``Upstream-Status: Backport``
+    only. This distinction is applied **only** when the agent introduced
+    extra commits (no known PR series, but more than one patch). Known PR
+    series (``series_state`` set) and single-patch fixes keep the existing
+    all-``CVE:`` behavior untouched.
+
+    Safety: if the fix commit's subject can't be matched to any generated
+    patch, fall back to tagging every patch — the fix must never silently
+    lose its ``CVE:`` tag.
+    """
+    flags = [True] * len(patches)
+    series_commits = (state.series_state or {}).get("commits", [])
+    if series_commits or len(patches) <= 1 or state.meta_layer is None:
+        return flags
+    meta_layer = state.meta_layer
+
+    fix_subject = _git_commit_subject(state.workspace_path, state.commit_hash)
+    if not fix_subject:
+        return flags
+
+    norm_fix = _normalize_subject(fix_subject)
+    matched = []
+    for patch_rel in patches:
+        text = (meta_layer / patch_rel).read_text(encoding="utf-8")
+        matched.append(_normalize_subject(_extract_patch_subject(text)) == norm_fix)
+
+    if not any(matched):
+        logger.warning(
+            "Could not match fix commit subject to any generated patch; "
+            "tagging all patches with CVE so the fix keeps its CVE: tag")
+        return flags
+    return matched
 
 
 def update_patches_with_metadata(state: WorkflowState) -> None:
@@ -114,14 +220,27 @@ def update_patches_with_metadata(state: WorkflowState) -> None:
             fallback = f"commit/{state.commit_hash}"
         commit_urls = [fallback] * len(original_patches)
 
+    cve_tag_flags = _compute_cve_tag_flags(state, original_patches)
+
     for idx, original_patch_path in enumerate(original_patches, 1):
         original_patch = state.meta_layer / original_patch_path
         if not original_patch.exists():
             continue
 
+        include_cve = cve_tag_flags[idx - 1]
         original_url = commit_urls[idx - 1]
-        logger.info("Upstream-Status: Backport [%s]", original_url)
-        modify_patch(original_patch, state.cve_id, original_url)
+        if not include_cve:
+            # Prefer the prerequisite's own upstream commit for its
+            # Upstream-Status link, if the agent recorded it via
+            # `git cherry-pick -x`.
+            prereq_sha = _cherry_picked_sha(
+                original_patch.read_text(encoding="utf-8"))
+            if prereq_sha and repo_base_url:
+                original_url = f"{repo_base_url}/commit/{prereq_sha}"
+        kind = "" if include_cve else " (prerequisite, no CVE tag)"
+        logger.info("Upstream-Status: Backport [%s]%s", original_url, kind)
+        modify_patch(original_patch, state.cve_id, original_url,
+                     include_cve_tag=include_cve)
 
         new_name = (f"{state.cve_id}.patch" if len(original_patches) == 1
                     else f"{state.cve_id}-{idx}.patch")

--- a/tests/agent/test_claude_kiro_parity.py
+++ b/tests/agent/test_claude_kiro_parity.py
@@ -44,8 +44,23 @@ def _claude_bash_prefixes() -> list[str]:
 
 
 def _base_command(command: str) -> str:
-    """Normalize a kiro allowedCommands entry: strip trailing glob."""
-    return command.rstrip("*").strip()
+    """Normalize a kiro allowedCommands regex entry: strip anchors/wildcard.
+
+    kiro's ``allowedCommands`` entries are regex patterns anchored with
+    ``^``/``$``; a trailing "anything after the prefix" match is spelled
+    ``.*$`` (e.g. ``^git add .*$``). Strip both anchors and the wildcard
+    tail so the remaining literal prefix (e.g. ``git add``) can be compared
+    against Claude's plain-text ``Bash(<prefix>:*)`` rules.
+    """
+    base = command
+    if base.startswith("^"):
+        base = base[1:]
+    if base.endswith("$"):
+        base = base[:-1]
+    if base.endswith(".*"):
+        base = base[:-2]
+    base = base.replace("\\.", ".").strip()
+    return base
 
 
 def _to_claude_path(kiro_path: str) -> str:

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -9,11 +9,15 @@ from cve_agent.context import _build_phase_instructions, _gather_interdiff, buil
 
 
 def test_build_phase_instructions_file_exists(tmp_path):
+    """When the instructions file exists, a short pointer is returned —
+    not the full file content, which already reaches the model via the
+    system prompt (see cve_agent.kiro_backend / cve_agent.claude_backend)."""
     instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
     instructions.write_text("# Instructions\nDo the thing.")
     with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
         result = _build_phase_instructions()
-    assert "Do the thing" in result
+    assert "Do the thing" not in result
+    assert "AGENT_INSTRUCTIONS.md" in result
 
 
 def test_build_phase_instructions_missing(tmp_path):

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 """Tests for cve_agent.context — context building helpers."""
+from pathlib import Path
 from unittest.mock import patch as mock_patch
 
-from cve_agent.context import _build_phase_instructions
+from cve_agent import EXIT_CONFLICT, EXIT_SUCCESS
+from cve_agent.context import _build_phase_instructions, _gather_interdiff, build_context
 
 
 def test_build_phase_instructions_file_exists(tmp_path):
@@ -19,3 +21,73 @@ def test_build_phase_instructions_missing(tmp_path):
     with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=missing):
         result = _build_phase_instructions()
     assert "AGENT_INSTRUCTIONS.md" in result
+
+
+class TestGatherInterdiff:
+    @mock_patch("cve_agent.context.generate_interdiff", return_value="-old\n+new\n")
+    @mock_patch("cve_agent.context.run_git_stdout", return_value="diff text")
+    @mock_patch("cve_agent.context.get_upstream_sha", return_value="abc123456789")
+    def test_returns_section_when_available(self, mock_sha, mock_git, mock_interdiff):
+        result = _gather_interdiff(Path("/ws"), {})
+        assert "Interdiff (upstream" in result
+        assert "-old\n+new\n" in result
+
+    @mock_patch("cve_agent.context.generate_interdiff", return_value=None)
+    @mock_patch("cve_agent.context.run_git_stdout", return_value="diff text")
+    @mock_patch("cve_agent.context.get_upstream_sha", return_value="abc123456789")
+    def test_returns_empty_when_interdiff_unavailable(self, mock_sha, mock_git, mock_interdiff):
+        result = _gather_interdiff(Path("/ws"), {})
+        assert result == ""
+
+    @mock_patch("cve_agent.context.generate_interdiff")
+    @mock_patch("cve_agent.context.get_upstream_sha", return_value="unknown")
+    def test_returns_empty_when_no_upstream_sha(self, mock_sha, mock_interdiff):
+        result = _gather_interdiff(Path("/ws"), {})
+        assert result == ""
+        mock_interdiff.assert_not_called()
+
+
+class TestBuildContextInterdiffWiring:
+    @mock_patch("cve_agent.context._gather_interdiff", return_value="## Interdiff (upstream → backport)\n\ndelta")
+    @mock_patch("cve_agent.context._gather_knowledge", return_value="")
+    @mock_patch("cve_agent.context._gather_context_for_exit_code", return_value="ctx")
+    @mock_patch("cve_agent.context._build_phase_instructions", return_value="instr")
+    @mock_patch("cve_agent.context._build_header", return_value="header")
+    def test_interdiff_section_included_for_non_conflict_phase(
+            self, mock_header, mock_instr, mock_ctx, mock_knowledge, mock_interdiff, tmp_path):
+        with mock_patch("cve_agent.context.get_agent_dir", return_value=tmp_path):
+            context_file = build_context(
+                tmp_path, EXIT_SUCCESS, "CVE-2025-0001", {'name': 'busybox'}
+            )
+        content = context_file.read_text(encoding='utf-8')
+        assert "Interdiff (upstream" in content
+        mock_interdiff.assert_called_once()
+
+    @mock_patch("cve_agent.context._gather_interdiff", return_value="## Interdiff (upstream → backport)\n\ndelta")
+    @mock_patch("cve_agent.context._gather_knowledge", return_value="")
+    @mock_patch("cve_agent.context._gather_context_for_exit_code", return_value="ctx")
+    @mock_patch("cve_agent.context._build_phase_instructions", return_value="instr")
+    @mock_patch("cve_agent.context._build_header", return_value="header")
+    def test_interdiff_skipped_for_conflict_phase(
+            self, mock_header, mock_instr, mock_ctx, mock_knowledge, mock_interdiff, tmp_path):
+        with mock_patch("cve_agent.context.get_agent_dir", return_value=tmp_path):
+            context_file = build_context(
+                tmp_path, EXIT_CONFLICT, "CVE-2025-0001", {'name': 'busybox'}
+            )
+        content = context_file.read_text(encoding='utf-8')
+        assert "Interdiff (upstream" not in content
+        mock_interdiff.assert_not_called()
+
+    @mock_patch("cve_agent.context._gather_interdiff", return_value="")
+    @mock_patch("cve_agent.context._gather_knowledge", return_value="")
+    @mock_patch("cve_agent.context._gather_context_for_exit_code", return_value="ctx")
+    @mock_patch("cve_agent.context._build_phase_instructions", return_value="instr")
+    @mock_patch("cve_agent.context._build_header", return_value="header")
+    def test_no_section_when_interdiff_empty(
+            self, mock_header, mock_instr, mock_ctx, mock_knowledge, mock_interdiff, tmp_path):
+        with mock_patch("cve_agent.context.get_agent_dir", return_value=tmp_path):
+            context_file = build_context(
+                tmp_path, EXIT_SUCCESS, "CVE-2025-0001", {'name': 'busybox'}
+            )
+        content = context_file.read_text(encoding='utf-8')
+        assert "Interdiff (upstream" not in content

--- a/tests/agent/test_context_full.py
+++ b/tests/agent/test_context_full.py
@@ -72,13 +72,29 @@ class TestBuildHeader:
         result = _build_header("CVE-1", "busybox", 0, ws, {})
         assert "tmp-glibc" in result
 
+    @patch("cve_agent.context.get_all_upstream_shas", return_value=["abc"])
+    @patch("cve_agent.context.get_upstream_sha", return_value="abc")
+    @patch("cve_agent.context.run_git_stdout", return_value="")
+    def test_working_dir_does_not_instruct_cd(self, mock_git, mock_sha, mock_all, tmp_path):
+        """The header must not render a runnable `cd <path>` — the shell
+        already runs in the workspace, and a `cd ... && cmd` wrapper is
+        rejected by the command allow-list. Regression guard for the
+        `cd /ws && git status` rejection."""
+        result = _build_header("CVE-1", "busybox", EXIT_CONFLICT, tmp_path, {})
+        assert f"cd {tmp_path}" not in result
+        assert "bare" in result.lower()
+
 
 class TestBuildPhaseInstructions:
     def test_file_exists(self, tmp_path):
+        """Returns a short pointer, not the full file content (already
+        delivered via the session's system prompt)."""
         instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
         instructions.write_text("# Do stuff")
         with patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
-            assert "Do stuff" in _build_phase_instructions()
+            result = _build_phase_instructions()
+            assert "Do stuff" not in result
+            assert "AGENT_INSTRUCTIONS.md" in result
 
     def test_file_missing(self, tmp_path):
         with patch("cve_agent.context.resolve_agent_instructions",

--- a/tests/agent/test_interactive.py
+++ b/tests/agent/test_interactive.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for cve_agent interactive mode and session behavior."""
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -45,6 +46,29 @@ class TestInteractiveFlag:
             bbappend=False, skip_cve_applicability=False, interactive=True)
         cfg = _config_from_args(args, 'CVE-1')
         assert cfg.interactive is True
+
+    def test_cli_default_is_non_interactive(self, monkeypatch):
+        """No -i/--interactive flag -> non-interactive, safe for CI."""
+        from cve_agent.__main__ import _parse_args
+        monkeypatch.setattr(sys, 'argv', [
+            'cve-agent', '--cve-id', 'CVE-2024-1234',
+            '--cve-info', '/tmp/x.json'])
+        args = _parse_args()
+        assert args.interactive is False
+
+    def test_cli_short_flag_matches_long_flag(self, monkeypatch):
+        """-i is a backward-compatible alias for --interactive."""
+        from cve_agent.__main__ import _parse_args
+        monkeypatch.setattr(sys, 'argv', [
+            'cve-agent', '--cve-id', 'CVE-2024-1234',
+            '--cve-info', '/tmp/x.json', '-i'])
+        short_args = _parse_args()
+        monkeypatch.setattr(sys, 'argv', [
+            'cve-agent', '--cve-id', 'CVE-2024-1234',
+            '--cve-info', '/tmp/x.json', '--interactive'])
+        long_args = _parse_args()
+        assert short_args.interactive is True
+        assert long_args.interactive is True
 
 
 class TestInteractiveAgentSelection:

--- a/tests/agent/test_interactive.py
+++ b/tests/agent/test_interactive.py
@@ -73,13 +73,62 @@ class TestInteractiveAgentSelection:
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=False)
         cmd = mock_run.call_args_list[0][0][0]
         assert '--no-interactive' in cmd
-        assert '--trust-tools=fs_read,fs_write,execute_bash' in cmd
+        assert '--trust-tools' not in cmd
+        assert '--trust-all-tools' not in cmd
+
+
+class TestNonInteractivePromptIncludesInstructions:
+    """CI (--no-interactive) runs inline AGENT_INSTRUCTIONS.md into the query
+    text itself, since kiro-cli has no --append-system-prompt equivalent and
+    there's no human to notice a silently-unresolved file:// agent prompt."""
+
+    @patch('subprocess.run')
+    def test_non_interactive_prompt_prepends_instructions(self, mock_run, tmp_path):
+        instructions_file = tmp_path / 'AGENT_INSTRUCTIONS.md'
+        instructions_file.write_text('# CVE Backport Agent Instructions\n'
+                                     'Use fs_read for everything.',
+                                     encoding='utf-8')
+        with patch('cve_agent.resolve_agent_instructions',
+                   return_value=instructions_file):
+            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
+                            interactive=False)
+        cmd = mock_run.call_args_list[0][0][0]
+        query = cmd[-1]
+        assert 'Use fs_read for everything.' in query
+        assert 'Read /ctx.md' in query
+
+    @patch('subprocess.run')
+    def test_interactive_prompt_does_not_duplicate_instructions(
+            self, mock_run, tmp_path):
+        """Interactive already gets instructions via the agent config's
+        file:// prompt; inlining them again would be redundant noise."""
+        instructions_file = tmp_path / 'AGENT_INSTRUCTIONS.md'
+        instructions_file.write_text('# CVE Backport Agent Instructions',
+                                     encoding='utf-8')
+        with patch('cve_agent.resolve_agent_instructions',
+                   return_value=instructions_file):
+            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
+                            interactive=True)
+        cmd = mock_run.call_args_list[0][0][0]
+        query = cmd[-1]
+        assert query == 'Read /ctx.md'
+
+    @patch('subprocess.run')
+    def test_missing_instructions_file_falls_back_to_plain_prompt(
+            self, mock_run, tmp_path):
+        missing = tmp_path / 'does-not-exist.md'
+        with patch('cve_agent.resolve_agent_instructions', return_value=missing):
+            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
+                            interactive=False)
+        cmd = mock_run.call_args_list[0][0][0]
+        assert cmd[-1] == 'Read /ctx.md'
 
     @patch('subprocess.run')
     def test_interactive_omits_trust_tools(self, mock_run):
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=True)
         cmd = mock_run.call_args_list[0][0][0]
-        assert '--trust-tools=fs_read,fs_write,execute_bash' not in cmd
+        assert '--trust-tools' not in ' '.join(cmd)
+        assert '--trust-all-tools' not in cmd
 
 
 class TestSessionErrorHandling:
@@ -94,3 +143,51 @@ class TestSessionErrorHandling:
     @patch('subprocess.run', side_effect=[FileNotFoundError, MagicMock(returncode=0, stdout='')])
     def test_kiro_not_found_returns_false(self, _):
         assert _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300) is False
+
+
+class TestTranscriptCapture:
+    """Interactive sessions are wrapped with `script` to capture a
+    stdin+stdout transcript, without disrupting the live TTY kiro-cli needs
+    for its prompts."""
+
+    def test_wrap_with_script_captures_stdin_and_stdout(self):
+        cmd = ['kiro-cli', 'chat', '--agent', 'yocto-cve-backport-interactive',
+               '--model', 'm', 'do the thing']
+        wrapped = _kiro._wrap_with_script(cmd, Path('/tmp/session.log'))
+        assert wrapped[0] == 'script'
+        assert '-B' in wrapped
+        assert str(Path('/tmp/session.log')) in wrapped
+        assert '-c' in wrapped
+        # The original command is preserved (shell-quoted) after -c.
+        inner = wrapped[wrapped.index('-c') + 1]
+        assert 'kiro-cli' in inner
+        assert 'yocto-cve-backport-interactive' in inner
+
+    def test_wrap_with_script_returns_none_without_script_binary(self):
+        cmd = ['kiro-cli', 'chat', 'x']
+        with patch('shutil.which', return_value=None):
+            assert _kiro._wrap_with_script(cmd, Path('/tmp/session.log')) is None
+
+    def test_transcript_path_none_on_uncreatable_dir(self):
+        # /ws doesn't exist and isn't creatable in the test sandbox, so this
+        # must fail gracefully rather than raising.
+        assert _kiro._transcript_path(Path('/ws')) is None
+
+    @patch('subprocess.run')
+    def test_interactive_session_wraps_with_script_when_dir_creatable(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout='')
+        with patch('cve_agent.git.build_git_env', return_value={'PATH': '/usr/bin'}):
+            _spawn_kiro_cli(Path('/ctx.md'), tmp_path, 'model', 300, interactive=True)
+        cmd = mock_run.call_args_list[0][0][0]
+        assert cmd[0] == 'script'
+        inner = cmd[cmd.index('-c') + 1]
+        assert 'yocto-cve-backport-interactive' in inner
+
+    @patch('subprocess.run')
+    def test_non_interactive_session_never_wrapped(self, mock_run, tmp_path):
+        """Non-interactive runs are unaffected by transcript capture."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='')
+        with patch('cve_agent.git.build_git_env', return_value={'PATH': '/usr/bin'}):
+            _spawn_kiro_cli(Path('/ctx.md'), tmp_path, 'model', 300, interactive=False)
+        cmd = mock_run.call_args_list[0][0][0]
+        assert cmd[0] == 'kiro-cli'

--- a/tests/agent/test_interdiff.py
+++ b/tests/agent/test_interdiff.py
@@ -5,7 +5,12 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cve_agent.interdiff import _ensure_trailing_newline, generate_interdiff
+from cve_agent.interdiff import (
+    InterdiffArtifacts,
+    _ensure_trailing_newline,
+    generate_interdiff,
+    generate_interdiff_artifacts,
+)
 
 UPSTREAM = "diff --git a/f.c b/f.c\n--- a/f.c\n+++ b/f.c\n@@ -1 +1 @@\n-old\n+new\n"
 BACKPORT = "diff --git a/f.c b/f.c\n--- a/f.c\n+++ b/f.c\n@@ -1 +1 @@\n-old\n+new2\n"
@@ -165,3 +170,113 @@ class TestGenerateInterdiff:
 
         for content in captured_contents:
             assert not content.endswith("\n\n")
+
+
+class TestGenerateInterdiffArtifacts:
+    @patch("cve_agent.interdiff.shutil.which", return_value=None)
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_binary_missing_returns_none(self, mock_run, mock_which):
+        assert generate_interdiff_artifacts(UPSTREAM, BACKPORT) is None
+        mock_run.assert_not_called()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_success_returns_artifacts_with_command_and_paths(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(returncode=0, stdout="-old\n+new2\n", stderr="")
+        result = generate_interdiff_artifacts(UPSTREAM, BACKPORT)
+        assert isinstance(result, InterdiffArtifacts)
+        assert result.output == "-old\n+new2\n"
+        assert result.command.startswith("interdiff ")
+        assert str(result.old_patch_path) in result.command
+        assert str(result.new_patch_path) in result.command
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_nonzero_exit_returns_none(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+        assert generate_interdiff_artifacts(UPSTREAM, BACKPORT) is None
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_temp_files_cleaned_up_when_no_keep_dir(self, mock_which):
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff_artifacts(UPSTREAM, BACKPORT)
+
+        assert result is not None
+        assert not result.old_patch_path.exists()
+        assert not result.new_patch_path.exists()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_keep_files_dir_persists_both_patches(self, mock_which, tmp_path):
+        keep_dir = tmp_path / "interdiff-out"
+
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff_artifacts(
+                UPSTREAM, BACKPORT, keep_files_dir=keep_dir
+            )
+
+        assert result is not None
+        assert result.old_patch_path == keep_dir / "upstream.patch"
+        assert result.new_patch_path == keep_dir / "backport.patch"
+        assert result.old_patch_path.exists()
+        assert result.new_patch_path.exists()
+        assert result.old_patch_path.read_text(encoding="utf-8") == UPSTREAM
+        assert result.new_patch_path.read_text(encoding="utf-8") == BACKPORT
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_keep_files_dir_command_uses_persisted_paths(self, mock_which, tmp_path):
+        keep_dir = tmp_path / "interdiff-out"
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["argv"] = cmd
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff_artifacts(
+                UPSTREAM, BACKPORT, keep_files_dir=keep_dir
+            )
+
+        assert result is not None
+        assert result.command == " ".join(captured["argv"])
+        assert result.command == (
+            f"interdiff {keep_dir / 'upstream.patch'} {keep_dir / 'backport.patch'}"
+        )
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_keep_files_dir_not_removed_on_nonzero_exit(self, mock_which, tmp_path):
+        """Even on failure, callers who asked to keep files should not lose
+        them silently — but since no concise delta is produced we still
+        return None; the persisted directory is left in place for
+        troubleshooting rather than being cleaned up."""
+        keep_dir = tmp_path / "interdiff-out"
+
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=1, stdout="", stderr="error")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff_artifacts(
+                UPSTREAM, BACKPORT, keep_files_dir=keep_dir
+            )
+
+        assert result is None
+        assert (keep_dir / "upstream.patch").exists()
+        assert (keep_dir / "backport.patch").exists()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_generate_interdiff_wraps_artifacts_output(self, mock_which, tmp_path):
+        keep_dir = tmp_path / "interdiff-out"
+
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff(UPSTREAM, BACKPORT, keep_files_dir=keep_dir)
+
+        assert result == "delta\n"
+        assert (keep_dir / "upstream.patch").exists()

--- a/tests/agent/test_interdiff.py
+++ b/tests/agent/test_interdiff.py
@@ -1,0 +1,167 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for cve_agent.interdiff — optional patchutils integration."""
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from cve_agent.interdiff import _ensure_trailing_newline, generate_interdiff
+
+UPSTREAM = "diff --git a/f.c b/f.c\n--- a/f.c\n+++ b/f.c\n@@ -1 +1 @@\n-old\n+new\n"
+BACKPORT = "diff --git a/f.c b/f.c\n--- a/f.c\n+++ b/f.c\n@@ -1 +1 @@\n-old\n+new2\n"
+
+
+class TestEnsureTrailingNewline:
+    def test_adds_newline_when_missing(self):
+        assert _ensure_trailing_newline("abc") == "abc\n"
+
+    def test_leaves_single_trailing_newline_unchanged(self):
+        assert _ensure_trailing_newline("abc\n") == "abc\n"
+
+    def test_does_not_add_second_newline(self):
+        result = _ensure_trailing_newline("abc\n")
+        assert not result.endswith("\n\n")
+
+    def test_empty_string_gets_newline(self):
+        assert _ensure_trailing_newline("") == "\n"
+
+
+class TestGenerateInterdiff:
+    @patch("cve_agent.interdiff.shutil.which", return_value=None)
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_binary_missing_returns_none(self, mock_run, mock_which):
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result is None
+        mock_run.assert_not_called()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_empty_backport_returns_none(self, mock_run, mock_which):
+        result = generate_interdiff(UPSTREAM, "")
+        assert result is None
+        mock_run.assert_not_called()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_empty_upstream_returns_none(self, mock_run, mock_which):
+        result = generate_interdiff("   ", BACKPORT)
+        assert result is None
+        mock_run.assert_not_called()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_success_returns_stdout(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="-old\n+new2\n", stderr=""
+        )
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result == "-old\n+new2\n"
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "interdiff"
+        assert len(args) == 3
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_nonzero_exit_returns_none(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error"
+        )
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result is None
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run")
+    def test_empty_stdout_returns_none(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result is None
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run",
+           side_effect=subprocess.SubprocessError("boom"))
+    def test_subprocess_error_returns_none(self, mock_run, mock_which):
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result is None
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    @patch("cve_agent.interdiff.subprocess.run", side_effect=OSError("boom"))
+    def test_os_error_returns_none(self, mock_run, mock_which):
+        result = generate_interdiff(UPSTREAM, BACKPORT)
+        assert result is None
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_temp_files_cleaned_up(self, mock_which):
+        created_paths = []
+
+        def fake_run(cmd, **kwargs):
+            # cmd = ['interdiff', old_path, new_path]
+            created_paths.extend(cmd[1:3])
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff(UPSTREAM, BACKPORT)
+
+        assert result == "delta\n"
+        assert len(created_paths) == 2
+        for path in created_paths:
+            assert not Path(path).exists()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_temp_files_cleaned_up_on_failure(self, mock_which):
+        created_paths = []
+
+        def fake_run(cmd, **kwargs):
+            created_paths.extend(cmd[1:3])
+            raise OSError("boom")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff(UPSTREAM, BACKPORT)
+
+        assert result is None
+        assert len(created_paths) == 2
+        for path in created_paths:
+            assert not Path(path).exists()
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_temp_files_always_end_with_newline(self, mock_which):
+        """Regression: run_git_stdout() strips trailing newlines before
+        callers pass patch text in. If the temp files written for
+        interdiff lack a trailing newline, interdiff's parser corrupts
+        the last hunk (stray control chars, spurious 'No newline at end
+        of file' markers) instead of producing a clean delta."""
+        captured_contents = []
+
+        def fake_run(cmd, **kwargs):
+            for path in cmd[1:3]:
+                captured_contents.append(Path(path).read_text(encoding="utf-8"))
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        stripped_upstream = UPSTREAM.rstrip("\n")
+        stripped_backport = BACKPORT.rstrip("\n")
+        assert not stripped_upstream.endswith("\n")
+        assert not stripped_backport.endswith("\n")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            result = generate_interdiff(stripped_upstream, stripped_backport)
+
+        assert result == "delta\n"
+        assert len(captured_contents) == 2
+        for content in captured_contents:
+            assert content.endswith("\n")
+            assert not content.endswith("\n\n")
+
+    @patch("cve_agent.interdiff.shutil.which", return_value="/usr/bin/interdiff")
+    def test_temp_files_not_double_newlined_when_already_terminated(self, mock_which):
+        captured_contents = []
+
+        def fake_run(cmd, **kwargs):
+            for path in cmd[1:3]:
+                captured_contents.append(Path(path).read_text(encoding="utf-8"))
+            return MagicMock(returncode=0, stdout="delta\n", stderr="")
+
+        with patch("cve_agent.interdiff.subprocess.run", side_effect=fake_run):
+            generate_interdiff(UPSTREAM, BACKPORT)
+
+        for content in captured_contents:
+            assert not content.endswith("\n\n")

--- a/tests/agent/test_main_process.py
+++ b/tests/agent/test_main_process.py
@@ -21,6 +21,53 @@ def _cfg(**kwargs):
     defaults.update(kwargs)
     return AgentConfig(**defaults)
 
+class TestReadEscalation:
+    """_read_escalation recognizes the needs_human conclusion (Strategy E),
+    distinct from the not_applicable conclusion."""
+
+    def _write(self, tmp_path, payload):
+        import json as _json
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "conclusion.json").write_text(_json.dumps(payload))
+        return agent_dir
+
+    def test_needs_human_returns_reason(self, tmp_path):
+        from cve_agent.orchestrator import _read_escalation
+        agent_dir = self._write(
+            tmp_path, {"needs_human": True, "reason": "prereq touches out-of-scope files"})
+        with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
+            assert _read_escalation(tmp_path) == "prereq touches out-of-scope files"
+
+    def test_needs_human_without_reason_has_default(self, tmp_path):
+        from cve_agent.orchestrator import _read_escalation
+        agent_dir = self._write(tmp_path, {"needs_human": True})
+        with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
+            assert "human review" in _read_escalation(tmp_path)
+
+    def test_not_applicable_is_not_escalation(self, tmp_path):
+        """A not_applicable conclusion must NOT read as an escalation."""
+        from cve_agent.orchestrator import _read_escalation
+        agent_dir = self._write(
+            tmp_path, {"not_applicable": True, "reason": "code absent"})
+        with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
+            assert _read_escalation(tmp_path) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        from cve_agent.orchestrator import _read_escalation
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
+            assert _read_escalation(tmp_path) is None
+
+    def test_get_agent_dir_failure_returns_none(self, tmp_path):
+        """A read helper must never crash the loop if agent_dir can't resolve."""
+        from cve_agent.orchestrator import _read_escalation
+        with patch("cve_agent.orchestrator.get_agent_dir",
+                   side_effect=OSError("permission denied")):
+            assert _read_escalation(tmp_path) is None
+
+
 
 class TestProcessSingleCve:
     @patch("cve_agent.__main__._log_result")

--- a/tests/agent/test_preserve_commit_msg.py
+++ b/tests/agent/test_preserve_commit_msg.py
@@ -8,7 +8,7 @@ commit message when the AI replaced it with backport notes.
 from pathlib import Path
 from unittest.mock import patch
 
-from cve_agent.review import amend_commit_with_summary
+from cve_agent.review import _dedupe_agent_notes, amend_commit_with_summary
 
 UPSTREAM_SHA = "97acf3dfda80c91c3a8c9f2372546301d4a1a7a8"
 UPSTREAM_SUBJECT = (
@@ -30,15 +30,12 @@ class TestPreserveOriginalCommitMessage:
     def test_restores_original_when_ai_replaced_message(
         self, mock_git, mock_run
     ):
-        """When the AI wrote 'Backport Resolution:' as the message body
+        """When the AI wrote 'Conflicts Resolved:' as the message body
         (replacing the original), amend_commit_with_summary should restore
         the original upstream subject+body and append backport notes after."""
         # Simulate AI having replaced the message entirely
         ai_replaced_msg = (
             "transport.c: Additional boundary checks for packet length (#2052)\n"
-            "\n"
-            "Backport Resolution: Add additional bounds checking on packet\n"
-            "length to prevent OOB write.\n"
             "\n"
             "Conflicts Resolved:\n"
             "\n"
@@ -73,7 +70,6 @@ class TestPreserveOriginalCommitMessage:
         assert "LIBSSH2_PACKET_MAXPAYLOAD" in final_msg
         assert "Closes #2050" in final_msg
         # Kiro notes must still be present
-        assert "Backport Resolution:" in final_msg
         assert "Conflicts Resolved:" in final_msg
         # Summary must be appended
         assert "Changes from upstream commit" in final_msg
@@ -91,8 +87,6 @@ class TestPreserveOriginalCommitMessage:
             "LIBSSH2_PACKET_MAXPAYLOAD to prevent OOB write.\n"
             "\n"
             "Closes #2050\n"
-            "\n"
-            "Backport Resolution: Add bounds checking on packet length.\n"
             "\n"
             "Conflicts Resolved:\n"
             "\n"
@@ -124,7 +118,7 @@ class TestPreserveOriginalCommitMessage:
         # Original body preserved
         assert "Closes #2050" in final_msg
         # Kiro notes preserved
-        assert "Backport Resolution:" in final_msg
+        assert "Conflicts Resolved:" in final_msg
         # Summary appended
         assert "Changes from upstream commit" in final_msg
 
@@ -134,8 +128,6 @@ class TestPreserveOriginalCommitMessage:
         """When the AI wrote a completely different subject line (edge case),
         the original should be restored from upstream SHA."""
         ai_msg = (
-            "Backport Resolution: Add bounds checking on packet length.\n"
-            "\n"
             "Conflicts Resolved:\n"
             "\n"
             "src/transport.c (1 conflict):\n"
@@ -164,4 +156,99 @@ class TestPreserveOriginalCommitMessage:
         # Original body restored
         assert "Closes #2050" in final_msg
         # AI notes kept
-        assert "Backport Resolution:" in final_msg
+        assert "Conflicts Resolved:" in final_msg
+
+
+class TestDedupeDuplicateNoteBlocks:
+    """Bug: repeated AI resolution attempts duplicate the agent note block.
+
+    When the resolution loop runs the AI backend more than once for the
+    same CVE (e.g. a conflict is resolved, then a later ptest/build
+    failure triggers another AI session), the backend may append a
+    fresh ``Conflicts Resolved:`` / ``Assisted-by:`` block on top of the
+    one already present from an earlier attempt instead of updating it
+    in place, producing duplicated justification text in the final
+    commit message.
+    """
+
+    def test_dedupe_removes_earlier_duplicate_blocks(self):
+        """_dedupe_agent_notes keeps only the last note block."""
+        msg = (
+            UPSTREAM_SUBJECT + "\n\n" + UPSTREAM_BODY + "\n\n"
+            "Conflicts Resolved:\n\n"
+            "src/transport.c (1 conflict):\n"
+            "- resolution details from attempt 1\n\n"
+            "Assisted-by: kiro:claude-sonnet-5\n\n"
+            "Conflicts Resolved:\n\n"
+            "src/transport.c (1 conflict):\n"
+            "- resolution details from attempt 2\n\n"
+            "Assisted-by: kiro:claude-sonnet-5\n"
+        )
+
+        deduped = _dedupe_agent_notes(msg)
+
+        assert deduped.count("Conflicts Resolved:") == 1
+        assert deduped.count("Assisted-by:") == 1
+        assert "attempt 1" not in deduped
+        assert "attempt 2" in deduped
+        assert UPSTREAM_SUBJECT in deduped
+        assert "LIBSSH2_PACKET_MAXPAYLOAD" in deduped
+
+    def test_dedupe_noop_when_single_block(self):
+        """_dedupe_agent_notes leaves a single note block untouched."""
+        msg = (
+            UPSTREAM_SUBJECT + "\n\n" + UPSTREAM_BODY + "\n\n"
+            "Conflicts Resolved:\n\n"
+            "src/transport.c (1 conflict):\n"
+            "- resolution details\n\n"
+            "Assisted-by: kiro:claude-sonnet-5\n"
+        )
+
+        assert _dedupe_agent_notes(msg) == msg
+
+    @patch("subprocess.run")
+    @patch("cve_agent.review.run_git_stdout")
+    def test_amend_commit_dedupes_before_appending_summary(
+        self, mock_git, mock_run
+    ):
+        """End-to-end: amend_commit_with_summary strips duplicate note
+        blocks left by repeated AI resolution attempts before appending
+        the change summary."""
+        duplicated_msg = (
+            UPSTREAM_SUBJECT + "\n\n" + UPSTREAM_BODY + "\n\n"
+            "Conflicts Resolved:\n\n"
+            "libarchive/archive_read_support_format_rar5.c (1 conflict):\n"
+            "- resolution details from attempt 1\n\n"
+            "Assisted-by: kiro:claude-sonnet-5\n\n"
+            "Conflicts Resolved:\n\n"
+            "libarchive/archive_read_support_format_rar5.c (1 conflict):\n"
+            "- resolution details from attempt 2\n\n"
+            "Assisted-by: kiro:claude-sonnet-5\n"
+        )
+
+        def git_side_effect(args, cwd):
+            if '--format=%B' in args:
+                return duplicated_msg
+            if '--format=%s' in args and UPSTREAM_SHA in args:
+                return UPSTREAM_SUBJECT
+            if '--format=%b' in args and UPSTREAM_SHA in args:
+                return UPSTREAM_BODY
+            return ""
+
+        mock_git.side_effect = git_side_effect
+        mock_run.return_value = type("R", (), {"returncode": 0})()
+
+        amend_commit_with_summary(
+            Path("/ws"), UPSTREAM_SHA,
+            "Changes from upstream commit 97acf3dfda80:\n"
+            "  - libarchive/archive_read_support_format_rar5.c: adapted"
+        )
+
+        mock_run.assert_called_once()
+        final_msg = mock_run.call_args[0][0][-1]
+
+        assert final_msg.count("Conflicts Resolved:") == 1
+        assert final_msg.count("Assisted-by:") == 1
+        assert "attempt 1" not in final_msg
+        assert "attempt 2" in final_msg
+        assert "Changes from upstream commit" in final_msg

--- a/tests/agent/test_review.py
+++ b/tests/agent/test_review.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from cve_agent import AgentConfig
+from cve_agent.interdiff import InterdiffArtifacts
 from cve_agent.review import (
     _display_changes,
     _save_review_diff,
@@ -141,7 +142,7 @@ class TestSaveReviewDiff:
             result = _save_review_diff(Path("/ws"), "abc123456789")
         assert result.exists()
 
-    @patch("cve_agent.review.generate_interdiff", return_value=None)
+    @patch("cve_agent.review.generate_interdiff_artifacts", return_value=None)
     @patch("cve_agent.review.run_git_stdout", return_value="diff content")
     @patch("cve_agent.review.get_changed_files", return_value={"a.c"})
     def test_no_interdiff_section_when_unavailable(self, mock_files, mock_git,
@@ -153,13 +154,20 @@ class TestSaveReviewDiff:
         content = result.read_text()
         assert "INTERDIFF" not in content
 
-    @patch("cve_agent.review.generate_interdiff", return_value="-old\n+new\n")
+    @patch("cve_agent.review.generate_interdiff_artifacts")
     @patch("cve_agent.review.run_git_stdout", return_value="diff content")
     @patch("cve_agent.review.get_changed_files", return_value={"a.c"})
     def test_interdiff_section_appended_when_available(self, mock_files, mock_git,
                                                         mock_interdiff, tmp_path):
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
+        interdiff_dir = agent_dir / "interdiff-abc123456789"
+        mock_interdiff.return_value = InterdiffArtifacts(
+            output="-old\n+new\n",
+            command=f"interdiff {interdiff_dir}/upstream.patch {interdiff_dir}/backport.patch",
+            old_patch_path=interdiff_dir / "upstream.patch",
+            new_patch_path=interdiff_dir / "backport.patch",
+        )
         with patch("cve_agent.review.get_agent_dir", return_value=agent_dir):
             result = _save_review_diff(Path("/ws"), "abc123456789")
         content = result.read_text()
@@ -168,6 +176,14 @@ class TestSaveReviewDiff:
         # Existing sections are preserved as before
         assert "UPSTREAM COMMIT" in content
         assert "BACKPORTED DIFF" in content
+        # Reproduction command and persisted patch paths are logged
+        assert "Reproduce outside this tool" in content
+        assert str(interdiff_dir / "upstream.patch") in content
+        assert str(interdiff_dir / "backport.patch") in content
+        assert "interdiff " in content
+        # The interdiff files dir passed matches the review diff's sha
+        _, kwargs = mock_interdiff.call_args
+        assert kwargs["keep_files_dir"] == agent_dir / "interdiff-abc123456789"
 
 
 class TestDisplayChanges:

--- a/tests/agent/test_review.py
+++ b/tests/agent/test_review.py
@@ -110,12 +110,12 @@ class TestAmendCommit:
 
     @patch("subprocess.run")
     @patch("cve_agent.review.run_git_stdout",
-           return_value="Fix CVE\n\nBackport-Resolution: adapted")
+           return_value="Fix CVE\n\nConflicts Resolved:\n\na.c (1 conflict):\n- adapted")
     def test_preserves_kiro_notes(self, mock_git, mock_run):
         amend_commit_with_summary(Path("/ws"), "def456", "summary")
         mock_run.assert_called_once()
         msg = mock_run.call_args[0][0][-1]
-        assert "Backport-Resolution" in msg
+        assert "Conflicts Resolved:" in msg
         # Summary is now always appended alongside kiro notes
         assert "summary" in msg
 

--- a/tests/agent/test_review.py
+++ b/tests/agent/test_review.py
@@ -141,6 +141,34 @@ class TestSaveReviewDiff:
             result = _save_review_diff(Path("/ws"), "abc123456789")
         assert result.exists()
 
+    @patch("cve_agent.review.generate_interdiff", return_value=None)
+    @patch("cve_agent.review.run_git_stdout", return_value="diff content")
+    @patch("cve_agent.review.get_changed_files", return_value={"a.c"})
+    def test_no_interdiff_section_when_unavailable(self, mock_files, mock_git,
+                                                    mock_interdiff, tmp_path):
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        with patch("cve_agent.review.get_agent_dir", return_value=agent_dir):
+            result = _save_review_diff(Path("/ws"), "abc123456789")
+        content = result.read_text()
+        assert "INTERDIFF" not in content
+
+    @patch("cve_agent.review.generate_interdiff", return_value="-old\n+new\n")
+    @patch("cve_agent.review.run_git_stdout", return_value="diff content")
+    @patch("cve_agent.review.get_changed_files", return_value={"a.c"})
+    def test_interdiff_section_appended_when_available(self, mock_files, mock_git,
+                                                        mock_interdiff, tmp_path):
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        with patch("cve_agent.review.get_agent_dir", return_value=agent_dir):
+            result = _save_review_diff(Path("/ws"), "abc123456789")
+        content = result.read_text()
+        assert "INTERDIFF (upstream" in content
+        assert "-old\n+new\n" in content
+        # Existing sections are preserved as before
+        assert "UPSTREAM COMMIT" in content
+        assert "BACKPORTED DIFF" in content
+
 
 class TestDisplayChanges:
     @patch("cve_agent.review.get_agent_dir")
@@ -168,3 +196,30 @@ class TestDisplayChanges:
         log = tmp_path / "busybox-CVE-2025-0001-ai-changes.log"
         log.write_text("AI did things")
         _display_changes(tmp_path / "busybox", "abc123", "summary", "CVE-2025-0001")
+
+    @patch("cve_agent.review.generate_interdiff", return_value="-old\n+new\n")
+    @patch("cve_agent.review.run_git_stdout", return_value="upstream diff text")
+    @patch("cve_agent.review.get_agent_dir")
+    @patch("cve_agent.review.run_git_display")
+    @patch("cve_agent.review.get_changed_files")
+    def test_display_prints_interdiff_when_available(
+            self, mock_files, mock_display, mock_dir, mock_git, mock_interdiff, tmp_path, capsys):
+        mock_files.return_value = {"a.c"}
+        mock_dir.return_value = tmp_path
+        _display_changes(Path("/ws"), "abc123", "summary", "CVE-2025-0001")
+        out = capsys.readouterr().out
+        assert "Interdiff (upstream" in out
+        assert "-old\n+new\n" in out
+
+    @patch("cve_agent.review.generate_interdiff", return_value=None)
+    @patch("cve_agent.review.run_git_stdout", return_value="upstream diff text")
+    @patch("cve_agent.review.get_agent_dir")
+    @patch("cve_agent.review.run_git_display")
+    @patch("cve_agent.review.get_changed_files")
+    def test_display_notes_when_interdiff_unavailable(
+            self, mock_files, mock_display, mock_dir, mock_git, mock_interdiff, tmp_path, capsys):
+        mock_files.return_value = {"a.c"}
+        mock_dir.return_value = tmp_path
+        _display_changes(Path("/ws"), "abc123", "summary", "CVE-2025-0001")
+        out = capsys.readouterr().out
+        assert "interdiff unavailable" in out

--- a/tests/agent/test_review_comprehensive.py
+++ b/tests/agent/test_review_comprehensive.py
@@ -13,31 +13,11 @@ from cve_agent.review import (
 class TestAmendSkipsKiroNotes:
     @patch('subprocess.run')
     @patch('cve_agent.review.run_git_stdout',
-           return_value='Fix CVE\n\nBackport-Resolution: adapted')
-    def test_skips_backport_resolution(self, mock_git, mock_run):
+           return_value='Fix CVE\n\nConflicts Resolved:\n\na.c (1 conflict):\n- adapted')
+    def test_skips_conflicts_resolved(self, mock_git, mock_run):
         amend_commit_with_summary(Path('/ws'), 'def456', 'summary')
         msg = mock_run.call_args[0][0][-1]
-        assert 'Backport-Resolution' in msg
-        # Summary is now appended alongside kiro notes
-        assert 'summary' in msg
-
-    @patch('subprocess.run')
-    @patch('cve_agent.review.run_git_stdout',
-           return_value='Fix CVE\n\nBackport changes: adapted code')
-    def test_skips_backport_changes(self, mock_git, mock_run):
-        amend_commit_with_summary(Path('/ws'), 'def456', 'summary')
-        msg = mock_run.call_args[0][0][-1]
-        assert 'Backport changes' in msg
-        # Summary is now appended alongside kiro notes
-        assert 'summary' in msg
-
-    @patch('subprocess.run')
-    @patch('cve_agent.review.run_git_stdout',
-           return_value='Fix CVE\n\nConflict resolution notes: adapted')
-    def test_skips_conflict_resolution_notes(self, mock_git, mock_run):
-        amend_commit_with_summary(Path('/ws'), 'def456', 'summary')
-        msg = mock_run.call_args[0][0][-1]
-        assert 'Conflict resolution notes' in msg
+        assert 'Conflicts Resolved:' in msg
         # Summary is now appended alongside kiro notes
         assert 'summary' in msg
 

--- a/tests/agent/test_security.py
+++ b/tests/agent/test_security.py
@@ -93,7 +93,58 @@ class TestAgentConfig:
         config_path = _KIRO_CONFIG
         config = json.loads(config_path.read_text())
         assert config['tools'] == ['fs_read', 'fs_write', 'execute_bash']
-        assert config['allowedTools'] == ['fs_read', 'fs_write', 'execute_bash']
+        # execute_bash is deliberately excluded from allowedTools so that
+        # toolsSettings.execute_bash.allowedCommands (a lower-priority rule)
+        # actually gates bash commands instead of being shadowed by blanket
+        # tool-level trust.
+        assert config['allowedTools'] == ['fs_read', 'fs_write']
+        assert config['toolsSettings']['execute_bash']['denyByDefault'] is True
+
+    @pytest.mark.skipif(not _KIRO_CONFIG.exists(),
+                        reason="kiro agent config not installed")
+    def test_prerequisite_cherry_pick_allowed(self):
+        """The agent must be able to start a fresh cherry-pick of an in-scope
+        prerequisite (Strategy A), but the rule must not permit command
+        chaining. The pre-commit scope hook remains the hard boundary for
+        what actually gets committed."""
+        import re
+        config = json.loads(_KIRO_CONFIG.read_text())
+        allowed = config['toolsSettings']['execute_bash']['allowedCommands']
+
+        def permitted(cmd):
+            return any(re.fullmatch(pat, cmd) for pat in allowed)
+
+        # Fresh cherry-picks (with/without -x, refs, multiple SHAs) are allowed.
+        assert permitted("git cherry-pick -x deadbeefcafe1234")
+        assert permitted("git cherry-pick abc1234")
+        assert permitted("git cherry-pick -x --no-edit abc1234 def5678")
+        # Chaining / injection via the cherry-pick rule is rejected.
+        assert not permitted("git cherry-pick abc1234 && rm -rf /")
+        assert not permitted("git cherry-pick abc1234; rm -rf /")
+        assert not permitted("git cherry-pick abc1234 | tee x")
+
+    @pytest.mark.skipif(not _KIRO_CONFIG.exists(),
+                        reason="kiro agent config not installed")
+    def test_build_verify_command_is_single_line(self):
+        """The build-verify command must be run as ONE line. The recommended
+        single-line form is allowed; a multi-line (build + echo on separate
+        lines) submission is rejected — regression guard for the
+        `devtool build ... \\n echo "Exit code: $?"` rejection."""
+        import re
+        config = json.loads(_KIRO_CONFIG.read_text())
+        allowed = config['toolsSettings']['execute_bash']['allowedCommands']
+
+        def permitted(cmd):
+            return any(re.fullmatch(pat, cmd) for pat in allowed)
+
+        assert permitted("devtool build libarchive")
+        assert permitted(
+            'devtool build libarchive > /ws/cve_agent/libarchive/build.log '
+            '2>&1; echo "Exit code: $?"')
+        # A two-line submission matches nothing (the newline breaks it).
+        assert not permitted(
+            'devtool build libarchive > /ws/build.log 2>&1\n'
+            'echo "Exit code: $?"')
 
     @pytest.mark.skipif(not _KIRO_CONFIG.exists(),
                         reason="kiro agent config not installed")
@@ -112,8 +163,12 @@ class TestAgentConfig:
 
 class TestTrustToolsInNonInteractiveMode:
     @patch('subprocess.run')
-    def test_non_interactive_trusts_only_allowed_tools(self, mock_run):
-        """Non-interactive mode trusts only fs_read, fs_write, execute_bash."""
+    def test_non_interactive_does_not_pass_trust_flags(self, mock_run):
+        """Non-interactive mode passes no --trust-tools/--trust-all-tools —
+        permissions live entirely in the agent config JSON (allowedTools +
+        toolsSettings.execute_bash.allowedCommands), so execute_bash relies
+        on that allowlist instead of blanket tool trust (which would
+        shadow it)."""
         mock_run.return_value = MagicMock(returncode=0, stdout='')
         with patch('cve_agent.git.build_git_env', return_value={'PATH': '/usr/bin'}):
             _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=False)
@@ -122,7 +177,7 @@ class TestTrustToolsInNonInteractiveMode:
         cmd_str = ' '.join(cmd)
         assert '--agent' in cmd_str
         assert 'yocto-cve-backport' in cmd_str
-        assert '--trust-tools=fs_read,fs_write,execute_bash' in cmd_str
+        assert '--trust-tools' not in cmd_str
         assert '--trust-all-tools' not in cmd_str
 
     @patch('subprocess.run')

--- a/tests/agent/test_session_full.py
+++ b/tests/agent/test_session_full.py
@@ -109,9 +109,9 @@ class TestSplitDiffByFile:
 
 class TestGetBackportNote:
     @patch("cve_agent.session.run_git_stdout",
-           return_value="Fix CVE\n\nBackport-Resolution: adapted code")
+           return_value="Fix CVE\n\nConflicts Resolved:\n\na.c (1 conflict):\n- adapted code")
     def test_finds_note(self, _):
-        assert "Backport-Resolution" in _get_backport_note(Path("/ws"))
+        assert "adapted code" in _get_backport_note(Path("/ws"))
 
     @patch("cve_agent.session.run_git_stdout", return_value="Fix CVE\n\nSigned-off-by: x")
     def test_no_note(self, _):

--- a/tests/agent/test_setup.py
+++ b/tests/agent/test_setup.py
@@ -128,6 +128,42 @@ def test_ensure_agents_reinstalls_stale_prompt_path(fake_dirs, tmp_path, monkeyp
         assert str(stale_prompt) not in data['prompt']
 
 
+def test_ensure_agents_refreshes_present_agents(fake_dirs, monkeypatch):
+    """ensure_agents() overwrites already-installed agents from the packaged
+    source every run, so config changes (e.g. new allowedCommands) propagate
+    without a manual reinstall. Regression guard for stale installed configs."""
+    source, target = fake_dirs
+    # The prompt path must resolve for the pre-installed agents to count as
+    # "present" (not stale), so create the stable instructions file first.
+    setup.STABLE_AGENT_INSTRUCTIONS.parent.mkdir(parents=True, exist_ok=True)
+    setup.STABLE_AGENT_INSTRUCTIONS.write_text("instructions")
+    # Pre-install both agents with a STALE body (missing a command the source
+    # grants) but a VALID prompt path, so get_missing_agents() sees them as
+    # present and would otherwise skip reinstalling them.
+    for name in REQUIRED_AGENTS:
+        (target / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://{setup.STABLE_AGENT_INSTRUCTIONS}",'
+            f' "toolsSettings": {{"execute_bash": {{"allowedCommands": ["^git status$"]}}}}}}')
+    # The packaged source grants an extra command the stale copy lacks.
+    for name in REQUIRED_AGENTS:
+        (source / f"{name}.json").write_text(
+            f'{{"name": "{name}", "prompt": "file://cve_agent/AGENT_INSTRUCTIONS.md",'
+            f' "toolsSettings": {{"execute_bash": {{"allowedCommands":'
+            f' ["^git status$", "^git cherry-pick [^;&|]+$"]}}}}}}')
+
+    monkeypatch.setattr("cve_agent.setup.check_kiro_cli", lambda: True)
+    assert verify_agents_installed() is True  # present → skipped before this change
+
+    ensure_agents(interactive=False)
+
+    for name in REQUIRED_AGENTS:
+        data = json.loads((target / f"{name}.json").read_text())
+        cmds = data['toolsSettings']['execute_bash']['allowedCommands']
+        assert "^git cherry-pick [^;&|]+$" in cmds, \
+            "installed agent config was not refreshed from the packaged source"
+        assert data['prompt'] == f"file://{setup.STABLE_AGENT_INSTRUCTIONS}"
+
+
 def test_verify_agents_installed_false(fake_dirs):
     assert verify_agents_installed() is False
 
@@ -199,7 +235,20 @@ def test_sync_agent_instructions_copies_to_stable_path(fake_dirs):
     result = sync_agent_instructions()
     assert result == setup.STABLE_AGENT_INSTRUCTIONS
     assert setup.STABLE_AGENT_INSTRUCTIONS.is_file()
-    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text().endswith("instructions")
+
+
+def test_sync_agent_instructions_prepends_kiro_tool_preamble(fake_dirs):
+    """The stable copy consumed by kiro-cli's static file:// prompt must
+    carry kiro's tool-name mapping, since AGENT_INSTRUCTIONS.md itself is
+    shared verbatim across backends and stays tool-name-neutral."""
+    from cve_agent.kiro_backend import KiroBackend
+
+    sync_agent_instructions()
+
+    content = setup.STABLE_AGENT_INSTRUCTIONS.read_text()
+    assert content.startswith(KiroBackend().tool_preamble())
+    assert content.endswith("instructions")
 
 
 def test_sync_agent_instructions_overwrites_existing_stable_copy(fake_dirs):
@@ -208,19 +257,20 @@ def test_sync_agent_instructions_overwrites_existing_stable_copy(fake_dirs):
 
     sync_agent_instructions()
 
-    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text().endswith("instructions")
+    assert "old content" not in setup.STABLE_AGENT_INSTRUCTIONS.read_text()
 
 
 def test_sync_agent_instructions_propagates_content_upgrades(fake_dirs):
     """A newer packaged AGENT_INSTRUCTIONS.md must overwrite the stable copy
     on re-sync, so content upgrades reach the kiro agent's prompt."""
     sync_agent_instructions()
-    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text().endswith("instructions")
 
     setup.PACKAGED_AGENT_INSTRUCTIONS.write_text("updated instructions v2")
     sync_agent_instructions()
 
-    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "updated instructions v2"
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text().endswith("updated instructions v2")
 
 
 def test_sync_agent_instructions_missing_packaged_file_raises(fake_dirs):
@@ -264,7 +314,8 @@ def test_ensure_agents_syncs_instructions_even_when_already_installed(fake_dirs,
 
     ensure_agents(interactive=False)
 
-    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text() == "instructions"
+    assert setup.STABLE_AGENT_INSTRUCTIONS.read_text().endswith("instructions")
+    assert "stale content" not in setup.STABLE_AGENT_INSTRUCTIONS.read_text()
 
 
 def test_ensure_agents_exits_when_packaged_instructions_missing(fake_dirs, monkeypatch):

--- a/tests/corrector/test_patch.py
+++ b/tests/corrector/test_patch.py
@@ -140,3 +140,137 @@ def test_no_patches_when_all_from_other_recipes(mock_modify, mock_capture, mock_
 
     update_patches_with_metadata(state)
     mock_modify.assert_not_called()
+
+
+# --- Tests for prerequisite-aware CVE tagging ---
+
+from cve_corrector.patch_ops import (
+    _cherry_picked_sha,
+    _compute_cve_tag_flags,
+    _extract_patch_subject,
+    _normalize_subject,
+)
+
+_FIX_PATCH = """\
+From aaa111 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] net: fix use-after-free in foo()
+
+The real CVE fix.
+---
+ net/foo.c | 2 +-
+"""
+
+_PREREQ_PATCH = """\
+From bbb222 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] net: add foo_helper() infrastructure
+
+Prerequisite introducing the helper the fix calls.
+
+(cherry picked from commit deadbeefcafe1234)
+---
+ net/foo.c | 8 ++++++++
+"""
+
+
+def test_modify_patch_prerequisite_omits_cve_tag(tmp_path):
+    """A prerequisite patch gets Upstream-Status but NOT a CVE tag."""
+    p = tmp_path / "prereq.patch"
+    p.write_text(_PREREQ_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/bbb",
+                     include_cve_tag=False)
+    content = p.read_text()
+    assert "CVE: CVE-2025-0001" not in content
+    assert "Upstream-Status: Backport [https://example.com/commit/bbb]" in content
+    assert "Signed-off-by: Test User <test@example.com>" in content
+
+
+def test_modify_patch_prerequisite_idempotent(tmp_path):
+    """Re-running on a prerequisite (already has Upstream-Status) is a no-op."""
+    p = tmp_path / "prereq.patch"
+    p.write_text(_PREREQ_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/bbb",
+                     include_cve_tag=False)
+        first = p.read_text()
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/bbb",
+                     include_cve_tag=False)
+        second = p.read_text()
+    assert first == second
+    assert "CVE: CVE-2025-0001" not in second
+
+
+def test_extract_patch_subject_strips_patch_prefix():
+    assert _extract_patch_subject(_FIX_PATCH) == "net: fix use-after-free in foo()"
+
+
+def test_normalize_subject_collapses_whitespace_and_case():
+    assert _normalize_subject("Net:  Fix   FOO") == "net: fix foo"
+
+
+def test_cherry_picked_sha_extracts_origin():
+    assert _cherry_picked_sha(_PREREQ_PATCH) == "deadbeefcafe1234"
+    assert _cherry_picked_sha(_FIX_PATCH) is None
+
+
+def _write_patches(meta_layer, names_and_text):
+    rels = []
+    for name, text in names_and_text:
+        path = meta_layer / name
+        path.write_text(text)
+        rels.append(name)
+    return rels
+
+
+def test_compute_flags_series_state_tags_all(tmp_path):
+    """Known PR series keep the existing all-CVE tagging (unchanged)."""
+    state = _make_state(tmp_path)
+    state.series_state = {"commits": ["a", "b"]}
+    rels = _write_patches(state.meta_layer,
+                          [("0001.patch", _FIX_PATCH), ("0002.patch", _PREREQ_PATCH)])
+    assert _compute_cve_tag_flags(state, rels) == [True, True]
+
+
+def test_compute_flags_single_patch_tags_all(tmp_path):
+    """A lone patch is always the fix — tagged with CVE."""
+    state = _make_state(tmp_path)
+    rels = _write_patches(state.meta_layer, [("0001.patch", _FIX_PATCH)])
+    assert _compute_cve_tag_flags(state, rels) == [True]
+
+
+def test_compute_flags_prerequisite_only_fix_tagged(tmp_path):
+    """Agent-added prerequisite (no series, >1 patch): only the fix patch
+    whose subject matches the fix commit gets the CVE tag."""
+    state = _make_state(tmp_path)
+    rels = _write_patches(state.meta_layer,
+                          [("0001-prereq.patch", _PREREQ_PATCH),
+                           ("0002-fix.patch", _FIX_PATCH)])
+    with mock_patch("cve_corrector.patch_ops._git_commit_subject",
+                    return_value="net: fix use-after-free in foo()"):
+        flags = _compute_cve_tag_flags(state, rels)
+    assert flags == [False, True]
+
+
+def test_compute_flags_no_subject_match_falls_back_to_all(tmp_path):
+    """If the fix subject matches no patch, fall back to tagging all so the
+    fix never silently loses its CVE tag."""
+    state = _make_state(tmp_path)
+    rels = _write_patches(state.meta_layer,
+                          [("0001.patch", _PREREQ_PATCH), ("0002.patch", _FIX_PATCH)])
+    with mock_patch("cve_corrector.patch_ops._git_commit_subject",
+                    return_value="totally different subject not in any patch"):
+        flags = _compute_cve_tag_flags(state, rels)
+    assert flags == [True, True]
+
+
+def test_compute_flags_unknown_fix_subject_falls_back_to_all(tmp_path):
+    """If the fix commit subject can't be resolved, tag all patches."""
+    state = _make_state(tmp_path)
+    rels = _write_patches(state.meta_layer,
+                          [("0001.patch", _PREREQ_PATCH), ("0002.patch", _FIX_PATCH)])
+    with mock_patch("cve_corrector.patch_ops._git_commit_subject",
+                    return_value=None):
+        flags = _compute_cve_tag_flags(state, rels)
+    assert flags == [True, True]


### PR DESCRIPTION
  Description:
  
  Summary
  
  A collection of improvements to cve-agent focused on three themes: more robust backend invocation,
  better visibility into backport adaptations via interdiff, and safer handling of edge cases.
  
  Changes
  
  Interdiff review support
  
  - Add optional interdiff review comparing upstream fix vs backport adaptation (interdiff/patchutils
   integration)
  - Record interdiff reproduction artifacts in the review diff for traceability
  - Deduplicate repeated backport-note blocks and standardize their format
  
  Backend invocation hardening
  
  - Generalize non-interactive backend invocation to be more robust across backends
  - Set claude-sonnet-5 as the default model
  - Add -i short flag for --interactive
  
  Backport safety
  
  - Escalate applicable-but-unsafe backports to human review instead of silently proceeding
  - Omit CVE tag on prerequisite patches in the corrector (fixes incorrect CVE attribution)
  
  Testing
  
  - Existing test suite passes (pytest --cov)
  - Lint and type checks clean (ruff check ., mypy)
