### PR TITLE
cve_corrector: fix ptest result parsing for timed-out tests

### DIFF
--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -8,6 +8,7 @@ and writes a structured context.md file for Claude to consume.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -322,10 +323,18 @@ def _read_ptest_results(workspace_path: Path) -> str:
     ptest_log = _find_ptest_log(build_dir, recipe)
     if ptest_log:
         content = ptest_log.read_text(encoding=TEXT_ENCODING, errors=TEXT_ERRORS)
-        failing = [line for line in content.splitlines() if 'FAILED:' in line]
+        failing = [line for line in content.splitlines()
+                   if re.match(r'\s*FAIL:', line)]
+        aborted = [line for line in content.splitlines()
+                   if line.startswith('TIMEOUT:') or
+                   line.startswith('ERROR: Exited from signal')]
         if failing:
             lines.append("**Failing test cases**:\n```\n" +
                          '\n'.join(failing) + "\n```\n")
+        if aborted:
+            lines.append("**Aborted/killed test cases** (no PASS/FAIL result "
+                         "reported — likely hung or timed out):\n```\n" +
+                         '\n'.join(aborted) + "\n```\n")
 
     if len(lines) == 1:
         lines.append("(No ptest result data found in state file or logs)\n")

--- a/cve_corrector/ptest.py
+++ b/cve_corrector/ptest.py
@@ -110,22 +110,114 @@ def run_ptest(recipe: str, build_timeout: int = 7200,
             f'work/*/core-image-minimal/*/testimage/ptest_log/{recipe}'))
     if ptest_logs:
         content = sorted(ptest_logs)[-1].read_text()
-        passed = content.count('PASSED:')
-        failed = content.count('FAILED:')
-        skipped = content.count('SKIPPED:')
-        failing = [line.split('FAILED:')[1].strip()
-                   for line in content.splitlines() if 'FAILED:' in line]
-        summary = f"PASSED: {passed}, FAILED: {failed}, SKIPPED: {skipped}"
-        if failing:
-            summary += '\nFailing cases:\n' + '\n'.join(f'  {c}' for c in failing)
-        return summary
+        return summarize_ptest_log(content)
     return None
 
 
+# Per the ptest-runner result-line convention (test-manual/ptest.rst):
+# "result: testname" where result is PASS, FAIL, or SKIP. Anchored to the
+# start of the line (optional leading whitespace) so that unrelated text
+# elsewhere on the line — e.g. the aggregate "STOP: ptest-runner" /
+# "TOTAL: 1 FAIL: 2" summary lines ptest-runner prints at the end of a
+# run — is never mistaken for an individual test result.
+_RESULT_LINE_RE = re.compile(r'^\s*(PASS|FAIL|SKIP):\s*(.+)$')
+
+# A test run that never reaches a PASS/FAIL/SKIP result line because the
+# runner killed it (e.g. it hung and hit the per-test timeout) instead
+# reports a "TIMEOUT: <path>" marker line naming the ptest that was
+# killed. ptest-runner also prints "ERROR: Exited from signal Killed (9)"
+# immediately before it, but that is context/detail about *why* the test
+# was killed, not a second aborted test — counting both would double the
+# aborted tally for a single kill.
+_ABORTED_MARKER = 'TIMEOUT:'
+
+
+def summarize_ptest_log(content: str) -> str:
+    """Summarize a ptest log's PASS/FAIL/SKIP result lines.
+
+    Individual ptest result lines follow the Automake-style convention
+    documented for ptest-runner: ``result: testname`` where ``result`` is
+    one of ``PASS``, ``FAIL``, or ``SKIP``.
+
+    A test that is killed (e.g. by the per-test timeout) never emits a
+    PASS/FAIL/SKIP result line at all — it is reported via a ``TIMEOUT:
+    <path>`` marker line instead (ptest-runner also logs an "ERROR: Exited
+    from signal Killed (9)" line right before it, but that is
+    context/detail about the kill, not a second test). Such tests are
+    counted separately as "aborted" so they are not silently treated as
+    passing (zero failures) just because no FAIL: line was emitted for
+    them.
+
+    The overall run is only considered complete if it reaches
+    ``STOP: ptest-runner`` — a run that never finishes (e.g. the QEMU
+    instance crashed or the whole testimage task was itself killed before
+    ptest-runner could print its final summary) has a truncated, unreliable
+    PASS/FAIL/SKIP count and must not be reported as if it were a normal
+    clean result.
+
+    Args:
+        content: Raw ptest log content.
+
+    Returns:
+        Human-readable summary string, e.g.
+        ``"PASSED: 10, FAILED: 1, SKIPPED: 0, ABORTED: 1"``. Prefixed with
+        a warning if the run never reached ``STOP: ptest-runner``.
+    """
+    passed = 0
+    failed = 0
+    skipped = 0
+    failing: list[str] = []
+
+    for line in content.splitlines():
+        match = _RESULT_LINE_RE.match(line)
+        if not match:
+            continue
+        result, name = match.group(1), match.group(2).strip()
+        if result == 'PASS':
+            passed += 1
+        elif result == 'FAIL':
+            failed += 1
+            failing.append(name)
+        elif result == 'SKIP':
+            skipped += 1
+
+    aborted = sum(1 for line in content.splitlines() if line.startswith(_ABORTED_MARKER))
+    finished = any(line.startswith('STOP: ptest-runner') for line in content.splitlines())
+
+    summary = f"PASSED: {passed}, FAILED: {failed}, SKIPPED: {skipped}, ABORTED: {aborted}"
+    if not finished:
+        summary = (
+            "WARNING: ptest-runner did not reach STOP: ptest-runner — the "
+            "run was cut short and this summary is incomplete/unreliable.\n"
+            + summary
+        )
+    if failing:
+        summary += '\nFailing cases:\n' + '\n'.join(f'  {c}' for c in failing)
+    return summary
+
+
 def compare_ptest_results(before: str, after: str) -> bool:
-    """Compare ptest results, return True if failures did not increase."""
-    before_match = re.search(r'PASSED: (\d+), FAILED: (\d+)', before)
-    after_match = re.search(r'PASSED: (\d+), FAILED: (\d+)', after)
+    """Compare ptest results, return True if failures did not increase.
+
+    Both failed tests (``FAILED:``) and aborted/killed tests (``ABORTED:``,
+    e.g. a test that hit the per-test timeout and was never able to report
+    a result) are treated as regressions if their count increases — a test
+    that used to complete and now hangs is a regression even though it
+    never emits a FAIL: line.
+
+    If the *after* run never reached ``STOP: ptest-runner`` (flagged by the
+    ``WARNING:`` prefix ``summarize_ptest_log`` adds), its PASS/FAIL counts
+    are unreliable/incomplete and must not be trusted to declare "no
+    regression" — this is treated as a regression so it gets investigated
+    rather than silently accepted.
+    """
+    if after.startswith('WARNING:'):
+        return False
+
+    before_match = re.search(r'PASSED: (\d+), FAILED: (\d+)(?:, SKIPPED: \d+, ABORTED: (\d+))?', before)
+    after_match = re.search(r'PASSED: (\d+), FAILED: (\d+)(?:, SKIPPED: \d+, ABORTED: (\d+))?', after)
     if before_match and after_match:
-        return int(after_match.group(2)) <= int(before_match.group(2))
+        before_bad = int(before_match.group(2)) + int(before_match.group(3) or 0)
+        after_bad = int(after_match.group(2)) + int(after_match.group(3) or 0)
+        return after_bad <= before_bad
     return True

--- a/tests/agent/test_context_comprehensive.py
+++ b/tests/agent/test_context_comprehensive.py
@@ -104,11 +104,29 @@ class TestContextPtestResults:
         ws = tmp_path / 'build' / 'workspace' / 'sources' / 'busybox'
         ws.mkdir(parents=True)
         log = tmp_path / 'ptest.log'
-        log.write_text('PASS: test1\nFAILED: test2\nFAILED: test3')
+        log.write_text('PASS: test1\nFAIL: test2\nFAIL: test3')
         with patch('cve_agent.context._find_ptest_log', return_value=log):
             result = _read_ptest_results(ws)
-        assert 'FAILED: test2' in result
-        assert 'FAILED: test3' in result
+        assert 'FAIL: test2' in result
+        assert 'FAIL: test3' in result
+
+    @patch('cve_agent.context._find_state_file', return_value=None)
+    def test_ptest_log_aborted_lines(self, _, tmp_path):
+        """A ptest killed by timeout emits no PASS/FAIL line for itself —
+        it must still surface in the AI context instead of being silently
+        dropped."""
+        ws = tmp_path / 'build' / 'workspace' / 'sources' / 'jq'
+        ws.mkdir(parents=True)
+        log = tmp_path / 'ptest.log'
+        log.write_text(
+            'PASS: optionaltest\n'
+            'ERROR: Exited from signal Killed (9)\n'
+            'TIMEOUT: /usr/lib/jq/ptest\n'
+        )
+        with patch('cve_agent.context._find_ptest_log', return_value=log):
+            result = _read_ptest_results(ws)
+        assert 'Aborted/killed test cases' in result
+        assert 'TIMEOUT: /usr/lib/jq/ptest' in result
 
 
 class TestContextYoctoTmpDir:

--- a/tests/agent/test_context_full.py
+++ b/tests/agent/test_context_full.py
@@ -189,7 +189,7 @@ class TestReadPtestResults:
         ws = tmp_path / "build" / "workspace" / "sources" / "busybox"
         ws.mkdir(parents=True)
         log = tmp_path / "ptest.log"
-        log.write_text("PASS: test1\nFAILED: test2\nFAILED: test3")
+        log.write_text("PASS: test1\nFAIL: test2\nFAIL: test3")
         with patch("cve_agent.context._find_ptest_log", return_value=log):
             result = _read_ptest_results(ws)
         assert "Failing test cases" in result

--- a/tests/corrector/test_ptest.py
+++ b/tests/corrector/test_ptest.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cve_corrector.ptest import check_ptest_in_recipe, enable_ptest, run_ptest
+from cve_corrector.ptest import (
+    check_ptest_in_recipe,
+    compare_ptest_results,
+    enable_ptest,
+    run_ptest,
+    summarize_ptest_log,
+)
 from cve_corrector.state import BuildPreexistingError
 
 
@@ -66,7 +72,7 @@ class TestRunPtest:
                    "ptest_log")
         log_dir.mkdir(parents=True)
         log_file = log_dir / "busybox"
-        log_file.write_text("PASSED: test1\nPASSED: test2\nFAILED: test3\nSKIPPED: test4")
+        log_file.write_text("PASS: test1\nPASS: test2\nFAIL: test3\nSKIP: test4")
 
         result = run_ptest("busybox")
         assert result is not None
@@ -126,3 +132,82 @@ class TestRunPtest:
         # After run, local.conf should be restored to original
         content = conf.read_text()
         assert content == "# config\n"
+
+
+# A trimmed excerpt of the real ptest-runner.log that surfaced this bug:
+# the jq ptest hangs and is killed by the per-test timeout before it can
+# print a PASS:/FAIL: result line for itself. Only its "optionaltest"
+# sub-case reported PASS before the kill.
+_JQ_TIMEOUT_LOG = """START: ptest-runner
+2026-07-29T07:39
+BEGIN: /usr/lib/jq/ptest
+PASS: optionaltest
+Timeout! System state:
+Collected system state:
+ERROR: Exited from signal Killed (9)
+DURATION: 451
+TIMEOUT: /usr/lib/jq/ptest
+END: /usr/lib/jq/ptest
+2026-07-29T07:46
+STOP: ptest-runner
+TOTAL: 1 FAIL: 2
+"""
+
+
+class TestSummarizePtestLog:
+    def test_real_format_uses_single_colon(self):
+        """ptest-runner emits 'PASS: name'/'FAIL: name'/'SKIP: name' (see
+        test-manual/ptest.rst), not 'PASSED:'/'FAILED:'/'SKIPPED:'. Counting
+        the wrong substrings means real logs always summarize as 0/0/0."""
+        result = summarize_ptest_log("PASS: t1\nPASS: t2\nFAIL: t3\nSKIP: t4")
+        assert "PASSED: 2" in result
+        assert "FAILED: 1" in result
+        assert "SKIPPED: 1" in result
+
+    def test_killed_test_counted_as_aborted_not_silently_passing(self):
+        """A ptest killed by the per-test timeout never emits a PASS/FAIL
+        line for itself. It must show up as ABORTED, not be invisible."""
+        result = summarize_ptest_log(_JQ_TIMEOUT_LOG)
+        assert "PASSED: 1" in result   # optionaltest
+        assert "FAILED: 0" in result  # jq itself never reported FAIL
+        assert "ABORTED: 1" in result  # but it was killed — must be visible
+
+    def test_runner_summary_line_not_mistaken_for_a_result(self):
+        """The aggregate 'TOTAL: 1 FAIL: 2' summary line ptest-runner
+        prints at the end must not be parsed as an individual FAIL: result
+        (it is not anchored at line start in the same way and belongs to
+        the runner, not a test case)."""
+        result = summarize_ptest_log(_JQ_TIMEOUT_LOG)
+        assert "Failing cases" not in result
+
+    def test_incomplete_run_flagged_as_unreliable(self):
+        """If STOP: ptest-runner is never reached (e.g. QEMU crashed before
+        the runner finished), the PASS/FAIL counts are truncated and must
+        be flagged rather than reported as a clean result."""
+        truncated = _JQ_TIMEOUT_LOG.replace("STOP: ptest-runner\n", "")
+        result = summarize_ptest_log(truncated)
+        assert result.startswith("WARNING:")
+
+    def test_complete_run_not_flagged(self):
+        result = summarize_ptest_log(_JQ_TIMEOUT_LOG)
+        assert not result.startswith("WARNING:")
+
+
+class TestComparePtestResults:
+    def test_aborted_increase_is_a_regression(self):
+        before = "PASSED: 10, FAILED: 0, SKIPPED: 0, ABORTED: 0"
+        after = "PASSED: 9, FAILED: 0, SKIPPED: 0, ABORTED: 1"
+        assert compare_ptest_results(before, after) is False
+
+    def test_same_aborted_count_not_a_regression(self):
+        before = "PASSED: 9, FAILED: 0, SKIPPED: 0, ABORTED: 1"
+        after = "PASSED: 9, FAILED: 0, SKIPPED: 0, ABORTED: 1"
+        assert compare_ptest_results(before, after) is True
+
+    def test_incomplete_after_run_is_a_regression(self):
+        """An after-run summary flagged WARNING (never reached STOP:
+        ptest-runner) is unreliable and must not be accepted as "no
+        regression" just because its visible counts look unchanged."""
+        before = "PASSED: 10, FAILED: 0, SKIPPED: 0, ABORTED: 0"
+        after = summarize_ptest_log(_JQ_TIMEOUT_LOG.replace("STOP: ptest-runner\n", ""))
+        assert compare_ptest_results(before, after) is False


### PR DESCRIPTION
run_ptest() counted the substrings 'PASSED:'/'FAILED:'/'SKIPPED:', but real ptest-runner output uses the single-colon Automake convention 'PASS: name'/'FAIL: name'/'SKIP: name' (test-manual/ ptest.rst). Real logs therefore always summarized as 0/0/0, and compare_ptest_results() always reported 'no regression' regardless of actual test outcomes.

The failure mode that surfaced this: a ptest killed by its per-test timeout (seen with jq's ptest, 'ERROR: Exited from signal Killed (9)' / 'TIMEOUT: /usr/lib/jq/ptest') never emits a PASS/FAIL/SKIP line for itself at all, so it was invisible to the parser either way — the corrector had no way to tell a hung/killed test apart from a clean run with zero tests.

Add summarize_ptest_log() in cve_corrector/ptest.py:
- Anchors PASS:/FAIL:/SKIP: matching to the start of the line so the aggregate 'TOTAL: 1 FAIL: 2' summary ptest-runner prints at the end of a run is never mistaken for an individual test result.
- Counts tests aborted by the per-test timeout (TIMEOUT: lines) in a new ABORTED bucket, so a killed test is surfaced instead of silently counting as zero failures. ptest-runner also logs 'ERROR: Exited from signal ...' right before TIMEOUT: for the same test; only TIMEOUT: is counted to avoid double-counting one kill as two aborted tests.
- Flags a run that never reaches 'STOP: ptest-runner' (e.g. QEMU crashed mid-run) as incomplete/unreliable via a WARNING: prefix. compare_ptest_results() now treats an increase in ABORTED, or an incomplete after-run, as a regression.

cve_agent/context.py's ptest failure context had the same 'FAILED:' substring bug when extracting failing lines for the AI prompt; fixed to anchor on FAIL: and to also surface aborted/killed test lines.

Tests: tests/corrector/test_ptest.py adds coverage using a trimmed excerpt of the real ptest-runner.log that reported this bug (jq killed by timeout, one PASS: from its optionaltest sub-case) — correct PASS/FAIL/SKIP counts, single ABORTED count (not doubled), runner summary line not mistaken for a result, and incomplete-run detection. tests/agent/test_context_*.py updated to use the real PASS:/FAIL: format and add an aborted-lines case.

Verified: ruff check ., mypy cve_agent cve_corrector cve_metadata_extractor shared, and pytest --cov all pass (1042 passed, 3 skipped, 77% coverage).

Assisted-by: Kiro:claude-sonnet-5