### PR TITLE
extractor: checkpoint completed results to survive interruption

### DIFF
--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -61,6 +61,7 @@ Input (one required):
 
 Options:
   --output FILE           Output path (default: stdout)
+  --checkpoint-interval S Periodic save interval; 0 disables (default: 60)
   --cve-component-name N  Override component name deduction
   --check-oe-status       Check if already fixed in OE branches
   --no-debian / --no-osv / --no-cvelistv5 / --no-ubuntu

--- a/cve_metadata_extractor/__main__.py
+++ b/cve_metadata_extractor/__main__.py
@@ -8,8 +8,12 @@ Run with: python3 -m cve_metadata_extractor [options]
 import argparse
 import json
 import logging
+import math
 import os
+import secrets
+import stat
 import sys
+import time
 
 # Import source modules so they register themselves in SOURCE_REGISTRY.
 from . import cve_sources as _cve_sources
@@ -29,6 +33,19 @@ def _get_version() -> str:
         return version('yocto-security-tools')
     except PackageNotFoundError:
         return 'dev'
+
+
+def _non_negative_float(value):
+    '''Parse a non-negative floating-point CLI value.'''
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f'invalid floating-point value: {value}') from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(
+            'value must be a finite non-negative number')
+    return parsed
 
 
 def parse_arguments(cfg):
@@ -67,6 +84,10 @@ def parse_arguments(cfg):
                        help='Download .patch files and extract Debian source patches')
     output_group.add_argument('--reprocess-missing-series', action='store_true',
                        help='Re-fetch PR/issue data for CVEs that lack series in existing output')
+    output_group.add_argument('--checkpoint-interval',
+                       type=_non_negative_float, default=60.0,
+                       help='Seconds between periodic result checkpoints; '
+                            '0 disables periodic saves (default: %(default)s)')
 
     # --- OE integration ---
     oe_group = parser.add_argument_group('OpenEmbedded integration')
@@ -312,6 +333,47 @@ def _merge_results(existing, new):
     return merged
 
 
+def _save_results(results, output):
+    '''Atomically save extraction results.
+
+    The temporary file is created next to the destination so ``os.replace``
+    remains atomic. A failed or interrupted write therefore leaves the
+    previous valid output untouched.
+    '''
+    output_path = os.path.abspath(output)
+    temp_output = None
+    temp_fd = None
+    try:
+        for _ in range(10):
+            token = secrets.token_hex(8)
+            temp_output = os.path.join(
+                os.path.dirname(output_path),
+                f'.{os.path.basename(output_path)}.{token}.tmp')
+            try:
+                temp_fd = os.open(
+                    temp_output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+                break
+            except FileExistsError:
+                continue
+        if temp_fd is None:
+            raise FileExistsError("Could not create unique temporary output")
+        assert temp_output is not None
+        if os.path.exists(output_path):
+            mode = stat.S_IMODE(os.stat(output_path).st_mode)
+            os.fchmod(temp_fd, mode)
+        with os.fdopen(temp_fd, 'w', encoding='utf-8') as f:
+            temp_fd = None
+            json.dump(results, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_output, output_path)
+    finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
+        if temp_output and os.path.exists(temp_output):
+            os.unlink(temp_output)
+
+
 def main():
     '''Main function.'''
     cfg = load_config()
@@ -377,42 +439,53 @@ def main():
     results = dict(existing_results)
     skipped = 0
     reprocessed = 0
-    for idx, cve in enumerate(known_affected, 1):
-        cve_id = cve['id']
-        if cve_id in existing_results:
-            if args.reprocess_missing_series and not existing_results[cve_id].get('series'):
-                # Invalidate cached PR/issue URLs so they get re-fetched
-                for ref in existing_results[cve_id].get('references', []):
-                    PR_CACHE.pop(ref['url'], None)
-                reprocessed += 1
-            else:
-                _accumulate_stats(existing_results[cve_id], stats)
-                skipped += 1
-                continue
-        result = process_cve(
-            cve, idx, len(known_affected), args,
-            active_sources, stats, oe_token)
-        if result:
+    last_checkpoint = time.monotonic()
+    try:
+        for idx, cve in enumerate(known_affected, 1):
+            cve_id = cve['id']
             if cve_id in existing_results:
-                result = _merge_results(existing_results[cve_id], result)
-                # Count stats for inactive sources preserved from existing data
-                active_names = {s.name for s in active_sources}
-                inactive = (
-                    set(_iter_sources(existing_results[cve_id].get('hash_details', [])))
-                    | set(_iter_sources(existing_results[cve_id].get('patch_details', [])))
-                ) - active_names
-                _accumulate_stats(existing_results[cve_id], stats,
-                                  only_sources=inactive)
-            results[cve_id] = result
+                if (args.reprocess_missing_series
+                        and not existing_results[cve_id].get('series')):
+                    # Invalidate cached PR/issue URLs so they get re-fetched
+                    for ref in existing_results[cve_id].get('references', []):
+                        PR_CACHE.pop(ref['url'], None)
+                    reprocessed += 1
+                else:
+                    _accumulate_stats(existing_results[cve_id], stats)
+                    skipped += 1
+                    continue
+            result = process_cve(
+                cve, idx, len(known_affected), args,
+                active_sources, stats, oe_token)
+            if result:
+                if cve_id in existing_results:
+                    result = _merge_results(existing_results[cve_id], result)
+                    # Count stats for inactive sources preserved from existing data
+                    active_names = {s.name for s in active_sources}
+                    inactive = (
+                        set(_iter_sources(
+                            existing_results[cve_id].get('hash_details', [])))
+                        | set(_iter_sources(
+                            existing_results[cve_id].get('patch_details', [])))
+                    ) - active_names
+                    _accumulate_stats(existing_results[cve_id], stats,
+                                      only_sources=inactive)
+                results[cve_id] = result
+                if args.checkpoint_interval > 0:
+                    now = time.monotonic()
+                    if now - last_checkpoint >= args.checkpoint_interval:
+                        _save_results(results, args.output)
+                        last_checkpoint = time.monotonic()
+        print(f"\nSaving results to {args.output}...")
+    finally:
+        # Preserve completed work on Ctrl-C or a source failure without
+        # repeatedly rewriting a potentially large image result.
+        _save_results(results, args.output)
 
     if skipped:
         print(f"\nSkipped {skipped} already-processed CVEs")
     if reprocessed:
         print(f"Reprocessed {reprocessed} CVEs missing series data")
-
-    print(f"\nSaving results to {args.output}...")
-    with open(args.output, 'w', encoding='utf-8') as f:
-        json.dump(results, f, indent=2)
 
     _print_summary(results, stats, args)
 

--- a/tests/extractor/test_main_and_processing.py
+++ b/tests/extractor/test_main_and_processing.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for cve_metadata_extractor CLI, processing, and cve_sources."""
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -64,6 +65,29 @@ class TestParseArguments:
             with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
                 args = parse_arguments(cfg)
         assert args.check_oe is True
+
+    def test_checkpoint_interval(self):
+        from cve_metadata_extractor.__main__ import parse_arguments
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        with patch('sys.argv', [
+                'prog', '--cve-id', 'CVE-1',
+                '--checkpoint-interval', '0']):
+            with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
+                args = parse_arguments(cfg)
+        assert args.checkpoint_interval == 0
+
+    @pytest.mark.parametrize('value', ['-1', 'nan', 'inf'])
+    def test_checkpoint_interval_rejects_invalid_value(self, value):
+        from cve_metadata_extractor.__main__ import parse_arguments
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        with patch('sys.argv', [
+                'prog', '--cve-id', 'CVE-1',
+                '--checkpoint-interval', value]):
+            with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
+                with pytest.raises(SystemExit):
+                    parse_arguments(cfg)
 
 
 class TestCfgKeyForFlag:
@@ -144,6 +168,174 @@ class TestMain:
         main()
         data = json.loads(out_file.read_text())
         assert 'CVE-2025-0001' in data
+
+    @patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [])
+    @patch('cve_metadata_extractor.__main__.load_pr_cache')
+    @patch('cve_metadata_extractor.cve_sources.load_cves_from_sources')
+    @patch('cve_metadata_extractor.__main__.process_cve')
+    def test_checkpoints_completed_cves_on_interrupt(
+            self, mock_process, mock_load, mock_pr, tmp_path, monkeypatch):
+        mock_load.return_value = [
+            {'id': 'CVE-2025-0001', 'name': 'foo'},
+            {'id': 'CVE-2025-0002', 'name': 'bar'},
+        ]
+        first_result = {
+            'name': 'foo', 'hashes': ['abc123'], 'hash_details': [],
+            'patches': [], 'patch_details': [], 'references': [],
+            'version': '1.0', 'cvss3_score': None,
+        }
+        mock_process.side_effect = [first_result, KeyboardInterrupt]
+        out_file = tmp_path / 'out.json'
+        monkeypatch.setattr('sys.argv', [
+            'prog', '--cve-id', 'CVE-2025-0001', 'CVE-2025-0002',
+            '--output', str(out_file)])
+
+        from cve_metadata_extractor.__main__ import main
+        with pytest.raises(KeyboardInterrupt):
+            main()
+
+        assert json.loads(out_file.read_text()) == {
+            'CVE-2025-0001': first_result,
+        }
+
+    @patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [])
+    @patch('cve_metadata_extractor.__main__.load_pr_cache')
+    @patch('cve_metadata_extractor.cve_sources.load_cves_from_sources')
+    @patch('cve_metadata_extractor.__main__.process_cve')
+    @patch('cve_metadata_extractor.__main__._save_results')
+    def test_periodic_checkpoint_after_interval(
+            self, mock_save, mock_process, mock_load, mock_pr,
+            tmp_path, monkeypatch):
+        mock_load.return_value = [
+            {'id': 'CVE-2025-0001', 'name': 'foo'},
+            {'id': 'CVE-2025-0002', 'name': 'bar'},
+        ]
+        mock_process.side_effect = [
+            {'name': 'foo', 'hashes': [], 'hash_details': [],
+             'patches': [], 'patch_details': [], 'references': []},
+            {'name': 'bar', 'hashes': [], 'hash_details': [],
+             'patches': [], 'patch_details': [], 'references': []},
+        ]
+        monkeypatch.setattr('sys.argv', [
+            'prog', '--cve-id', 'CVE-2025-0001', 'CVE-2025-0002',
+            '--output', str(tmp_path / 'out.json'),
+            '--checkpoint-interval', '60'])
+
+        from cve_metadata_extractor.__main__ import main
+        with patch('cve_metadata_extractor.__main__.time.monotonic',
+                   side_effect=[100, 159, 160, 161]):
+            main()
+
+        assert mock_save.call_count == 2
+        assert set(mock_save.call_args_list[0].args[0]) == {
+            'CVE-2025-0001', 'CVE-2025-0002',
+        }
+
+    @patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [])
+    @patch('cve_metadata_extractor.__main__.load_pr_cache')
+    @patch('cve_metadata_extractor.cve_sources.load_cves_from_sources')
+    @patch('cve_metadata_extractor.__main__.process_cve')
+    @patch('cve_metadata_extractor.__main__._save_results')
+    def test_periodic_checkpoint_throttled_before_interval(
+            self, mock_save, mock_process, mock_load, mock_pr,
+            tmp_path, monkeypatch):
+        mock_load.return_value = [{'id': 'CVE-2025-0001', 'name': 'foo'}]
+        mock_process.return_value = {
+            'name': 'foo', 'hashes': [], 'hash_details': [],
+            'patches': [], 'patch_details': [], 'references': [],
+        }
+        monkeypatch.setattr('sys.argv', [
+            'prog', '--cve-id', 'CVE-2025-0001',
+            '--output', str(tmp_path / 'out.json'),
+            '--checkpoint-interval', '60'])
+
+        from cve_metadata_extractor.__main__ import main
+        with patch('cve_metadata_extractor.__main__.time.monotonic',
+                   side_effect=[100, 159]):
+            main()
+
+        assert mock_save.call_count == 1
+
+    @patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', [])
+    @patch('cve_metadata_extractor.__main__.load_pr_cache')
+    @patch('cve_metadata_extractor.cve_sources.load_cves_from_sources')
+    @patch('cve_metadata_extractor.__main__.process_cve')
+    @patch('cve_metadata_extractor.__main__._save_results')
+    def test_zero_interval_disables_periodic_but_saves_on_interrupt(
+            self, mock_save, mock_process, mock_load, mock_pr,
+            tmp_path, monkeypatch):
+        mock_load.return_value = [
+            {'id': 'CVE-2025-0001', 'name': 'foo'},
+            {'id': 'CVE-2025-0002', 'name': 'bar'},
+        ]
+        first_result = {
+            'name': 'foo', 'hashes': [], 'hash_details': [],
+            'patches': [], 'patch_details': [], 'references': [],
+        }
+        mock_process.side_effect = [first_result, KeyboardInterrupt]
+        monkeypatch.setattr('sys.argv', [
+            'prog', '--cve-id', 'CVE-2025-0001', 'CVE-2025-0002',
+            '--output', str(tmp_path / 'out.json'),
+            '--checkpoint-interval', '0'])
+
+        from cve_metadata_extractor.__main__ import main
+        with pytest.raises(KeyboardInterrupt):
+            main()
+
+        mock_save.assert_called_once()
+        assert mock_save.call_args.args[0] == {
+            'CVE-2025-0001': first_result,
+        }
+
+
+class TestSaveResults:
+    def test_new_output_respects_umask(self, tmp_path):
+        from cve_metadata_extractor.__main__ import _save_results
+        out_file = tmp_path / 'out.json'
+
+        old_umask = os.umask(0o022)
+        try:
+            _save_results({'CVE-NEW': {'hashes': []}}, str(out_file))
+        finally:
+            os.umask(old_umask)
+
+        assert out_file.stat().st_mode & 0o777 == 0o644
+
+    def test_existing_output_preserves_mode(self, tmp_path):
+        from cve_metadata_extractor.__main__ import _save_results
+        out_file = tmp_path / 'out.json'
+        out_file.write_text('{}')
+        out_file.chmod(0o640)
+
+        _save_results({'CVE-NEW': {'hashes': []}}, str(out_file))
+
+        assert out_file.stat().st_mode & 0o777 == 0o640
+
+    def test_failed_write_preserves_existing_output(self, tmp_path):
+        from cve_metadata_extractor.__main__ import _save_results
+        out_file = tmp_path / 'out.json'
+        original = {'CVE-OLD': {'hashes': []}}
+        out_file.write_text(json.dumps(original))
+
+        with pytest.raises(TypeError):
+            _save_results({'not-json': {object()}}, str(out_file))
+
+        assert json.loads(out_file.read_text()) == original
+        assert not list(tmp_path.glob('*.tmp'))
+
+    def test_interrupted_write_preserves_existing_output(self, tmp_path):
+        from cve_metadata_extractor.__main__ import _save_results
+        out_file = tmp_path / 'out.json'
+        original = {'CVE-OLD': {'hashes': []}}
+        out_file.write_text(json.dumps(original))
+
+        with patch('cve_metadata_extractor.__main__.json.dump',
+                   side_effect=KeyboardInterrupt):
+            with pytest.raises(KeyboardInterrupt):
+                _save_results({'CVE-NEW': {'hashes': []}}, str(out_file))
+
+        assert json.loads(out_file.read_text()) == original
+        assert not list(tmp_path.glob('*.tmp'))
 
 
 class TestProcessCve:


### PR DESCRIPTION
## Problem

`cve-metadata-extractor` writes its output only once, after the entire CVE loop
finishes, with a plain `open(args.output, 'w')`. This has two failure modes:

1. **Interruption loses everything.** A long run over thousands of CVEs that is
   interrupted (Ctrl-C, or a scheduler/OOM/SSH-drop on an unattended run) discards
   every already-processed CVE — nothing is on disk until the very end.
2. **A crash mid-write corrupts the previous output.** `open(..., 'w')` truncates
   immediately, so a failure during `json.dump` (disk full, kill) leaves the prior
   valid result file truncated/unreadable.

## Fix

Make result persistence durable:

- **Atomic writes** — write to a unique temp file in the destination directory,
  `fsync`, then `os.replace()`. A failed or interrupted write leaves the previous
  valid output intact. New files respect the umask; existing files keep their mode.
- **Save on exit** — a `finally` around the loop persists completed work on Ctrl-C
  (SIGINT) and on source exceptions.
- **Periodic, time-throttled checkpoints** — a new `--checkpoint-interval` option
  (seconds; default `60`, `0` disables) saves completed results during the loop.
  Throttling uses a monotonic clock and avoids rewriting a potentially large result
  after every CVE. This bounds worst-case loss to roughly one interval even for
  failures that bypass `finally` entirely (SIGKILL, SIGTERM, OOM, power loss).

## Behavior, before vs after (interrupted at CVE 10/21 on a real summary)

| Failure | Before | After |
|---|---|---|
| Ctrl-C (SIGINT) | output never written — all completed CVEs lost | completed CVEs preserved |
| unhandled source exception | all lost | completed CVEs preserved |
| crash mid-write | previous output truncated/corrupted | previous output intact (atomic) |
| SIGKILL / SIGTERM / OOM / power loss | all lost | ≤ ~one checkpoint interval lost |

## Testing

- New pytest cases reproduce the bug and verify the fix: interrupt checkpointing,
  periodic checkpoint fires after the interval, throttled before it,
  `--checkpoint-interval 0` disables periodic saves while still saving on exit,
  atomic protection when a write is interrupted, and umask/mode preservation.
- Full suite: `pytest` → all green; `ruff check .` and `mypy` clean.
- Verified end-to-end against a real `sbom-cve-check.yocto.json`: after `kill -9`
  mid-run, completed CVEs are recovered from the last checkpoint (0 recovered on the
  previous code).

## Note

A Ubuntu source timeout does not itself raise — it only slows the run, which can
prompt a manual abort. The timeout is not the cause of the data loss this change
addresses; the interruption is.
