### PR TITLE
shared: restrict commit hash extraction to commit URLs

### DIFF
--- a/.agents/summary/components.md
+++ b/.agents/summary/components.md
@@ -58,7 +58,7 @@ graph TB
 | `exit_codes.py` | Single source of truth for all exit codes (0–15) |
 | `paths.py` | XDG-compliant `data_dir()` and `cache_dir()` with env overrides |
 | `json_cache.py` | Gzip-compressed JSON cache with atomic writes (`cache_load`, `cache_dump`) |
-| `url_parser.py` | Parse GitHub/GitLab commit URLs, extract hashes, fetch PR commit lists |
+| `url_parser.py` | Structure-aware commit-URL parsing (GitHub/GitLab, cgit, gitweb, Gitiles, kernel.org shortlinks, Pagure, SourceForge, Fossil), extract hashes, fetch PR commit lists. `HASH_RE` is shared and intentionally unanchored — `cve_metadata_extractor/debian.py` scans free-text notes with `findall()` |
 | `__init__.py` | `GIT_ENV_ALLOWLIST` and `build_git_env()` for safe subprocess environments |
 
 ## cve_metadata_extractor/

--- a/shared/url_parser.py
+++ b/shared/url_parser.py
@@ -8,8 +8,40 @@ used by both cve_metadata_extractor (with caching) and cve_corrector/cve_agent
 """
 import re
 from typing import Optional
+from urllib.parse import parse_qsl, urlparse
 
+# Unanchored on purpose: consumers such as cve_metadata_extractor.debian use
+# HASH_RE.findall() to pull hashes out of free-text notes. Checks that need a
+# whole-string match use HASH_RE.fullmatch().
 HASH_RE = re.compile(r'[0-9a-fA-F]{7,40}')
+_HASH_TOKEN_RE = r'([0-9a-fA-F]{7,40})(?![0-9a-fA-F])'
+# URL path shapes that identify a commit object.
+_COMMIT_PATH_RES = (
+    # GitHub/GitLab/cgit/gitweb: /commit/<hash>, /-/commit/<hash>,
+    # /commits/<hash> (commit within a PR), /commitdiff/<hash>
+    re.compile(rf'/(?:-/)?commit(?:s|diff)?/+{_HASH_TOKEN_RE}(?:[/.]|$)'),
+    # Fossil: /info/<hash>
+    re.compile(rf'/info/+{_HASH_TOKEN_RE}(?:[/.]|$)'),
+    # kernel.org /stable/c/<hash> shortlinks and Pagure /c/<hash>. Anchored at
+    # the end of the path: a bare /c/ segment is too common in unrelated URLs
+    # (file-sharing links embed a hex account id as /c/<id>/<file>).
+    re.compile(rf'/c/+{_HASH_TOKEN_RE}/?$'),
+    # SourceForge: /ci/<hash>
+    re.compile(rf'/ci/+{_HASH_TOKEN_RE}(?:[/.]|$)'),
+    # Gitiles (*.googlesource.com): /<repo>/+/<hash>
+    re.compile(rf'/\+/+{_HASH_TOKEN_RE}(?:[/.]|$)'),
+    # 9front: /<hash>/commit.html
+    re.compile(rf'/{_HASH_TOKEN_RE}/commit\.html$'),
+    # Patch artifacts named after the commit: /<hash>.patch, /<hash>.diff
+    re.compile(rf'/{_HASH_TOKEN_RE}\.(?:patch|diff)$'),
+)
+
+# Hosts that serve a bare /<hash> path as a commit redirect.
+_BARE_HASH_HOSTS = frozenset({'kernel.dance'})
+
+# Path segments that, combined with an id=/h= query parameter, denote a
+# commit view. cgit exposes the same commit as /commit/, /patch/ and /diff/.
+_COMMIT_VIEW_SEGMENTS = frozenset({'commit', 'commitdiff', 'patch', 'diff'})
 
 IGNORED_URL_PATTERNS = [
     'marc.info', 'NEWS.html#', '/blob/', 'bugzilla', 'viewtopic',
@@ -24,7 +56,20 @@ _PR_RE = re.compile(r'https://github\.com/([^/]+)/([^/]+)/pull/(\d+)')
 def extract_commit_hash(url: str) -> Optional[str]:
     """Extract a commit hash from a URL.
 
-    Skips URLs matching ignored patterns and pure-numeric matches.
+    Only extracts from URL structures that identify a commit:
+    ``/commit/<hash>`` and ``/-/commit/<hash>`` (GitHub, GitLab),
+    ``/commits/<hash>`` (commit within a pull request), ``/commitdiff/``,
+    cgit ``/commit|patch|diff/?id=<hash>``, gitweb
+    ``?p=<repo>;a=commit;h=<hash>``, kernel.org ``/stable/c/<hash>``
+    shortlinks, Pagure ``/c/<hash>``, SourceForge ``/ci/<hash>``,
+    Gitiles ``/+/<hash>``, Fossil ``/info/<hash>``, 9front
+    ``/<hash>/commit.html``, and patch artifacts named ``/<hash>.patch``.
+
+    This avoids treating arbitrary hexadecimal-looking document IDs,
+    advisory UUIDs, message IDs or Gerrit change IDs as Git commits.
+    Ranges (``/compare/<a>..<b>``), blob and tree views, and non-Git
+    revisions (Mercurial ``/rev/<id>``) are deliberately not extracted:
+    they do not name a single Git commit the corrector could cherry-pick.
 
     Args:
         url: URL string potentially containing a commit hash.
@@ -34,13 +79,45 @@ def extract_commit_hash(url: str) -> Optional[str]:
     """
     if any(p in url for p in IGNORED_URL_PATTERNS):
         return None
-    match = HASH_RE.search(url)
-    if match:
-        h = match.group(0)
-        if h.isdigit():
-            return None
-        return h
+
+    parsed = urlparse(url)
+    for path_re in _COMMIT_PATH_RES:
+        path_match = path_re.search(parsed.path)
+        if path_match:
+            return _non_numeric_hash(path_match.group(1))
+
+    bare_path = parsed.path.strip('/')
+    if ((parsed.hostname or '').lower() in _BARE_HASH_HOSTS
+            and HASH_RE.fullmatch(bare_path)):
+        return _non_numeric_hash(bare_path)
+
+    # Gitweb commonly separates query parameters with semicolons rather than
+    # ampersands, and some references percent-encode them; normalise every
+    # form before parsing.
+    raw_query = re.sub('%3B', ';', parsed.query, flags=re.IGNORECASE)
+    query = dict(parse_qsl(raw_query.replace(';', '&'),
+                           keep_blank_values=True))
+    path_parts = {part for part in parsed.path.split('/') if part}
+    action = query.get('a')
+    is_commit_view = (
+        bool(path_parts & _COMMIT_VIEW_SEGMENTS)
+        or action in {'commit', 'commitdiff'}
+        # Old-style gitweb links omit the action: ?p=<repo>;h=<hash>. An
+        # explicit non-commit action (a=blob, a=tree) means h= is a blob or
+        # tree object, not a commit, so it must not be accepted here.
+        or ('p' in query and action is None)
+    )
+    if is_commit_view:
+        for key in ('id', 'h', 'hash', 'commit'):
+            candidate = query.get(key, '')
+            if HASH_RE.fullmatch(candidate):
+                return _non_numeric_hash(candidate)
     return None
+
+
+def _non_numeric_hash(candidate: str) -> Optional[str]:
+    """Return a hexadecimal hash candidate unless it is purely numeric."""
+    return None if candidate.isdigit() else candidate
 
 
 def fetch_github_pr_commits(pr_url: str,

--- a/tests/extractor/test_debian.py
+++ b/tests/extractor/test_debian.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 '''Tests for Debian source patch extraction.'''
+import argparse
 import io
 import os
 import tarfile
@@ -8,6 +9,7 @@ import tempfile
 from unittest import TestCase, mock
 
 from cve_metadata_extractor.debian import (
+    DebianSource,
     _match_patches_to_cve,
     diff_debian_patches,
     extract_debian_source_patches,
@@ -412,3 +414,27 @@ class TestExtractDebianSourcePatches(TestCase):
         url, fname = find_debian_tar_url('curl', '7.88.1-10+deb12u10')
         self.assertIsNone(url)
         self.assertIsNone(fname)
+
+
+class TestDebianSourceEnrichKnownHashes(TestCase):
+    '''Hashes embedded in tracker notes feed patch matching.'''
+
+    @mock.patch('cve_metadata_extractor.debian.extract_debian_source_patches')
+    def test_note_hashes_reach_known_hashes(self, mock_extract):
+        '''Regression: HASH_RE must stay unanchored for note scanning.'''
+        source = DebianSource()
+        source._extended = {  # pylint: disable=protected-access
+            'CVE-2024-1234': {
+                'fixes': {'bookworm': {'pkg': 'testpkg', 'version': '1.0-1'}},
+                'notes': ['Fixed by commit abc1234def and def5678abc upstream'],
+            },
+        }
+        args = argparse.Namespace(
+            download_patches=True, cache='/tmp/cache',
+            debian_release='bookworm')
+        mock_extract.return_value = []
+
+        source.enrich('CVE-2024-1234', {}, {'hashes': []}, args)
+
+        known_hashes = mock_extract.call_args[1]['known_hashes']
+        self.assertEqual(known_hashes, {'abc1234def', 'def5678abc'})

--- a/tests/shared/test_url_parser.py
+++ b/tests/shared/test_url_parser.py
@@ -6,12 +6,28 @@ from unittest.mock import Mock, patch
 import pytest
 
 from shared.url_parser import (
+    HASH_RE,
     deduce_repo_url,
     extract_commit_hash,
     fetch_github_pr_commits,
     fetch_gitlab_issue_commits,
     parse_fix_url,
 )
+
+
+class TestHashRe:
+    """HASH_RE is shared; it must stay usable for both scanning and matching."""
+
+    def test_findall_extracts_embedded_hashes(self):
+        # cve_metadata_extractor.debian scans free-text tracker notes with
+        # findall(), so the pattern must not be anchored.
+        note = "Fixed upstream in commit abc1234def and later def5678abc"
+        assert HASH_RE.findall(note) == ['abc1234def', 'def5678abc']
+
+    def test_fullmatch_rejects_surrounding_text(self):
+        assert HASH_RE.fullmatch('abc1234def') is not None
+        assert HASH_RE.fullmatch('emr_na-c04497075') is None
+        assert HASH_RE.fullmatch('abc1234 and more') is None
 
 
 class TestExtractCommitHash:
@@ -26,6 +42,156 @@ class TestExtractCommitHash:
     def test_short_hash(self):
         url = "https://github.com/owner/repo/commit/abc1234"
         assert extract_commit_hash(url) == "abc1234"
+
+    def test_cgit_commit_query(self):
+        url = ("https://git.busybox.net/busybox/commit/"
+               "?id=d417193cf37ca1005830d7e16f5fa7e1d8a44209")
+        assert extract_commit_hash(url) == "d417193cf37ca1005830d7e16f5fa7e1d8a44209"
+
+    def test_gitweb_commit_query(self):
+        url = ("https://git.samba.org/?p=rsync.git;a=commit;"
+               "h=0902b52f6687b1f7952422080d50b93108742e53")
+        assert extract_commit_hash(url) == "0902b52f6687b1f7952422080d50b93108742e53"
+
+    def test_fossil_info_url(self):
+        url = "https://sqlite.org/src/info/498e3f1cf57f164f"
+        assert extract_commit_hash(url) == "498e3f1cf57f164f"
+
+    def test_kernel_stable_shortlink(self):
+        # The most common commit reference shape in the CVE feeds by far.
+        url = ("https://git.kernel.org/stable/c/"
+               "512a01da7134bac8f8b373506011e8aaa3283854")
+        assert extract_commit_hash(url) == (
+            "512a01da7134bac8f8b373506011e8aaa3283854")
+
+    def test_gitiles_commit_url(self):
+        url = ("https://android.googlesource.com/platform/frameworks/base/+/"
+               "db86972777c84a386d8a6d2d34879923bdbccdf6")
+        assert extract_commit_hash(url) == (
+            "db86972777c84a386d8a6d2d34879923bdbccdf6")
+
+    def test_github_pull_request_commit_url(self):
+        url = ("https://github.com/FRRouting/frr/pull/19480/commits/"
+               "cda5ddac0940562d1dca7cbef34d0ce5b00f160b")
+        assert extract_commit_hash(url) == (
+            "cda5ddac0940562d1dca7cbef34d0ce5b00f160b")
+
+    def test_gitweb_hash_without_explicit_action(self):
+        # Old-style gitweb omits a=commit; h= still denotes the commit.
+        url = ("https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;"
+               "h=d1458933830456e54223d9fc61f0d9b3a19256f5")
+        assert extract_commit_hash(url) == (
+            "d1458933830456e54223d9fc61f0d9b3a19256f5")
+
+    def test_gitweb_percent_encoded_separators(self):
+        url = ("https://git.ghostscript.com/?p=ghostpdl.git%3B"
+               "a=commitdiff%3Bh=3d4cfdc1a44")
+        assert extract_commit_hash(url) == "3d4cfdc1a44"
+
+    def test_gitweb_blob_hash_not_treated_as_commit(self):
+        url = ("https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=blob;"
+               "h=d1458933830456e54223d9fc61f0d9b3a19256f5")
+        assert extract_commit_hash(url) is None
+
+    def test_hex_in_repo_name_not_mistaken_for_hash(self):
+        # Previously returned 'ec61850', taken from the repository name.
+        url = ("https://github.com/mz-automation/libiec61850/commit/"
+               "1f52be9ddeae00e69cd43e4cac3cb4f0c880c4f0")
+        assert extract_commit_hash(url) == (
+            "1f52be9ddeae00e69cd43e4cac3cb4f0c880c4f0")
+
+    def test_commitdiff_path(self):
+        url = ("https://git.example.org/repo/commitdiff/"
+               "3d4cfdc1a44ee1b4f0b3d3d1d0f6e0e91f28b1a0")
+        assert extract_commit_hash(url) == (
+            "3d4cfdc1a44ee1b4f0b3d3d1d0f6e0e91f28b1a0")
+
+    # The remaining shapes below were found by diffing this parser against the
+    # previous one over the 2024-2025 CVE List V5 reference URLs; each one is a
+    # real commit reference that a /commit/-only parser silently dropped.
+    def test_cgit_patch_query(self):
+        url = ("https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/"
+               "linux.git/patch/?id=944d5fe50f3f03daacfea16300e656a1691c4a23")
+        assert extract_commit_hash(url) == (
+            "944d5fe50f3f03daacfea16300e656a1691c4a23")
+
+    def test_cgit_diff_query(self):
+        url = ("https://cgit.ghostscript.com/cgi-bin/cgit.cgi/mupdf.git/diff/"
+               "?id=b5c898a30f068b5342e8263a2cd5b9f0be291aac")
+        assert extract_commit_hash(url) == (
+            "b5c898a30f068b5342e8263a2cd5b9f0be291aac")
+
+    def test_pagure_commit_url(self):
+        url = ("https://pagure.io/freeipa/c/"
+               "6b9400c135ed16b10057b350cc9ce42aa0e862d4")
+        assert extract_commit_hash(url) == (
+            "6b9400c135ed16b10057b350cc9ce42aa0e862d4")
+
+    def test_sourceforge_commit_url(self):
+        url = ("https://sourceforge.net/p/openipmi/code/ci/"
+               "4c129d0540f3578ecc078d8612bbf84b6cd24c87/")
+        assert extract_commit_hash(url) == (
+            "4c129d0540f3578ecc078d8612bbf84b6cd24c87")
+
+    def test_9front_commit_url(self):
+        url = ("https://git.9front.org/plan9front/plan9front/"
+               "07aa9bfeef55ca987d411115adcfbbd4390ecf34/commit.html")
+        assert extract_commit_hash(url) == (
+            "07aa9bfeef55ca987d411115adcfbbd4390ecf34")
+
+    def test_kernel_dance_shortlink(self):
+        url = "https://kernel.dance/b1db244ffd041a49ecc9618e8feb6b5c1afcdaa7"
+        assert extract_commit_hash(url) == (
+            "b1db244ffd041a49ecc9618e8feb6b5c1afcdaa7")
+
+    def test_patch_artifact_named_after_commit(self):
+        url = ("https://depot.galaxyproject.org/patch/GX-2024-0001/"
+               "022da344a02bafd604402ac8e253e0014f6e2e08.patch")
+        assert extract_commit_hash(url) == (
+            "022da344a02bafd604402ac8e253e0014f6e2e08")
+
+    def test_file_share_hex_account_id_ignored(self):
+        # /c/<hex>/<file> share links must not look like Pagure /c/<hash>.
+        url = ("https://1drv.ms/t/c/12406a392c92914b/"
+               "EQ5pK82-KmxKht6YgsEzaOsBzrC05Cael1vwpfM9ZxX97Q?e=qEgmtB")
+        assert extract_commit_hash(url) is None
+
+    def test_mercurial_revision_ignored(self):
+        # Not a Git object; the corrector could not cherry-pick it.
+        url = "https://hg.savannah.gnu.org/hgweb/unrtf/rev/a5d3b025a8b1"
+        assert extract_commit_hash(url) is None
+
+    def test_compare_range_ignored(self):
+        url = ("https://github.com/oxidecomputer/omicron/compare/"
+               "01bb875a1b2c3d4...ec069f0a1b2c3d4")
+        assert extract_commit_hash(url) is None
+
+    def test_tree_browse_url_ignored(self):
+        url = ("https://github.com/Homebrew/brew/tree/"
+               "237d1e783f7ee261beaba7d3f6bde22da7148b0a")
+        assert extract_commit_hash(url) is None
+
+    def test_gerrit_change_id_ignored(self):
+        # A Gerrit Change-Id is not a commit hash.
+        url = ("https://gerrit.wikimedia.org/r/q/"
+               "I7878f8f7bc067080f80427b90f8d85337f172711")
+        assert extract_commit_hash(url) is None
+
+    def test_advisory_uuid_ignored(self):
+        url = ("https://www.wordfence.com/threat-intel/vulnerabilities/id/"
+               "894b43ed-143d-4c0b-afd1-05fcd6fa5018?source=cve")
+        assert extract_commit_hash(url) is None
+
+    @pytest.mark.parametrize("url", [
+        ("https://support.hpe.com/hpsc/doc/public/display"
+         "?docLocale=en_US&docId=emr_na-c04497075"),
+        ("https://support.hpe.com/hpsc/doc/public/display"
+         "?docLocale=en_US&docId=emr_na-c04518183"),
+        ("https://inbox.sourceware.org/libc-announce/"
+         "b11f0003-6ec1-4bd6-b9de-9e38a4efeca3@redhat.com/T/"),
+    ])
+    def test_non_commit_hex_identifier_ignored(self, url):
+        assert extract_commit_hash(url) is None
 
     def test_ignored_bugzilla(self):
         url = "https://bugzilla.redhat.com/show_bug.cgi?id=1234567"


### PR DESCRIPTION
## Problem

`extract_commit_hash()` ran `HASH_RE.search()` across the whole URL and returned the
first hexadecimal-looking run it found anywhere. Any reference URL containing a hex-ish
identifier was therefore recorded as a fix commit — Wordfence/WPScan advisory UUIDs, HPE
document IDs (`docId=emr_na-c04497075`), Notion page IDs, Gerrit change IDs, mailing-list
message IDs. The hash could also be taken from the repository name rather than the
commit: `github.com/mz-automation/libiec61850/commit/<hash>` yielded `ec61850`.

## Change

Parse the URL structurally and extract only when it denotes a commit object:

- `/commit/<hash>`, `/-/commit/<hash>`, `/commits/<hash>` (commit inside a PR),
  `/commitdiff/<hash>`
- cgit `/commit/?id=<hash>`, plus the `/patch/` and `/diff/` views of the same commit
- gitweb `?p=<repo>;a=commit;h=<hash>`, including old-style links that omit the action
  and links whose `;` separators are percent-encoded
- kernel.org `/stable/c/<hash>` and `kernel.dance/<hash>` shortlinks
- Pagure `/c/<hash>` and SourceForge `/ci/<hash>`
- Gitiles `/+/<hash>` (`*.googlesource.com`)
- Fossil `/info/<hash>` and 9front `/<hash>/commit.html`
- patch artifacts named after the commit: `/<hash>.patch`, `/<hash>.diff`

A gitweb `h=` is rejected when an explicit non-commit action is present (`a=blob`,
`a=tree`), since `h=` then names a blob or tree. The `/c/<hash>` form is anchored to the
end of the path — a bare `/c/` segment is too common in unrelated URLs, where
file-sharing links embed a hex account id as `/c/<id>/<file>`.

`HASH_RE` stays unanchored on purpose: `cve_metadata_extractor/debian.py` scans free-text
tracker notes with `HASH_RE.findall()` to seed `known_hashes` for Debian patch matching.
The new query-parameter check uses `HASH_RE.fullmatch()`, which needs no anchors.

## Validation

Compared old vs new behaviour over every unique **CNA** reference URL in the 2024-2025
CVE List V5 feeds — 155983 URLs:

| outcome | count |
|---|---|
| unchanged | 146088 |
| corrected to the real commit hash | 4 |
| newly extracted | 0 |
| no longer extracted | 9891 |

All 9891 drops were classified, not sampled:

| category | count |
|---|---|
| Wordfence/WPScan advisory IDs | 8128 |
| vendor KB / documentation IDs | 814 |
| Notion pages | 632 |
| Medium article IDs | 194 |
| SCM-shaped URLs | 123 |

The SCM-shaped group contains no commit view: 56 Gerrit change IDs (a Change-Id spans
several patch sets and is not a commit), 15 tree browse URLs, 12 compare ranges, 8
pull-request file-diff anchors, 5 blob/blob-diff views, 3 bare repository URLs, 2
Mercurial revisions (not Git objects the corrector could cherry-pick), and a few one-offs
including a malformed 41-character hash and a URL-defense-wrapped commit link.

The supported URL shapes were derived from that corpus rather than guessed. A
`/commit/`-only implementation silently dropped 28501 `git.kernel.org/stable/c/<hash>`
references alone — the most common commit reference shape in the feeds — plus Gitiles,
action-less gitweb, cgit `patch`/`diff` views, Pagure, SourceForge and 9front commits.
Every one of those is now covered and has a corpus-derived regression test.

## Tests

`tests/shared/test_url_parser.py` covers every supported URL shape and the rejected ones,
each corpus-derived case included, plus a `HASH_RE.findall()` regression test.
`tests/extractor/test_debian.py` asserts hashes embedded in tracker notes still reach
`extract_debian_source_patches(known_hashes=...)`.

`ruff check .`, `mypy cve_agent cve_corrector cve_metadata_extractor shared` and `pytest`
all pass (1072 passed, 3 skipped).

## Known limitations (deliberate, not oversights)

- `deduce_repo_url()` does not understand every shape this parser accepts — a
  `git.kernel.org/stable/c/<hash>` URL is returned as its own "repository" URL, and
  Gitiles/Fossil return `None`. This mismatch predates the change (the old scan extracted
  hashes from those same URLs) and is left for a separate PR.
- `IGNORED_URL_PATTERNS` is applied before structural parsing, so a repository whose
  *name* contains a blocklisted substring is still skipped — `Asgaros/asgaros-forum`
  ("forum"), `user-registration` ("gist"). Also pre-existing, and worth removing once the
  structural parser is in, since issue/advisory/blob URLs no longer match any shape.
