### PR TITLE
Support dependent --fix-url chains for CVE backporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ cve-corrector --cve-id CVE-2024-1234 --cve-info cve-metadata.json
 cve-corrector --continue
 ```
 
+**Dependent commit chains.** `--fix-url` is repeatable. A single URL applies
+one fix commit (or one pull request's commits); two or more URLs are treated
+as one ordered, dependent chain — the caller controls the order, and **all**
+commits must apply or the run stops at a conflict (no falling back to
+applying just one of them). Use this when a CVE is fixed by a short series
+of follow-up commits on the same branch, e.g. acl's CVE-2026-XXXXX:
+
+```bash
+cve-corrector --cve-id CVE-2026-XXXXX --recipe acl \
+  --fix-url https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/?id=5906d2868ec8d3b08be556153696e6b1122eeeda \
+  --fix-url https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/?id=0071c6d1fea0a8a6270333baa85fb609be325c26 \
+  --fix-url https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c
+```
+
+If the chain conflicts partway through, resolve it and resume with
+`cve-corrector --continue` — the remaining commits are applied in the same
+order. `cve-agent` accepts the same repeated `--fix-url` flag and forwards
+it unchanged to `cve-corrector`.
+
 ### AI-assisted backporting
 
 ```bash

--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -106,7 +106,7 @@ class AgentConfig:
     interactive: bool = False
     bbappend: bool = False
     skip_cve_applicability: bool = False
-    fix_url: Optional[str] = None
+    fix_urls: list[str] = field(default_factory=list)
     recipe: Optional[str] = None
     backend: str = "kiro"
     skip_sources: list[str] = field(default_factory=list)

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -206,8 +206,13 @@ def _parse_args() -> argparse.Namespace:
                            help='File with CVE IDs, one per line')
     input_group.add_argument('--cve-info', type=Path,
                         help='JSON file with CVE metadata')
-    input_group.add_argument('--fix-url',
-                        help='URL of fix commit or pull request')
+    input_group.add_argument('--fix-url', action='append', default=[],
+                        metavar='URL', dest='fix_urls',
+                        help='URL of fix commit or pull request (repeatable). '
+                             'Two or more URLs are applied as one dependent '
+                             'series, in the order given, and all of them must '
+                             'apply — a partial application is reported as a '
+                             'conflict.')
     input_group.add_argument('--recipe',
                         help='Recipe name (required with --fix-url without --cve-info)')
     input_group.add_argument('--skip-source', action='append', default=[],
@@ -285,7 +290,7 @@ def _config_from_args(args: argparse.Namespace,
         bbappend=args.bbappend,
         skip_cve_applicability=args.skip_cve_applicability,
         interactive=args.interactive,
-        fix_url=args.fix_url,
+        fix_urls=args.fix_urls,
         recipe=args.recipe,
         backend=args.backend,
         skip_sources=args.skip_sources,
@@ -298,10 +303,10 @@ def main() -> None:
     signal.signal(signal.SIGINT, _sigint_handler(results))
     args = _parse_args()
 
-    if not args.cve_info and not args.fix_url:
+    if not args.cve_info and not args.fix_urls:
         print("Error: --cve-info or --fix-url is required", file=sys.stderr)
         sys.exit(EXIT_AGENT_ERROR)
-    if args.fix_url and not args.cve_info and not args.recipe:
+    if args.fix_urls and not args.cve_info and not args.recipe:
         print("Error: --recipe is required when using --fix-url without "
               "--cve-info", file=sys.stderr)
         sys.exit(EXIT_AGENT_ERROR)

--- a/cve_agent/corrector.py
+++ b/cve_agent/corrector.py
@@ -46,8 +46,8 @@ def run_corrector(config: AgentConfig, continue_mode: bool = False,
         ]
         if config.cve_info_path:
             cmd += ['--cve-info', str(config.cve_info_path)]
-        if config.fix_url:
-            cmd += ['--fix-url', config.fix_url]
+        for fix_url in config.fix_urls:
+            cmd += ['--fix-url', fix_url]
         if config.recipe:
             cmd += ['--recipe', config.recipe]
         if config.clean:

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -360,9 +360,9 @@ def process_single_cve(config: AgentConfig,
     try:
         if config.cve_info_path:
             cve_data = load_cve_metadata(config.cve_info_path)
-        elif config.fix_url and config.recipe:
-            from shared.url_parser import parse_fix_url
-            url_metadata = parse_fix_url(config.fix_url)
+        elif config.fix_urls and config.recipe:
+            from shared.url_parser import parse_fix_urls
+            url_metadata = parse_fix_urls(config.fix_urls)
             cve_data = {config.cve_id: {'name': config.recipe, **url_metadata}}
         else:
             return _make_result(

--- a/cve_corrector/__main__.py
+++ b/cve_corrector/__main__.py
@@ -92,8 +92,13 @@ def main():
                         help='CVE identifier (e.g., CVE-2024-1234)')
     input_group.add_argument('--cve-info', type=Path,
                         help='JSON file with CVE metadata (e.g., cve-metadata.json)')
-    input_group.add_argument('--fix-url',
-                        help='URL of fix commit or pull request')
+    input_group.add_argument('--fix-url', action='append', default=[],
+                        metavar='URL', dest='fix_urls',
+                        help='URL of fix commit or pull request (repeatable). '
+                             'Two or more URLs are applied as one dependent '
+                             'series, in the order given, and all of them must '
+                             'apply — a partial application is reported as a '
+                             'conflict.')
     input_group.add_argument('--recipe',
                         help='Recipe name (required with --fix-url without --cve-info)')
     input_group.add_argument('--skip-source', action='append', default=[],
@@ -162,18 +167,23 @@ def main():
     if not args.cve_id:
         parser.error('--cve-id is required (unless using --continue)')
 
-    if args.fix_url:
-        from shared.url_parser import parse_fix_url
+    if args.fix_urls:
+        from shared.url_parser import parse_fix_urls
         if not args.cve_info and not args.recipe:
             parser.error('--recipe is required when using --fix-url without --cve-info')
-        url_metadata = parse_fix_url(args.fix_url)
+        try:
+            url_metadata = parse_fix_urls(args.fix_urls)
+        except ValueError as err:
+            parser.error(str(err))
         if args.cve_info:
             cve_data = load_cve_metadata(args.cve_info)
             if args.cve_id not in cve_data:
                 cve_data[args.cve_id] = {'name': args.recipe or ''}
             cve_data[args.cve_id]['hashes'] = url_metadata['hashes']
             cve_data[args.cve_id]['hash_details'] = url_metadata['hash_details']
-            if url_metadata['series']:
+            # A multi-URL chain is authoritative: replace any series from the
+            # JSON so a stale PR series cannot compete with the explicit chain.
+            if url_metadata['series'] or len(args.fix_urls) > 1:
                 cve_data[args.cve_id]['series'] = url_metadata['series']
         else:
             cve_data = {args.cve_id: {'name': args.recipe, **url_metadata}}
@@ -264,6 +274,11 @@ def main():
         else:
             print(f"No mirror found for '{recipe_name}', will deduce from hash details")
 
+    # Two or more --fix-url values declare an ordered dependent chain: every
+    # commit must apply or the run stops at a conflict (no single-commit
+    # fallback, no least-conflict pick).
+    require_all_commits = len(args.fix_urls) > 1
+
     if args.dry_run:
         hashes = cve_info.get('hashes', [])
         series = cve_info.get('series', [])
@@ -272,6 +287,8 @@ def main():
         print(f"Meta-layer: {meta_layer}")
         print(f"Commits:    {len(hashes)}")
         print(f"Series:     {len(series)}")
+        if require_all_commits:
+            print(f"Dependent:  yes — all {len(hashes)} commit(s) must apply, in this order")
         if hashes:
             for h in hashes[:5]:
                 print(f"  - {h[:12]}")
@@ -304,7 +321,8 @@ def main():
                 skip_ptest=args.skip_ptest, edit_mode=args.edit,
                 manual_mode=args.manual, bbappend=args.bbappend,
                 skip_cve_applicability=args.skip_cve_applicability,
-                skip_confirm=args.yes))
+                skip_confirm=args.yes,
+                require_all_commits=require_all_commits))
         state.skip_confirm = args.yes
 
         finish_cve_workflow(state)

--- a/cve_corrector/blame.py
+++ b/cve_corrector/blame.py
@@ -278,7 +278,9 @@ def check_vulnerability_origin(workspace_path: Path,
             checked out at the recipe version).
         commit_hashes: List of upstream fix commit hashes.
         recipe_version: Current recipe version string.
-        series: Optional list of PR series dicts with 'commits' keys.
+        series: Optional list of series dicts with 'commits' keys — an
+            ordered set of commits that must all be applied, from a pull
+            request or from repeated ``--fix-url``.
 
     Returns:
         A reason string suitable for CVE_STATUS if the CVE is not

--- a/cve_corrector/blame.py
+++ b/cve_corrector/blame.py
@@ -104,9 +104,12 @@ def blame_line_ranges(workspace_path: Path,
             cmd += ['--', filepath]
             result = run_cmd_capture(cmd, cwd=workspace_path)
             if result.returncode != 0:
-                logger.warning(
-                    f"git blame failed for {filepath}:{start}-{end}: "
-                    f"{result.stderr.strip()}")
+                stderr = result.stderr.strip()
+                # A newly-added file has no path at the parent revision —
+                # this is an expected, harmless case (not a genuine blame
+                # failure), so log it at debug level instead of warning.
+                log = logger.debug if 'no such path' in stderr else logger.warning
+                log(f"git blame failed for {filepath}:{start}-{end}: {stderr}")
                 continue
             for blame_line in result.stdout.splitlines():
                 m = _BLAME_HASH_RE.match(blame_line)

--- a/cve_corrector/cherry_pick.py
+++ b/cve_corrector/cherry_pick.py
@@ -191,15 +191,31 @@ def cherry_pick_to_devtool(state: WorkflowState) -> None:
 
 
 def apply_series(workspace_path: Path,
-                 series: list[dict]) -> tuple[bool, Optional[str], Optional[dict]]:
-    """Apply PR series commits using batch cherry-pick.
+                 series: list[dict],
+                 require_all: bool = False) -> tuple[bool, Optional[str], Optional[dict]]:
+    """Apply a commit series using batch cherry-pick.
+
+    A series is an ordered set of commits that must all be applied — either
+    a pull request's commits or a dependent chain given via repeated
+    ``--fix-url``.
+
+    Args:
+        workspace_path: Path to the git repository.
+        series: Series dicts with ``commits`` (and optional ``pull_url``).
+        require_all: When True the commits form a caller-declared dependent
+            chain, so conflict state is reported even if nothing applied.
 
     Returns:
         Tuple of (success, last_commit_hash, best_partial_series)
     """
-    logger.info("Found %s pull request series", len(series))
+    logger.info("Found %s commit series", len(series))
     best_series = None
-    max_applied = 0
+    # A required chain must always surface conflict state, even when the very
+    # first commit conflicts and zero commits were applied — otherwise the
+    # caller falls back to applying a single commit, silently leaving the CVE
+    # only partially fixed. Candidate series keep the original ">0 applied"
+    # bar so their existing fallback behaviour is unchanged.
+    max_applied = -1 if require_all else 0
 
     for idx, pr_series in enumerate(series, 1):
         pull_url = pr_series.get('pull_url', '')
@@ -209,14 +225,16 @@ def apply_series(workspace_path: Path,
         if skipped:
             logger.warning("  Skipping %s bad object(s) in series", skipped)
         if not valid:
-            logger.warning("[%s/%s] No valid commits in series from %s", idx, len(series), pull_url)
+            logger.warning("[%s/%s] No valid commits in series from %s", idx, len(series),
+                           pull_url or 'command line')
             continue
-        logger.info("[%s/%s] Trying PR series from %s", idx, len(series), pull_url)
+        origin = f"PR {pull_url}" if pull_url else f"dependent chain of {len(valid)} commit(s)"
+        logger.info("[%s/%s] Trying %s", idx, len(series), origin)
 
         result = run_cmd(['git', 'cherry-pick'] + valid, cwd=workspace_path)
 
         if result == 0:
-            logger.info("✓ Successfully applied all %s commits from PR series", len(valid))
+            logger.info("✓ Successfully applied all %s commits from %s", len(valid), origin)
             return True, valid[-1], None
 
         cherry_pick_head = workspace_path / '.git' / 'CHERRY_PICK_HEAD'

--- a/cve_corrector/patch_ops.py
+++ b/cve_corrector/patch_ops.py
@@ -138,9 +138,10 @@ def _compute_cve_tag_flags(state: WorkflowState, patches: list[str]) -> list[boo
     Only the patch corresponding to the fix commit gets the ``CVE:`` tag;
     prerequisite commits the agent added get ``Upstream-Status: Backport``
     only. This distinction is applied **only** when the agent introduced
-    extra commits (no known PR series, but more than one patch). Known PR
-    series (``series_state`` set) and single-patch fixes keep the existing
-    all-``CVE:`` behavior untouched.
+    extra commits (no known series, but more than one patch). A known
+    series (``series_state`` set — from a pull request or from repeated
+    ``--fix-url``) and single-patch fixes keep the existing all-``CVE:``
+    behavior untouched.
 
     Safety: if the fix commit's subject can't be matched to any generated
     patch, fall back to tagging every patch — the fix must never silently

--- a/cve_corrector/ui.py
+++ b/cve_corrector/ui.py
@@ -64,7 +64,9 @@ def print_manual_instructions(workspace_path: Path, recipe: str,
         workspace_path: Path to devtool workspace source directory
         recipe: Recipe name being patched
         hashes: List of upstream fix commit hashes
-        series: List of PR series dicts
+        series: List of series dicts — an ordered set of commits that must
+            all be applied, from a pull request or from repeated
+            ``--fix-url``
     """
     print("=" * 60)
     print("MANUAL MODE - Environment ready for manual patching")
@@ -77,7 +79,7 @@ def print_manual_instructions(workspace_path: Path, recipe: str,
         for h in hashes:
             print(f"  git cherry-pick {h[:12]}")
     if series:
-        print(f"\nPR series available ({len(series)} series)")
+        print(f"\nDependent commit series available ({len(series)} series)")
     print("\nUseful commands:")
     print(f"  devtool build {recipe}        # Test the build")
     print("  git log --oneline             # View commit history")

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -79,8 +79,12 @@ def filter_by_skip_sources(cve_info: dict, skip_sources: list[str]) -> dict:
     ``hash_details`` and all of its sources are skipped — hashes with no
     ``hash_details`` entry are left untouched (we cannot attribute them).
 
-    Series are not filtered: series entries carry only ``pull_url`` and no
-    reliable source field, so their provenance cannot be determined here.
+    Series are not filtered: a series is an ordered set of commits that must
+    all be applied — from a pull request, or from repeated ``--fix-url`` —
+    and it carries only ``pull_url``/``commits`` (plus, for a PR, the ``cli``
+    source recorded in ``hash_details``); provenance for individual series
+    commits cannot be reliably attributed here, so series entries pass
+    through unfiltered.
 
     Args:
         cve_info: Per-CVE metadata dict (not mutated).
@@ -445,7 +449,15 @@ def continue_from_conflict() -> WorkflowState:
 
 @dataclass
 class WorkflowConfig:
-    """Configuration parameters for CVE workflow initialization."""
+    """Configuration parameters for CVE workflow initialization.
+
+    Attributes:
+        require_all_commits: When True, the fix commits form an ordered
+            dependent chain that must apply in full (set by passing
+            ``--fix-url`` more than once). A partial application is reported
+            as a conflict instead of falling back to applying a single
+            commit, which would leave the CVE only partially fixed.
+    """
     mirror_path: Optional[Path]
     mirror_dir: Optional[Path]
     meta_layer: Optional[Path]
@@ -457,6 +469,7 @@ class WorkflowConfig:
     bbappend: bool = False
     skip_cve_applicability: bool = False
     skip_confirm: bool = False
+    require_all_commits: bool = False
 
 
 def _handle_failed_series(workspace_path, best_series, make_state, recipe):
@@ -469,10 +482,17 @@ def _handle_failed_series(workspace_path, best_series, make_state, recipe):
     raise ConflictError("Conflict detected")
 
 
-def _handle_no_clean_apply(workspace_path, hashes, series, make_state, recipe):
+def _handle_no_clean_apply(workspace_path, hashes, series, make_state, recipe,
+                           require_all_commits=False):
     """Handle case where no commit applied cleanly."""
     if series:
-        logger.error("All PR series failed")
+        logger.error("All commit series failed")
+    if require_all_commits:
+        # The commits form a dependent chain: picking the single
+        # least-conflicting commit would produce a partial, wrong fix.
+        logger.error("Dependent commit chain must be resolved as a whole — "
+                     "resolve the conflict and resume with 'cve-corrector --continue'")
+        raise ConflictError("Conflict detected")
     if hashes:
         best_hash, conflicts = find_least_conflict_commit(workspace_path, hashes)
         if best_hash and conflicts < float('inf'):
@@ -667,7 +687,7 @@ def initialize_cve_workflow(
 
     if series:
         success, successful_hash, best_series = apply_series(
-            workspace_path, series)
+            workspace_path, series, require_all=config.require_all_commits)
         if success:
             # Preserve commit list for patch metadata (Upstream-Status per patch)
             for pr_series in series:
@@ -676,16 +696,22 @@ def initialize_cve_workflow(
                     applied_series = pr_series
                     break
         if not success and best_series:
+            # The strictness flag deliberately does not travel into
+            # series_state: the --continue path already applies every
+            # remaining commit and fails on the first conflict.
             _handle_failed_series(
                 workspace_path, best_series, make_state, recipe)
 
-    if not success and hashes:
+    # A dependent chain must apply in full, so never fall back to trying the
+    # commits individually — one commit alone is a partial fix.
+    if not success and hashes and not config.require_all_commits:
         success, successful_hash = apply_single_commits(
             workspace_path, hashes, subproject=subproject)
 
     if not success:
         _handle_no_clean_apply(
-            workspace_path, hashes, series, make_state, recipe)
+            workspace_path, hashes, series, make_state, recipe,
+            require_all_commits=config.require_all_commits)
 
     if config.edit_mode:
         save_workflow_state(make_state(successful_hash))

--- a/shared/url_parser.py
+++ b/shared/url_parser.py
@@ -256,6 +256,21 @@ _GIT_INDICATORS = (
 )
 
 
+def _savannah_domain(host: str) -> Optional[str]:
+    """Return ``'gnu.org'``/``'nongnu.org'`` if host is a genuine Savannah
+    host on that domain, or None otherwise (including for lookalike hosts
+    such as ``savannah.gnu.org.evil.com``).
+
+    Any subdomain depth is accepted (``git.``, ``cgit.git.``,
+    ``https.git.``, ...) since Savannah fronts the same repositories under
+    several hostnames.
+    """
+    for domain in ('savannah.gnu.org', 'savannah.nongnu.org'):
+        if host == domain or host.endswith(f'.{domain}'):
+            return domain.removeprefix('savannah.')
+    return None
+
+
 def deduce_repo_url(url: str) -> Optional[str]:
     """Deduce the git repository URL from a commit/patch URL.
 
@@ -286,23 +301,30 @@ def deduce_repo_url(url: str) -> Optional[str]:
             return f'https://sourceware.org/git/{repo_name}'
         if 'sourceware.org' in host:
             return None  # lookalike host
-        if host == 'git.savannah.gnu.org' or host.endswith('.savannah.gnu.org'):
-            return f'https://git.savannah.gnu.org/git/{repo_name}'
-        if 'savannah.gnu.org' in host:
+        savannah_domain = _savannah_domain(host)
+        if savannah_domain:
+            return f'https://https.git.savannah.{savannah_domain}/git/{repo_name}'
+        if 'savannah.' in host:
             return None  # lookalike host
         # Generic gitweb
         return f'{parsed.scheme}://{parsed.netloc}/{repo_name}'
 
-    # Savannah /cgit/ or /git/ path style
-    if host == 'git.savannah.gnu.org' or host.endswith('.savannah.gnu.org'):
+    # Savannah /cgit/ or /git/ path style, on either the gnu.org or
+    # nongnu.org Savannah instance (e.g. cgit.git.savannah.nongnu.org).
+    # Savannah's plain https://git. host 302-redirects every request to
+    # https://https.git. (its actual TLS-terminating vhost); some git/proxy
+    # configs don't follow that redirect, so build the URL against
+    # https.git. directly.
+    savannah_domain = _savannah_domain(host)
+    if savannah_domain:
         if '/cgit/' in parsed.path:
             repo_name = parsed.path.split('/cgit/')[1].split('/')[0]
         elif '/git/' in parsed.path:
             repo_name = parsed.path.split('/git/')[1].split('/')[0]
         else:
             return None
-        return f'https://git.savannah.gnu.org/git/{repo_name}'
-    if 'savannah.gnu.org' in host:
+        return f'https://https.git.savannah.{savannah_domain}/git/{repo_name}'
+    if 'savannah.' in host:
         return None  # lookalike host
 
     # Sourceware /cgit/ or /git/ path style

--- a/shared/url_parser.py
+++ b/shared/url_parser.py
@@ -334,43 +334,74 @@ def deduce_repo_url(url: str) -> Optional[str]:
     return None
 
 
-def parse_fix_url(url: str) -> dict:
-    """Parse a fix URL into hashes, hash_details, and series.
+def parse_fix_urls(urls: list[str]) -> dict:
+    """Parse one or more fix URLs into hashes, hash_details, and series.
 
-    Auto-detects commit URLs vs PR URLs.
+    Auto-detects commit URLs vs PR URLs. URLs are processed in the order
+    given and that order is preserved throughout the result: the caller
+    owns ordering, nothing is sorted here.
+
+    A single URL yields the historical single-fix shape (a commit URL
+    produces no ``series``; a PR URL produces its PR series). Two or more
+    URLs yield exactly one ``series`` entry holding every commit in caller
+    order — an ordered *dependent chain* meant to be applied as a whole,
+    with any PR commits expanded inline. Duplicate commits collapse to
+    their first occurrence.
+
+    This function is a pure parser: whether a chain *must* apply in full is
+    a caller policy (see ``WorkflowConfig.require_all_commits``), not
+    something encoded in the returned metadata.
 
     Args:
-        url: GitHub commit URL or PR URL.
+        urls: Commit and/or pull request URLs, in application order.
 
     Returns:
         Dict with keys: hashes, hash_details, series.
 
     Raises:
-        ValueError: If no hash or PR commits could be extracted.
+        ValueError: If ``urls`` is empty, or if any single URL yields no
+            commits (the offending URL is named in the message).
     """
-    clean_url = url.split('#')[0]
+    if not urls:
+        raise ValueError("No fix URLs provided")
 
-    # PR URL
-    if _PR_RE.match(clean_url):
-        commits = fetch_github_pr_commits(url)
-        if not commits:
-            raise ValueError(
-                f"Could not extract commits from PR: {url}")
-        return {
-            'hashes': commits,
-            'hash_details': [{'hash': h, 'url': clean_url, 'source': 'cli'}
-                             for h in commits],
-            'series': [{'pull_url': clean_url, 'commits': commits}],
-        }
+    commits: list[str] = []
+    origin_url: dict[str, str] = {}
+    pr_urls: list[str] = []
 
-    # Commit URL
-    commit_hash = extract_commit_hash(url)
-    if commit_hash:
-        return {
-            'hashes': [commit_hash],
-            'hash_details': [{'hash': commit_hash, 'url': url,
-                              'source': 'cli'}],
-            'series': [],
-        }
+    def _record(commit_hash: str, url: str) -> None:
+        """Append a commit, keeping the first occurrence's originating URL."""
+        if commit_hash not in origin_url:
+            origin_url[commit_hash] = url
+            commits.append(commit_hash)
 
-    raise ValueError(f"Could not extract commit hash from URL: {url}")
+    for url in urls:
+        clean_url = url.split('#')[0]
+
+        # PR URL — expand to its commits, inline and in PR order.
+        if _PR_RE.match(clean_url):
+            pr_commits = fetch_github_pr_commits(url)
+            if not pr_commits:
+                raise ValueError(f"Could not extract commits from PR: {url}")
+            pr_urls.append(clean_url)
+            for commit_hash in pr_commits:
+                _record(commit_hash, clean_url)
+            continue
+
+        # Commit URL
+        single_hash = extract_commit_hash(url)
+        if not single_hash:
+            raise ValueError(f"Could not extract commit hash from URL: {url}")
+        _record(single_hash, url)
+
+    # One series entry when the commits form an ordered chain: either the
+    # caller passed several URLs, or a PR already defines a chain.
+    series = ([{'pull_url': pr_urls[0] if pr_urls else '', 'commits': commits}]
+              if len(urls) > 1 or pr_urls else [])
+
+    return {
+        'hashes': commits,
+        'hash_details': [{'hash': h, 'url': origin_url[h], 'source': 'cli'}
+                         for h in commits],
+        'series': series,
+    }

--- a/tests/agent/test_main.py
+++ b/tests/agent/test_main.py
@@ -424,6 +424,66 @@ class TestConfigFromArgs:
         assert cfg.trust_mode is True
 
 
+class TestRepeatableFixUrlCli:
+    """Argparse-level coverage for repeatable --fix-url in the agent CLI."""
+
+    ACL_URLS = [
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=5906d2868ec8d3b08be556153696e6b1122eeeda",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=0071c6d1fea0a8a6270333baa85fb609be325c26",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c",
+    ]
+
+    def test_multiple_fix_url_collected_in_order(self, monkeypatch):
+        from cve_agent.__main__ import _parse_args
+        argv = ['cve-agent', '--cve-id', 'CVE-2025-0001', '--recipe', 'acl']
+        for url in self.ACL_URLS:
+            argv += ['--fix-url', url]
+        monkeypatch.setattr('sys.argv', argv)
+        args = _parse_args()
+        assert args.fix_urls == self.ACL_URLS
+
+    def test_no_fix_url_defaults_to_empty_list(self, monkeypatch):
+        from cve_agent.__main__ import _parse_args
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', '/tmp/c.json'])
+        args = _parse_args()
+        assert args.fix_urls == []
+
+    def test_missing_cve_info_and_fix_url_is_agent_error(self, monkeypatch):
+        from cve_agent import EXIT_AGENT_ERROR
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', ['cve-agent', '--cve-id', 'CVE-2025-0001'])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == EXIT_AGENT_ERROR
+
+    def test_fix_url_without_recipe_or_cve_info_is_agent_error(self, monkeypatch):
+        from cve_agent import EXIT_AGENT_ERROR
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--fix-url', self.ACL_URLS[0], '--fix-url', self.ACL_URLS[1]])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == EXIT_AGENT_ERROR
+
+    def test_fix_urls_passed_through_as_list(self):
+        """Repeatable --fix-url values reach AgentConfig.fix_urls unchanged."""
+        urls = ["https://github.com/o/r/commit/aaa1111",
+                "https://github.com/o/r/commit/bbb2222"]
+        args = MagicMock(
+            cve_id="CVE-1", cve_info=None, trust=False,
+            max_retries=3, mirror_dir=None, meta_layer=None,
+            skip_ptest=False, clean=False, model="m", session_timeout=600,
+            fix_urls=urls, recipe="foo", skip_sources=[])
+        cfg = _config_from_args(args, "CVE-1")
+        assert cfg.fix_urls == urls
+
+
 class TestSigintHandler:
     def test_empty_results(self):
         handler = _sigint_handler([])

--- a/tests/agent/test_main_process.py
+++ b/tests/agent/test_main_process.py
@@ -81,6 +81,41 @@ class TestProcessSingleCve:
 
     @patch("cve_agent.__main__._log_result")
     @patch("cve_agent.orchestrator.get_workspace_path", return_value=None)
+    @patch("cve_agent.orchestrator.run_corrector", return_value=(0, ""))
+    def test_multiple_fix_urls_build_one_dependent_series(
+            self, mock_run, mock_ws, mock_log, tmp_path):
+        """Three --fix-url values merge into one series consumed by the workflow."""
+        urls = [
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=5906d2868ec8d3b08be556153696e6b1122eeeda",
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=0071c6d1fea0a8a6270333baa85fb609be325c26",
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c",
+        ]
+        cfg = _cfg(cve_info_path=None, fix_urls=urls, recipe="acl")
+        result = process_single_cve(cfg, KnowledgeBase(tmp_path / "kb.json"))
+        assert result.status == ResultStatus.SUCCESS
+        expected_hashes = [
+            '5906d2868ec8d3b08be556153696e6b1122eeeda',
+            '0071c6d1fea0a8a6270333baa85fb609be325c26',
+            '170dbd3beff9bd5bdab3f72db1a04bf282f6087c']
+        cve_data_arg = mock_ws.call_args[0][1]
+        cve_info = cve_data_arg[cfg.cve_id]
+        assert cve_info['hashes'] == expected_hashes
+        assert cve_info['series'] == [{'pull_url': '', 'commits': expected_hashes}]
+
+    @patch("cve_agent.__main__._log_result")
+    def test_single_fix_url_without_recipe_fails(self, mock_log, tmp_path):
+        cfg = _cfg(cve_info_path=None,
+                   fix_urls=['https://github.com/o/r/commit/abc123'],
+                   recipe=None)
+        result = process_single_cve(cfg, KnowledgeBase(tmp_path / "kb.json"))
+        assert result.status == ResultStatus.FAILED
+        assert "No --cve-info or --fix-url" in result.resolution_summary
+
+    @patch("cve_agent.__main__._log_result")
+    @patch("cve_agent.orchestrator.get_workspace_path", return_value=None)
     @patch("cve_agent.orchestrator.run_corrector", return_value=(2, ""))
     @patch("cve_agent.orchestrator.load_cve_metadata",
            return_value={"CVE-2025-0001": {"name": "r"}})

--- a/tests/agent/test_security.py
+++ b/tests/agent/test_security.py
@@ -408,5 +408,70 @@ class TestSkipSourceForwarding:
             proc.__exit__ = MagicMock(return_value=False)
             mock_popen.return_value = proc
             run_corrector(config)
+
+
+class TestRepeatableFixUrlForwarding:
+    """--fix-url is repeatable end-to-end: AgentConfig.fix_urls -> corrector CLI."""
+
+    def test_fix_urls_forwarded_in_order(self):
+        from cve_agent import AgentConfig
+        from cve_agent.corrector import run_corrector
+        urls = [
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=5906d2868ec8d3b08be556153696e6b1122eeeda",
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=0071c6d1fea0a8a6270333baa85fb609be325c26",
+            "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+            "?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c",
+        ]
+        config = AgentConfig(cve_id='CVE-2025-0001', recipe='acl', fix_urls=urls)
+        with patch('subprocess.Popen') as mock_popen:
+            proc = MagicMock()
+            proc.stdout = iter([])
+            proc.wait.return_value = None
+            proc.returncode = 0
+            proc.__enter__ = lambda s: s
+            proc.__exit__ = MagicMock(return_value=False)
+            mock_popen.return_value = proc
+            run_corrector(config)
+            cmd = mock_popen.call_args[0][0]
+            assert cmd.count('--fix-url') == 3
+            # Order preserved: each --fix-url is immediately followed by its URL,
+            # in the same order as config.fix_urls.
+            got = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == '--fix-url']
+            assert got == urls
+
+    def test_single_fix_url_unchanged(self):
+        from cve_agent import AgentConfig
+        from cve_agent.corrector import run_corrector
+        config = AgentConfig(cve_id='CVE-2025-0001', recipe='acl',
+                             fix_urls=['https://github.com/o/r/commit/abc123'])
+        with patch('subprocess.Popen') as mock_popen:
+            proc = MagicMock()
+            proc.stdout = iter([])
+            proc.wait.return_value = None
+            proc.returncode = 0
+            proc.__enter__ = lambda s: s
+            proc.__exit__ = MagicMock(return_value=False)
+            mock_popen.return_value = proc
+            run_corrector(config)
+            cmd = mock_popen.call_args[0][0]
+            assert cmd.count('--fix-url') == 1
+
+    def test_no_fix_urls_omits_flag(self):
+        from cve_agent import AgentConfig
+        from cve_agent.corrector import run_corrector
+        config = AgentConfig(cve_id='CVE-2025-0001', cve_info_path=Path('/tmp/c.json'))
+        with patch('subprocess.Popen') as mock_popen:
+            proc = MagicMock()
+            proc.stdout = iter([])
+            proc.wait.return_value = None
+            proc.returncode = 0
+            proc.__enter__ = lambda s: s
+            proc.__exit__ = MagicMock(return_value=False)
+            mock_popen.return_value = proc
+            run_corrector(config)
+            cmd = mock_popen.call_args[0][0]
+            assert '--fix-url' not in cmd
             cmd = mock_popen.call_args[0][0]
             assert '--skip-source' not in cmd

--- a/tests/corrector/test_blame.py
+++ b/tests/corrector/test_blame.py
@@ -170,6 +170,35 @@ class TestBlameLineRanges:
         commits = blame_line_ranges(repo, {'file.c': [(1, 5)]})
         assert initial_hash in commits
 
+    def test_new_file_blame_failure_logged_as_debug(self, tmp_path, caplog):
+        """Blaming a file at a revision before it was added should log at
+        debug level (expected, harmless) rather than warning.
+
+        Reproduces the noisy "git blame failed ... no such path" warnings
+        seen when a fix commit both modifies existing files and adds new
+        ones (e.g. acl's *_at.c variants) — blaming the new file against
+        its own parent revision always fails since the path didn't exist
+        yet, which is not a genuine error.
+        """
+        repo = _init_repo(tmp_path)
+        # Add a brand-new file in a second commit.
+        (repo / 'new_file.c').write_text('a\nb\nc\n')
+        _git(repo, 'add', 'new_file.c')
+        _git(repo, 'commit', '-m', 'add new file')
+        new_hash = _git(repo, 'rev-parse', 'HEAD')
+
+        import logging
+        with caplog.at_level(logging.DEBUG):
+            commits = blame_line_ranges(
+                repo, {'new_file.c': [(1, 3)]},
+                file_revisions={'new_file.c': f'{new_hash}~1'})
+
+        assert commits == set()
+        warning_records = [r for r in caplog.records if r.levelname == 'WARNING']
+        debug_records = [r for r in caplog.records if r.levelname == 'DEBUG']
+        assert not warning_records
+        assert any('no such path' in r.message for r in debug_records)
+
 
 # --- _tag_to_version_str ---
 

--- a/tests/corrector/test_dependent_chain.py
+++ b/tests/corrector/test_dependent_chain.py
@@ -1,0 +1,217 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for dependent commit chains declared with repeated --fix-url.
+
+Covers the acl-style case where a CVE is fixed by several dependent upstream
+commits that must all be applied, in the order given on the command line.
+"""
+import json
+
+import pytest
+
+from cve_corrector import cherry_pick as cherry_pick_mod
+from cve_corrector import workflow as workflow_mod
+from cve_corrector.cherry_pick import apply_series
+from cve_corrector.state import EXIT_CONFLICT, ConflictError
+from cve_corrector.workflow import WorkflowConfig, _handle_no_clean_apply
+from tests.helpers import assert_patch_naming, run_workflow
+
+CHAIN = ['a' * 40, 'b' * 40, 'c' * 40]
+
+
+class TestApplySeriesRequireAll:
+    """apply_series must surface conflict state for a required chain."""
+
+    @staticmethod
+    def _fake_git(monkeypatch, tmp_path, failing_hash):
+        """Make cherry-pick fail, leaving CHERRY_PICK_HEAD at failing_hash."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.git' / 'CHERRY_PICK_HEAD').write_text(failing_hash + '\n')
+
+        def fake_run_cmd(cmd, cwd=None, **kwargs):
+            # Non-zero only for the batch cherry-pick itself.
+            if cmd[:2] == ['git', 'cherry-pick'] and '--abort' not in cmd:
+                return 1
+            return 0
+
+        monkeypatch.setattr(cherry_pick_mod, 'run_cmd', fake_run_cmd)
+        monkeypatch.setattr(cherry_pick_mod, 'is_bad_object',
+                            lambda *a, **kw: False)
+
+    def test_conflict_on_first_commit_reports_state(self, tmp_path, monkeypatch):
+        """Regression: a chain failing on commit 1 of 3 must not be lost.
+
+        With ``max_applied`` starting at 0, ``len([]) > 0`` was False, so
+        best_series stayed None and the caller silently fell back to applying
+        a single commit — a partial, wrong fix.
+        """
+        self._fake_git(monkeypatch, tmp_path, CHAIN[0])
+        series = [{'pull_url': '', 'commits': CHAIN}]
+
+        success, last, best = apply_series(tmp_path, series, require_all=True)
+
+        assert success is False
+        assert last is None
+        assert best is not None, "required chain lost its conflict state"
+        assert best['applied_commits'] == []
+        assert best['failed_at'] == CHAIN[0]
+        assert best['remaining_commits'] == CHAIN[1:]
+        assert best['commits'] == CHAIN
+
+    def test_conflict_on_first_commit_without_require_all_unchanged(
+            self, tmp_path, monkeypatch):
+        """Candidate (PR) series keep their existing fallback behaviour."""
+        self._fake_git(monkeypatch, tmp_path, CHAIN[0])
+        series = [{'pull_url': 'https://github.com/o/r/pull/1',
+                   'commits': CHAIN}]
+
+        success, last, best = apply_series(tmp_path, series)
+
+        assert (success, last, best) == (False, None, None)
+
+    def test_partial_progress_still_reported(self, tmp_path, monkeypatch):
+        """A chain failing mid-way reports what was applied."""
+        self._fake_git(monkeypatch, tmp_path, CHAIN[1])
+        series = [{'pull_url': '', 'commits': CHAIN}]
+
+        _, _, best = apply_series(tmp_path, series, require_all=True)
+
+        assert best['applied_commits'] == [CHAIN[0]]
+        assert best['failed_at'] == CHAIN[1]
+        assert best['remaining_commits'] == [CHAIN[2]]
+
+
+class TestHandleNoCleanApply:
+    """A required chain never degrades to a single least-conflict commit."""
+
+    def test_require_all_skips_least_conflict(self, monkeypatch, tmp_path):
+        calls = []
+        monkeypatch.setattr(workflow_mod, 'find_least_conflict_commit',
+                            lambda *a, **kw: calls.append(a) or ('x', 0))
+
+        with pytest.raises(ConflictError):
+            _handle_no_clean_apply(tmp_path, CHAIN, [], lambda *a: None, 'acl',
+                                   require_all_commits=True)
+
+        assert calls == [], "least-conflict pick must not run for a chain"
+
+    def test_without_require_all_uses_least_conflict(self, monkeypatch, tmp_path):
+        calls = []
+        monkeypatch.setattr(workflow_mod, 'find_least_conflict_commit',
+                            lambda *a, **kw: (calls.append(a), (CHAIN[0], 1))[1])
+        monkeypatch.setattr(workflow_mod, 'run_cmd', lambda *a, **kw: 0)
+        monkeypatch.setattr(workflow_mod, 'save_workflow_state', lambda s: None)
+        monkeypatch.setattr(workflow_mod, 'print_conflict_instructions',
+                            lambda *a, **kw: None)
+
+        with pytest.raises(ConflictError):
+            _handle_no_clean_apply(tmp_path, CHAIN, [], lambda *a: None, 'acl')
+
+        assert len(calls) == 1
+
+
+class TestWorkflowConfigDefault:
+    def test_require_all_commits_defaults_false(self):
+        config = WorkflowConfig(
+            mirror_path=None, mirror_dir=None, meta_layer=None,
+            skip_build=True, clean=False, skip_ptest=True, edit_mode=False)
+        assert config.require_all_commits is False
+
+
+class TestDependentChainEndToEnd:
+    """Full workflow with a three-commit dependent chain."""
+
+    @staticmethod
+    def _chain_repo(make_upstream_repo, make_workspace, conflicting=False):
+        """Upstream with 3 dependent commits touching the same file."""
+        bare, hashes = make_upstream_repo(
+            files={'libacl/acl_copy.c': 'v0\nshared\ntail\n'},
+            version_tag='v2.3.1',
+            fix_commits=[
+                {'files': {'libacl/acl_copy.c': 'fix1\nshared\ntail\n'},
+                 'message': 'Fix buffer overflow'},
+                {'files': {'libacl/acl_copy.c': 'fix1\nshared\nfix2\n'},
+                 'message': 'Follow-up: guard length'},
+                {'files': {'libacl/acl_copy.c': 'fix1\nfix3\nfix2\n'},
+                 'message': 'Follow-up: harden copy'},
+            ])
+        existing = None
+        if conflicting:
+            # Recipe patch rewrites the first line the chain depends on.
+            existing = [{'files': {'libacl/acl_copy.c': 'distro\nshared\ntail\n'},
+                         'message': 'Existing recipe patch'}]
+        ws = make_workspace(bare, 'acl', 'v2.3.1',
+                            existing_patch_commits=existing)
+        return ws, hashes
+
+    @staticmethod
+    def _cve_data(cve_id, hashes):
+        """Metadata as parse_fix_urls() would build it from 3 --fix-url values."""
+        return {cve_id: {
+            'name': 'acl',
+            'hashes': hashes,
+            'hash_details': [
+                {'hash': h,
+                 'url': 'https://cgit.git.savannah.nongnu.org/cgit/acl.git/'
+                        f'commit/?id={h}',
+                 'source': 'cli'} for h in hashes],
+            'series': [{'pull_url': '', 'commits': hashes}]}}
+
+    def test_all_commits_applied(self, make_upstream_repo, make_workspace,
+                                 make_meta_layer, mock_bitbake_env):
+        ws, hashes = self._chain_repo(make_upstream_repo, make_workspace)
+        meta = make_meta_layer('acl', '2.3.1')
+        mock_bitbake_env(ws, meta, 'acl', '2.3.1')
+
+        cve_id = 'CVE-2026-99001'
+        config = WorkflowConfig(
+            mirror_path=None, mirror_dir=None, meta_layer=meta,
+            skip_build=True, clean=False, skip_ptest=True,
+            edit_mode=False, skip_cve_applicability=True,
+            require_all_commits=True)
+
+        exit_code = run_workflow(self._cve_data(cve_id, hashes), cve_id, config)
+
+        assert exit_code == 0
+        # All three commits produce patches, numbered in application order.
+        assert_patch_naming(meta, cve_id, expect_series=True)
+        patches = sorted(meta.rglob(f'*{cve_id}*.patch'))
+        assert len(patches) == 3
+        # Every patch of the chain keeps its CVE tag.
+        for patch in patches:
+            assert f'CVE: {cve_id}' in patch.read_text()
+
+    def test_conflict_never_falls_back_to_single_commit(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, monkeypatch):
+        ws, hashes = self._chain_repo(make_upstream_repo, make_workspace,
+                                      conflicting=True)
+        meta = make_meta_layer('acl', '2.3.1')
+        mock_bitbake_env(ws, meta, 'acl', '2.3.1')
+
+        single_calls, least_calls = [], []
+        monkeypatch.setattr(
+            workflow_mod, 'apply_single_commits',
+            lambda *a, **kw: (single_calls.append(a), (False, None))[1])
+        monkeypatch.setattr(
+            workflow_mod, 'find_least_conflict_commit',
+            lambda *a, **kw: (least_calls.append(a), (None, float('inf')))[1])
+
+        cve_id = 'CVE-2026-99002'
+        config = WorkflowConfig(
+            mirror_path=None, mirror_dir=None, meta_layer=meta,
+            skip_build=True, clean=False, skip_ptest=True,
+            edit_mode=False, skip_cve_applicability=True,
+            require_all_commits=True)
+
+        exit_code = run_workflow(self._cve_data(cve_id, hashes), cve_id, config)
+
+        assert exit_code == EXIT_CONFLICT
+        assert single_calls == [], "chain must not fall back to one commit"
+        assert least_calls == [], "chain must not pick a least-conflict commit"
+
+        # Conflict state records the whole chain so --continue resumes it.
+        state_files = list((ws.parent.parent / 'cve_corrector').glob('*.json'))
+        assert state_files, "no state file saved for resume"
+        state = json.loads(state_files[0].read_text())
+        assert state['series_state']['commits'] == hashes

--- a/tests/corrector/test_git_ops.py
+++ b/tests/corrector/test_git_ops.py
@@ -46,7 +46,7 @@ def test_deduce_repo_rejects_sourceware_lookalike_host():
 def test_deduce_repo_savannah_cgit():
     url = "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=abc123"
     result = deduce_repo_from_patches([url])
-    assert result == "https://git.savannah.gnu.org/git/grub.git"
+    assert result == "https://https.git.savannah.gnu.org/git/grub.git"
 
 
 def test_deduce_repo_savannah_git():

--- a/tests/corrector/test_main_cli.py
+++ b/tests/corrector/test_main_cli.py
@@ -115,6 +115,83 @@ class TestMainCli:
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert exc_info.value.code == 6  # EXIT_METADATA_ERROR
+
+
+class TestRepeatableFixUrl:
+    """--fix-url is repeatable; N>1 values form one dependent chain."""
+
+    ACL_URLS = [
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=5906d2868ec8d3b08be556153696e6b1122eeeda",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=0071c6d1fea0a8a6270333baa85fb609be325c26",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c",
+    ]
+
+    def test_single_fix_url_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-corrector', '--cve-id', 'CVE-2025-0001',
+            '--recipe', 'foo', '--fix-url', self.ACL_URLS[0],
+            '--dry-run', '--meta-layer', str(tmp_path)])
+        captured = []
+        with patch('builtins.print', lambda *a, **k: captured.append(' '.join(map(str, a)))):
+            main()
+        joined = '\n'.join(captured)
+        assert 'Commits:    1' in joined
+        assert 'Series:     0' in joined
+        assert 'Dependent:' not in joined
+
+    def test_three_fix_urls_form_one_dependent_series(self, tmp_path, monkeypatch):
+        argv = ['cve-corrector', '--cve-id', 'CVE-2025-0002',
+                '--recipe', 'acl', '--dry-run', '--meta-layer', str(tmp_path)]
+        for url in self.ACL_URLS:
+            argv += ['--fix-url', url]
+        monkeypatch.setattr('sys.argv', argv)
+
+        captured = []
+        with patch('builtins.print', lambda *a, **k: captured.append(' '.join(map(str, a)))):
+            main()
+        joined = '\n'.join(captured)
+        assert 'Commits:    3' in joined
+        assert 'Series:     1' in joined
+        assert 'Dependent:  yes' in joined
+
+    def test_multiple_fix_urls_replace_stale_json_series(self, tmp_path, monkeypatch):
+        """N>1 --fix-url values must win over a stale series in --cve-info."""
+        cve_info = tmp_path / 'cve.json'
+        cve_info.write_text(json.dumps({
+            'CVE-2025-0003': {
+                'name': 'acl',
+                'hashes': ['stale1'],
+                'series': [{'pull_url': 'https://old', 'commits': ['stale1']}],
+            }
+        }))
+        argv = ['cve-corrector', '--cve-id', 'CVE-2025-0003',
+                '--cve-info', str(cve_info), '--dry-run',
+                '--meta-layer', str(tmp_path)]
+        for url in self.ACL_URLS:
+            argv += ['--fix-url', url]
+        monkeypatch.setattr('sys.argv', argv)
+
+        captured = []
+        with patch('builtins.print', lambda *a, **k: captured.append(' '.join(map(str, a)))):
+            main()
+        joined = '\n'.join(captured)
+        assert 'Commits:    3' in joined
+        assert 'stale1' not in joined
+
+    def test_bad_url_among_many_reports_parser_error(self, tmp_path, monkeypatch, capsys):
+        argv = ['cve-corrector', '--cve-id', 'CVE-2025-0004',
+                '--recipe', 'acl', '--dry-run', '--meta-layer', str(tmp_path),
+                '--fix-url', self.ACL_URLS[0],
+                '--fix-url', 'https://example.com/no-hash-here']
+        monkeypatch.setattr('sys.argv', argv)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 2  # argparse.error() exit code
+        assert 'no-hash-here' in capsys.readouterr().err
+
     def test_already_applied_skips_meta_layer_deduction(self, tmp_path, monkeypatch):
         """The SRC_URI already-applied check must run before — and skip —
         the (expensive) meta-layer deduction step."""

--- a/tests/shared/test_url_parser.py
+++ b/tests/shared/test_url_parser.py
@@ -408,7 +408,16 @@ class TestDeduceRepoUrl:
 
     def test_savannah_cgit_still_works(self):
         url = "https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=abc1234"
-        assert deduce_repo_url(url) == "https://git.savannah.gnu.org/git/coreutils.git"
+        assert deduce_repo_url(url) == "https://https.git.savannah.gnu.org/git/coreutils.git"
+
+    def test_savannah_nongnu_cgit_subdomain(self):
+        url = ("https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+               "?id=abc1234")
+        assert deduce_repo_url(url) == "https://https.git.savannah.nongnu.org/git/acl.git"
+
+    def test_savannah_nongnu_lookalike_host_rejected(self):
+        url = "https://git.savannah.nongnu.org.evil.com/cgit/acl.git/commit/?id=abc1234"
+        assert deduce_repo_url(url) is None
 
     def test_github_commit_url(self):
         url = "https://github.com/owner/repo/commit/abc1234"

--- a/tests/shared/test_url_parser.py
+++ b/tests/shared/test_url_parser.py
@@ -11,7 +11,7 @@ from shared.url_parser import (
     extract_commit_hash,
     fetch_github_pr_commits,
     fetch_gitlab_issue_commits,
-    parse_fix_url,
+    parse_fix_urls,
 )
 
 
@@ -234,10 +234,19 @@ class TestFetchGithubPrCommits:
         assert result == []
 
 
-class TestParseFixUrl:
+class TestParseFixUrls:
+    ACL_URLS = [
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=5906d2868ec8d3b08be556153696e6b1122eeeda",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=0071c6d1fea0a8a6270333baa85fb609be325c26",
+        "https://cgit.git.savannah.nongnu.org/cgit/acl.git/commit/"
+        "?id=170dbd3beff9bd5bdab3f72db1a04bf282f6087c",
+    ]
+
     def test_commit_url(self):
         url = "https://github.com/openssh/openssh-portable/commit/76685c9b09a66"
-        result = parse_fix_url(url)
+        result = parse_fix_urls([url])
         assert result['hashes'] == ['76685c9b09a66']
         assert result['hash_details'] == [
             {'hash': '76685c9b09a66', 'url': url, 'source': 'cli'}]
@@ -247,7 +256,7 @@ class TestParseFixUrl:
     def test_pr_url(self, mock_fetch):
         mock_fetch.return_value = ['aaa', 'bbb', 'ccc']
         url = "https://github.com/owner/repo/pull/99"
-        result = parse_fix_url(url)
+        result = parse_fix_urls([url])
         assert result['hashes'] == ['aaa', 'bbb', 'ccc']
         assert result['series'] == [
             {'pull_url': url, 'commits': ['aaa', 'bbb', 'ccc']}]
@@ -257,11 +266,59 @@ class TestParseFixUrl:
     def test_pr_url_no_commits_raises(self, mock_fetch):
         mock_fetch.return_value = []
         with pytest.raises(ValueError, match="Could not extract commits"):
-            parse_fix_url("https://github.com/owner/repo/pull/99")
+            parse_fix_urls(["https://github.com/owner/repo/pull/99"])
 
     def test_invalid_url_raises(self):
         with pytest.raises(ValueError, match="Could not extract commit hash"):
-            parse_fix_url("https://example.com/no-hash-here")
+            parse_fix_urls(["https://example.com/no-hash-here"])
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="No fix URLs provided"):
+            parse_fix_urls([])
+
+    def test_dependent_commit_chain_preserves_cli_order(self):
+        """Three dependent commit URLs become one ordered series (acl case)."""
+        result = parse_fix_urls(self.ACL_URLS)
+        expected = ['5906d2868ec8d3b08be556153696e6b1122eeeda',
+                    '0071c6d1fea0a8a6270333baa85fb609be325c26',
+                    '170dbd3beff9bd5bdab3f72db1a04bf282f6087c']
+        assert result['hashes'] == expected
+        assert result['series'] == [{'pull_url': '', 'commits': expected}]
+        assert [d['hash'] for d in result['hash_details']] == expected
+        assert all(d['source'] == 'cli' for d in result['hash_details'])
+        assert [d['url'] for d in result['hash_details']] == self.ACL_URLS
+
+    def test_reversed_order_is_not_sorted(self):
+        """Caller owns ordering — nothing is reordered."""
+        result = parse_fix_urls(list(reversed(self.ACL_URLS)))
+        assert result['hashes'] == [
+            '170dbd3beff9bd5bdab3f72db1a04bf282f6087c',
+            '0071c6d1fea0a8a6270333baa85fb609be325c26',
+            '5906d2868ec8d3b08be556153696e6b1122eeeda']
+
+    @patch('shared.url_parser.fetch_github_pr_commits')
+    def test_mixed_pr_and_commit_urls_merge_inline(self, mock_fetch):
+        mock_fetch.return_value = ['aaa1234', 'bbb1234']
+        pr_url = "https://github.com/owner/repo/pull/7"
+        commit_url = "https://github.com/owner/repo/commit/ccc1234"
+        result = parse_fix_urls([pr_url, commit_url])
+        assert result['hashes'] == ['aaa1234', 'bbb1234', 'ccc1234']
+        assert result['series'] == [
+            {'pull_url': pr_url,
+             'commits': ['aaa1234', 'bbb1234', 'ccc1234']}]
+
+    def test_duplicate_urls_collapse(self):
+        url = "https://github.com/owner/repo/commit/abc1234"
+        result = parse_fix_urls([url, url])
+        assert result['hashes'] == ['abc1234']
+        assert result['hash_details'] == [
+            {'hash': 'abc1234', 'url': url, 'source': 'cli'}]
+
+    def test_second_bad_url_raises_naming_it(self):
+        good = "https://github.com/owner/repo/commit/abc1234"
+        bad = "https://example.com/no-hash-here"
+        with pytest.raises(ValueError, match="no-hash-here"):
+            parse_fix_urls([good, bad])
 
 
 class TestFetchGitlabIssueCommits:


### PR DESCRIPTION
Description:
  
  Adds support for CVEs fixed by a short series of dependent follow-up
  commits (e.g. acl's CVE-2026-XXXXX), where all commits must apply in
  order or the run stops at a conflict — and fixes two issues surfaced
  while exercising that path end-to-end against the real acl repo.
  
  Changes
  
  1. corrector,agent: support repeated --fix-url as dependent chain
    - --fix-url is now repeatable on both cve-corrector and cve-agent. A single URL keeps today's behavior; two or more are merged into one ordered series (PR commits
  expanded inline) that must apply in full, in caller-given order — partial application is reported as a conflict rather than silently falling back to a single commit or
  the least-conflicting one.
    - shared/url_parser: replaced parse_fix_url() with parse_fix_urls(), a pure parser with no policy baked in.
    - cve_corrector: added WorkflowConfig.require_all_commits to gate the single-commit/least-conflict fallbacks; fixed apply_series() losing conflict state when the first
  commit in a required chain fails (previously max_applied started at 0, so 0 applied commits never beat it).
    - cve_agent: AgentConfig.fix_url → fix_urls (list), forwarded to cve-corrector as repeated --fix-url flags in order.
    - Documented the acl CVE-2026-XXXXX use case in the README.
  
  2. Fix Savannah URL deduction to use https.git. host, cover nongnu.org
    - Savannah's plain https://git.<domain> host 302-redirects every request to https://https.git.<domain> (its TLS-terminating vhost); some git/proxy configs don't follow
  redirects, so build repo URLs against https.git. directly.
    - Also handles savannah.nongnu.org (e.g. cgit.git.savannah.nongnu.org, used by acl's fix commits), previously unmatched and left as an unrewritten raw cgit URL.
  
  3. Downgrade blame warnings for newly-added files to debug
    - git blame on a file that didn't exist at <commit>~1 (fix commit both modifies existing files and adds new ones) always fails with "no such path" — expected and
  harmless, not a genuine blame failure. Logged at debug instead of warning now; other failure reasons still warn.
    - Surfaced by acl's fix series, where the *_at.c variants and their man pages are new files introduced by the fix commits themselves.
  
  Testing
  
  - New: tests/corrector/test_dependent_chain.py, plus additions to tests/shared/test_url_parser.py, tests/corrector/test_main_cli.py, tests/agent/test_main.py,
  tests/agent/test_main_process.py, tests/agent/test_security.py, tests/corrector/test_blame.py.
  - ruff check ., mypy cve_agent cve_corrector cve_metadata_extractor shared, and pytest --cov all pass (1099 passed, 7 skipped, 78.6% coverage, threshold 65%).
  - Manually exercised against the real acl CVE-2026-XXXXX commit chain end-to-end.