### PR TITLE
cve_corrector: don't clobber HEAD symlinks when copying devtool files

### DIFF
--- a/cve_corrector/git_ops.py
+++ b/cve_corrector/git_ops.py
@@ -236,6 +236,10 @@ def copy_missing_files_from_devtool(workspace_path: Path) -> None:
 
     Files under registered submodule paths are skipped — those are tracked
     by git submodule and must not be overwritten with regular file copies.
+
+    Files under paths that HEAD tracks as symlinks are also skipped — release
+    tarballs dereference symlinks into real directories, and copying those
+    files would clobber the symlink and break subsequent cherry-picks.
     """
     devtool_files = run_cmd_capture(
         ['git', 'ls-tree', '-r', '--name-only', 'devtool'], cwd=workspace_path)
@@ -248,10 +252,32 @@ def copy_missing_files_from_devtool(workspace_path: Path) -> None:
 
     cve_set = set(cve_files.stdout.strip().splitlines())
     submodule_paths = _get_submodule_paths(workspace_path)
+
+    # Collect paths that HEAD tracks as symlinks (git mode 120000). Release
+    # tarballs dereference symlinks into real directories, so the devtool
+    # branch lists the symlink target's contents (e.g.
+    # tutorial/swift/swift-dep/Sources/*.swift) as regular files. Copying
+    # those out of devtool would clobber the symlink with a real directory,
+    # leaving a staged deletion + untracked dir that blocks every subsequent
+    # cherry-pick. Skip anything living under a HEAD symlink: the symlink
+    # already resolves to an in-tree path, so nothing is actually missing.
+    symlink_prefixes: tuple[str, ...] = ()
+    cve_tree = run_cmd_capture(
+        ['git', 'ls-tree', '-r', 'HEAD'], cwd=workspace_path)
+    if cve_tree.returncode == 0:
+        symlinks = []
+        for line in cve_tree.stdout.strip().splitlines():
+            # Format: "<mode> <type> <hash>\t<path>"
+            meta, _, path = line.partition('\t')
+            if path and meta.split(' ', 1)[0] == '120000':
+                symlinks.append(path + '/')
+        symlink_prefixes = tuple(symlinks)
+
     missing = [f for f in devtool_files.stdout.strip().splitlines()
                if f not in cve_set
                and not any(f == sm or f.startswith(sm + '/')
-                           for sm in submodule_paths)]
+                           for sm in submodule_paths)
+               and not (symlink_prefixes and f.startswith(symlink_prefixes))]
     if not missing:
         return
 

--- a/tests/corrector/test_symlink_skip.py
+++ b/tests/corrector/test_symlink_skip.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+"""Tests for symlink handling in copy_missing_files_from_devtool.
+
+Reproduces the bug where recipes whose upstream tree tracks a directory
+symlink (git mode 120000) get their symlink clobbered because:
+1. Release tarballs dereference symlinks into real directories, so the
+   devtool branch lists the symlink target's contents as regular files
+   (e.g. tutorial/swift/swift-dep/Sources/*.swift).
+2. copy_missing_files_from_devtool() copies those files out of devtool,
+   overwriting the symlink with a real directory.
+3. The resulting staged deletion + untracked directory leaves the working
+   tree dirty and blocks every subsequent git cherry-pick.
+
+The fix: skip any devtool file living under a path that HEAD tracks as a
+symlink — the symlink already resolves to an in-tree path, so nothing is
+actually missing.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cve_corrector.git_ops import copy_missing_files_from_devtool
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ['git', *args], cwd=repo, check=True,
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, 'init', '-q', '-b', 'main')
+    _git(repo, 'config', 'user.email', 'test@test.com')
+    _git(repo, 'config', 'user.name', 'Test')
+    _git(repo, 'config', 'commit.gpgsign', 'false')
+
+
+@pytest.fixture
+def workspace_with_symlink(tmp_path: Path) -> Path:
+    """Create a repo whose HEAD tracks a directory symlink.
+
+    Layout on HEAD (upstream git):
+        src/real/a.swift
+        tutorial/swift -> ../src/real   (symlink, mode 120000)
+
+    Layout on devtool (tarball, symlink dereferenced into a real dir):
+        src/real/a.swift
+        tutorial/swift/a.swift          (regular file)
+        Makefile                        (a genuinely-missing generated file)
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    # Upstream HEAD: real dir + a symlink pointing at it.
+    (repo / 'src' / 'real').mkdir(parents=True)
+    (repo / 'src' / 'real' / 'a.swift').write_text('let x = 1\n')
+    (repo / 'tutorial').mkdir()
+    (repo / 'tutorial' / 'swift').symlink_to('../src/real')
+    _git(repo, 'add', '-A')
+    _git(repo, 'commit', '-m', 'upstream with symlink')
+    _git(repo, 'tag', 'v1.0')
+
+    # Build the devtool branch as an orphan mimicking a dereferenced tarball.
+    _git(repo, 'checkout', '-q', '--orphan', 'devtool')
+    _git(repo, 'rm', '-q', '-rf', '.')
+    # Remove any leftover working-tree entries from the symlink checkout.
+    subprocess.run(['rm', '-rf', 'tutorial', 'src'], cwd=repo, check=True)
+
+    (repo / 'src' / 'real').mkdir(parents=True)
+    (repo / 'src' / 'real' / 'a.swift').write_text('let x = 1\n')
+    # Symlink target dereferenced into a real directory of regular files.
+    (repo / 'tutorial' / 'swift').mkdir(parents=True)
+    (repo / 'tutorial' / 'swift' / 'a.swift').write_text('let x = 1\n')
+    # A genuinely-missing generated file that SHOULD be copied.
+    (repo / 'Makefile').write_text('all:\n')
+    _git(repo, 'add', '-A')
+    _git(repo, 'commit', '-m', 'devtool tarball content')
+
+    # Back to a CVE branch off the upstream tag (as prepare_cve_branch does).
+    _git(repo, 'checkout', '-q', '-b', 'CVE-2026-00001', 'v1.0')
+    return repo
+
+
+def test_symlink_is_not_clobbered(workspace_with_symlink: Path) -> None:
+    """copy_missing_files_from_devtool must not overwrite a HEAD symlink."""
+    repo = workspace_with_symlink
+
+    # Precondition: HEAD tracks tutorial/swift as a symlink (mode 120000).
+    head_tree = _git(repo, 'ls-tree', '-r', 'HEAD')
+    assert '120000' in head_tree
+    assert 'tutorial/swift' in head_tree
+    # And devtool lists the dereferenced contents as regular files.
+    devtool_files = _git(repo, 'ls-tree', '-r', '--name-only', 'devtool')
+    assert 'tutorial/swift/a.swift' in devtool_files
+
+    copy_missing_files_from_devtool(repo)
+
+    # The symlink must remain an intact symlink, not a real directory.
+    swift_path = repo / 'tutorial' / 'swift'
+    assert swift_path.is_symlink(), "symlink was clobbered by a real directory"
+
+    # Working tree must stay clean under the symlink path — no staged deletion,
+    # no untracked directory that would block subsequent cherry-picks.
+    status = _git(repo, 'status', '--porcelain')
+    dirty_under_symlink = [
+        line for line in status.splitlines() if 'tutorial/swift' in line
+    ]
+    assert not dirty_under_symlink, (
+        f"symlink path should stay clean, got:\n{chr(10).join(dirty_under_symlink)}"
+    )
+
+
+def test_genuinely_missing_files_still_copied(
+    workspace_with_symlink: Path,
+) -> None:
+    """Files not under a symlink (e.g. generated Makefile) are still copied."""
+    repo = workspace_with_symlink
+
+    copy_missing_files_from_devtool(repo)
+
+    makefile = repo / 'Makefile'
+    assert makefile.exists(), "genuinely-missing file should be copied"
+    assert makefile.read_text() == 'all:\n'

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -196,6 +196,10 @@ class TestCopyMissingFilesFromDevtool:
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="a.c\nb.c\nconfigure\n"),
             MagicMock(returncode=0, stdout="a.c\nb.c\n"),
+            # git ls-tree -r HEAD (symlink detection) — no symlinks
+            MagicMock(returncode=0,
+                      stdout="100644 blob abc123\ta.c\n"
+                             "100644 blob def456\tb.c\n"),
             MagicMock(returncode=0),  # checkout
             MagicMock(returncode=0),  # reset
         ]
@@ -206,6 +210,8 @@ class TestCopyMissingFilesFromDevtool:
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="a.c\n"),
             MagicMock(returncode=0, stdout="a.c\n"),
+            # git ls-tree -r HEAD (symlink detection) — no symlinks
+            MagicMock(returncode=0, stdout="100644 blob abc123\ta.c\n"),
         ]
         copy_missing_files_from_devtool(Path("/ws"))
 


### PR DESCRIPTION
Release tarballs dereference symlinks into real directories, so the devtool branch lists a symlink target's contents (e.g. tutorial/swift/swift-dep/Sources/*.swift) as regular files. Copying those out of devtool overwrote the HEAD symlink with a real directory, leaving a staged deletion plus an untracked dir that blocked every subsequent cherry-pick.

copy_missing_files_from_devtool now collects paths HEAD tracks as symlinks (git mode 120000) and skips any devtool file living under one of them. Genuinely-missing generated files are still copied.

Adds tests/corrector/test_symlink_skip.py reproducing the clobber and verifying non-symlink files are unaffected; updates the mocked call sequences in test_workflow_full.py for the extra ls-tree invocation.