### PR TITLE
corrector: fix ptest handling and git-vs-tarball build failures

### DIFF
--- a/cve_corrector/git_ops.py
+++ b/cve_corrector/git_ops.py
@@ -289,6 +289,103 @@ def copy_missing_files_from_devtool(workspace_path: Path) -> None:
     run_cmd_capture(['git', 'reset', 'HEAD'] + missing, cwd=workspace_path)
 
 
+def remove_git_only_build_triggers(workspace_path: Path) -> None:
+    """Remove files that exist in the git tree but not in the tarball and
+    that act as build-system triggers for additional dependencies.
+
+    Some projects (e.g. gnutls) distinguish git checkouts from release
+    tarballs by testing for sentinel files in ``configure.ac``. For
+    example, gnutls checks:
+
+        SUITE_FILE="${srcdir}/tests/suite/prime-check.c"
+        if test "$full_test_suite" = yes && test ! -f "$SUITE_FILE"; then
+            full_test_suite=no
+        fi
+
+    When the file exists (git checkout), the full test suite is enabled and
+    libev4 becomes a hard requirement — a dependency the OE recipe does not
+    provide because it expects tarball builds where the file is absent.
+
+    This function:
+    1. Parses ``configure.ac`` for file-existence checks (``test -f`` /
+       ``test ! -f`` patterns referencing ``$SUITE_FILE``-style variables
+       or literal paths).
+    2. Identifies which referenced files exist in the git tree (HEAD) but
+       NOT in the devtool branch (tarball).
+    3. Removes those files from the working tree (filesystem delete only)
+       so the build system behaves as it would with the release tarball.
+       The git index is left untouched — the file remains "tracked" — so
+       ``git checkout .`` can safely restore it later (e.g. before
+       ``devtool finish``). The function is idempotent and can be called
+       again after a restore.
+
+    This is safe because:
+    - The files are NOT part of the release tarball, so the recipe never
+      expected them to be present.
+    - Only the working tree is modified — the git index and history are
+      untouched, so cherry-picks and ``git checkout .`` work normally.
+    - If a CVE fix cherry-pick needs one of these files, it will re-add
+      the file as part of its own commit.
+    - The function is called before each build step and is idempotent.
+    """
+    configure_ac = workspace_path / 'configure.ac'
+    if not configure_ac.exists():
+        return
+
+    # Parse configure.ac to find file-existence checks and variable assignments
+    content = configure_ac.read_text(errors='replace')
+    trigger_files: set[str] = set()
+
+    # Collect variable assignments like SUITE_FILE="${srcdir}/tests/suite/prime-check.c"
+    var_pattern = re.compile(
+        r'^([A-Z_][A-Z_0-9]*)=["\']?\$\{srcdir\}/([^"\'}\s]+)["\']?',
+        re.MULTILINE,
+    )
+    vars_to_paths: dict[str, str] = {}
+    for m in var_pattern.finditer(content):
+        vars_to_paths[m.group(1)] = m.group(2)
+
+    # Find "test -f" / "test ! -f" checks referencing these variables
+    test_f_var = re.compile(r'test\s+!?\s*-f\s+["\']?\$\{?([A-Z_][A-Z_0-9]*)\}?["\']?')
+    for m in test_f_var.finditer(content):
+        varname = m.group(1)
+        if varname in vars_to_paths:
+            trigger_files.add(vars_to_paths[varname])
+
+    # Also find direct literal path checks: test -f "${srcdir}/some/path"
+    test_f_literal = re.compile(
+        r'test\s+!?\s*-f\s+["\']?\$\{srcdir\}/([^"\'}\s]+)["\']?'
+    )
+    for m in test_f_literal.finditer(content):
+        trigger_files.add(m.group(1))
+
+    if not trigger_files:
+        return
+
+    # Get the set of files in the devtool branch (tarball representation)
+    devtool_files = run_cmd_capture(
+        ['git', 'ls-tree', '-r', '--name-only', 'devtool'], cwd=workspace_path)
+    if devtool_files.returncode != 0:
+        return
+    tarball_set = set(devtool_files.stdout.strip().splitlines())
+
+    # Remove trigger files that are git-only (not in tarball)
+    removed = []
+    for filepath in sorted(trigger_files):
+        if filepath in tarball_set:
+            continue  # File exists in tarball too — recipe expects it
+        full_path = workspace_path / filepath
+        if full_path.exists():
+            full_path.unlink()
+            removed.append(filepath)
+
+    if removed:
+        logger.info(
+            "Removed %d git-only build trigger(s) absent from tarball: %s",
+            len(removed), ', '.join(removed),
+        )
+
+
 def git_clean_workspace(workspace_path: Path, remove_ignored: bool = False) -> None:
     """Clean untracked files from workspace, preserving oe-local-files."""
     flags = '-fdx' if remove_ignored else '-fd'

--- a/cve_corrector/ptest.py
+++ b/cve_corrector/ptest.py
@@ -86,15 +86,27 @@ def run_ptest(recipe: str, build_timeout: int = 7200,
             f.write(f'CORE_IMAGE_EXTRA_INSTALL = "{recipe}-ptest openssh-sshd"\n')
 
     print("Building test image...")
+    _failed = False
     try:
         if run_cmd(['bitbake', 'core-image-minimal'], timeout=build_timeout) != 0:
             print("bitbake build failed", file=sys.stderr)
+            _failed = True
             raise BuildPreexistingError("Test image build failed")
 
         print("Running testimage...")
         rc = run_cmd(['bitbake', 'core-image-minimal', '-c', 'testimage'],
                      timeout=test_timeout)
+        if rc != 0:
+            _failed = True
     finally:
+        # On failure, preserve the test-modified local.conf for debugging
+        if _failed and _original_conf is not None:
+            debug_conf = local_conf.with_suffix('.conf.ptest-debug')
+            debug_conf.write_text(local_conf.read_text())
+            logger.info(
+                "Preserved test-modified local.conf for debugging: %s",
+                debug_conf,
+            )
         # Restore original local.conf to remove insecure test features
         if _original_conf is not None:
             local_conf.write_text(_original_conf)

--- a/cve_corrector/ptest.py
+++ b/cve_corrector/ptest.py
@@ -116,12 +116,22 @@ def run_ptest(recipe: str, build_timeout: int = 7200,
         return None
 
     ptest_logs = list((build_path / 'tmp-glibc').glob(
-        f'work/*/core-image-minimal/*/testimage/ptest_log/{recipe}'))
+        f'work/*/core-image-minimal/*/testimage/ptest_log*/{recipe}'))
     if not ptest_logs:
         ptest_logs = list((build_path / 'tmp').glob(
-            f'work/*/core-image-minimal/*/testimage/ptest_log/{recipe}'))
+            f'work/*/core-image-minimal/*/testimage/ptest_log*/{recipe}'))
     if ptest_logs:
-        content = sorted(ptest_logs)[-1].read_text()
+        log_file = sorted(ptest_logs)[-1]
+        content = log_file.read_text()
+        # The per-recipe log doesn't contain the STOP: ptest-runner marker —
+        # that lives in the ptest-runner.log alongside it.  Check the runner
+        # log so summarize_ptest_log can distinguish a complete run from a
+        # truncated one.
+        runner_log = log_file.parent / 'ptest-runner.log'
+        if runner_log.exists():
+            runner_content = runner_log.read_text()
+            if 'STOP: ptest-runner' in runner_content:
+                content += '\nSTOP: ptest-runner\n'
         return summarize_ptest_log(content)
     return None
 
@@ -132,7 +142,10 @@ def run_ptest(recipe: str, build_timeout: int = 7200,
 # elsewhere on the line — e.g. the aggregate "STOP: ptest-runner" /
 # "TOTAL: 1 FAIL: 2" summary lines ptest-runner prints at the end of a
 # run — is never mistaken for an individual test result.
-_RESULT_LINE_RE = re.compile(r'^\s*(PASS|FAIL|SKIP):\s*(.+)$')
+#
+# ptest-runner.log uses "PASS:", "FAIL:", "SKIP:" while the per-recipe
+# log file uses "PASSED:", "FAILED:", "SKIPPED:" — match both variants.
+_RESULT_LINE_RE = re.compile(r'^\s*(PASS(?:ED)?|FAIL(?:ED)?|SKIP(?:PED)?):\s*(.+)$')
 
 # A test run that never reaches a PASS/FAIL/SKIP result line because the
 # runner killed it (e.g. it hung and hit the per-test timeout) instead
@@ -185,12 +198,12 @@ def summarize_ptest_log(content: str) -> str:
         if not match:
             continue
         result, name = match.group(1), match.group(2).strip()
-        if result == 'PASS':
+        if result.startswith('PASS'):
             passed += 1
-        elif result == 'FAIL':
+        elif result.startswith('FAIL'):
             failed += 1
             failing.append(name)
-        elif result == 'SKIP':
+        elif result.startswith('SKIP'):
             skipped += 1
 
     aborted = sum(1 for line in content.splitlines() if line.startswith(_ABORTED_MARKER))

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -204,6 +204,19 @@ def _run_build_step(state: WorkflowState) -> None:
         raise BuildError(f"Build failed for {state.recipe}")
 
 
+def _log_ptest_debug_conf() -> None:
+    """Log the location of the preserved ptest debug local.conf, if it exists."""
+    import os
+    bbpath = os.environ.get('BBPATH', '')
+    if not bbpath:
+        return
+    debug_conf = Path(bbpath.split(':')[0]) / 'conf' / 'local.conf.ptest-debug'
+    if debug_conf.exists():
+        logger.error(
+            "Preserved local.conf with test settings: %s", debug_conf
+        )
+
+
 def _run_ptest_step(state: WorkflowState) -> Optional[str]:
     """Run ptest after patch, returning ptest output or None."""
     if state.skip_ptest:
@@ -223,11 +236,13 @@ def _run_ptest_step(state: WorkflowState) -> Optional[str]:
             if not compare_ptest_results(state.ptest_before, ptest_after):
                 logger.error("Ptest failures increased after patch. Fix the patch to correct the failing test cases.")
                 logger.error("cd %s", state.workspace_path)
+                _log_ptest_debug_conf()
                 save_progress(state, 'ptest_after_patch')
                 raise PtestError("Ptest failures increased after patch")
     elif state.ptest_before:
         logger.error("Post-patch ptest failed to run. Fix the patch.")
         logger.error("cd %s", state.workspace_path)
+        _log_ptest_debug_conf()
         save_progress(state, 'ptest_after_patch')
         raise PtestError("Post-patch ptest failed to run")
     state.ptest_after = ptest_after

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -22,6 +22,7 @@ from .git_ops import (
     find_exact_tag,
     git_clean_workspace,
     is_bad_object,
+    remove_git_only_build_triggers,
     try_cherry_pick,
 )
 from .meta_layer import create_layer_commit, write_cve_status
@@ -198,6 +199,7 @@ def _run_build_step(state: WorkflowState) -> None:
     logger.info("Building %s", state.recipe)
     git_clean_workspace(state.workspace_path, remove_ignored=True)
     copy_missing_files_from_devtool(state.workspace_path)
+    remove_git_only_build_triggers(state.workspace_path)
     run_cmd(['bitbake', '-c', 'clean', state.recipe])
     if run_cmd(['devtool', 'build', state.recipe]) != 0:
         save_progress(state, 'build_after_patch')
@@ -667,10 +669,18 @@ def initialize_cve_workflow(
         if not ptest_before:
             logger.error("Failed to run pre-patch tests")
             raise PtestPreexistingError("Pre-patch ptest failed")
-        if 'FAILED:' in ptest_before and re.search(r'FAILED:\s*[1-9]', ptest_before):
+        # A truncated run with zero results is not a usable baseline —
+        # treat it the same as a failed ptest so we skip regression
+        # comparison rather than blocking on an unreliable before/after.
+        if ptest_before.startswith('WARNING:') and 'PASSED: 0, FAILED: 0' in ptest_before:
+            logger.warning("Pre-patch ptest was cut short with zero results — "
+                           "no usable baseline, skipping ptest comparison")
+            ptest_before = None
+        elif 'FAILED:' in ptest_before and re.search(r'FAILED:\s*[1-9]', ptest_before):
             logger.warning("Pre-patch ptest has existing failures — recording baseline")
             logger.warning("Results: %s", ptest_before)
-        logger.info("Before: %s", ptest_before)
+        if ptest_before:
+            logger.info("Before: %s", ptest_before)
 
     if not config.skip_build and not ptest_before:
         logger.info("Pre-patch build verification for %s", recipe)

--- a/cve_corrector/workspace.py
+++ b/cve_corrector/workspace.py
@@ -13,7 +13,12 @@ from .bitbake_ops import (
     get_recipe_src_uri_git,
     get_upstream_check_uri,
 )
-from .git_ops import checkout_version, copy_missing_files_from_devtool, deduce_repo_from_patches
+from .git_ops import (
+    checkout_version,
+    copy_missing_files_from_devtool,
+    deduce_repo_from_patches,
+    remove_git_only_build_triggers,
+)
 from .ptest import enable_ptest
 from .state import DevtoolError, GitError, MetadataError
 from .utils import logger, run_cmd, run_cmd_capture
@@ -328,6 +333,7 @@ def prepare_cve_branch(workspace_path: Path, version: Optional[str],
             logger.info("  - %s", entry)
 
     copy_missing_files_from_devtool(workspace_path)
+    remove_git_only_build_triggers(workspace_path)
 
     logger.debug("Creating tag original-version at current position")
     run_cmd_capture(['git', 'tag', '-f', 'original-version'], cwd=workspace_path)

--- a/tests/corrector/test_build_triggers.py
+++ b/tests/corrector/test_build_triggers.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for remove_git_only_build_triggers (git-vs-tarball dependency fix)."""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cve_corrector.git_ops import remove_git_only_build_triggers
+
+
+def _git_init(repo: Path) -> None:
+    """Initialize a git repo with user config."""
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"],
+                   cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"],
+                   cwd=repo, check=True, capture_output=True)
+
+
+def _git_commit(repo: Path, msg: str) -> None:
+    """Stage all and commit."""
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", msg],
+                   cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Git repo simulating gnutls: devtool branch = tarball (no prime-check.c),
+    HEAD = git checkout (has prime-check.c triggering libev4 via configure.ac).
+    """
+    repo = tmp_path / "gnutls"
+    repo.mkdir()
+    _git_init(repo)
+
+    # Tarball layout — no prime-check.c
+    (repo / "configure.ac").write_text(
+        'SUITE_FILE="${srcdir}/tests/suite/prime-check.c"\n'
+        'if test "$full_test_suite" = yes && test ! -f "$SUITE_FILE";then\n'
+        '\tfull_test_suite=no\n'
+        'fi\n'
+    )
+    (repo / "lib").mkdir()
+    (repo / "lib" / "gnutls.c").write_text("/* main lib */\n")
+    _git_commit(repo, "Initial tarball content")
+    subprocess.run(["git", "branch", "devtool"], cwd=repo,
+                   check=True, capture_output=True)
+
+    # Git-only test file (upstream tag checkout)
+    (repo / "tests" / "suite").mkdir(parents=True)
+    (repo / "tests" / "suite" / "prime-check.c").write_text("int main() {}\n")
+    _git_commit(repo, "Add git-only test suite file")
+    return repo
+
+
+def test_removes_git_only_trigger_file(workspace: Path):
+    """prime-check.c is removed — it triggers libev4 and isn't in the tarball."""
+    assert (workspace / "tests" / "suite" / "prime-check.c").exists()
+    remove_git_only_build_triggers(workspace)
+    assert not (workspace / "tests" / "suite" / "prime-check.c").exists()
+
+
+def test_preserves_file_that_exists_in_tarball(workspace: Path):
+    """configure.ac (in both git and tarball) is NOT removed."""
+    remove_git_only_build_triggers(workspace)
+    assert (workspace / "configure.ac").exists()
+
+
+def test_noop_when_no_configure_ac(tmp_path: Path):
+    """No-op when configure.ac doesn't exist."""
+    repo = tmp_path / "no_configure"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "main.c").write_text("int main() {}\n")
+    _git_commit(repo, "init")
+    subprocess.run(["git", "branch", "devtool"], cwd=repo,
+                   check=True, capture_output=True)
+    remove_git_only_build_triggers(repo)
+
+
+def test_noop_when_trigger_file_exists_in_tarball(tmp_path: Path):
+    """File is kept when it exists in both git tree and tarball."""
+    repo = tmp_path / "both"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "tests" / "suite").mkdir(parents=True)
+    (repo / "tests" / "suite" / "prime-check.c").write_text("int main() {}\n")
+    (repo / "configure.ac").write_text(
+        'SUITE_FILE="${srcdir}/tests/suite/prime-check.c"\n'
+        'if test "$full_test_suite" = yes && test ! -f "$SUITE_FILE";then\n'
+        '\tfull_test_suite=no\n'
+        'fi\n'
+    )
+    _git_commit(repo, "init")
+    subprocess.run(["git", "branch", "devtool"], cwd=repo,
+                   check=True, capture_output=True)
+
+    remove_git_only_build_triggers(repo)
+    assert (repo / "tests" / "suite" / "prime-check.c").exists()
+
+
+def test_handles_literal_path_in_test_f(tmp_path: Path):
+    """Detects literal 'test -f ${srcdir}/path' checks."""
+    repo = tmp_path / "literal"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / "configure.ac").write_text(
+        'if test -f "${srcdir}/extra/check.sh"; then\n'
+        '    enable_extra=yes\n'
+        'fi\n'
+    )
+    _git_commit(repo, "init tarball")
+    subprocess.run(["git", "branch", "devtool"], cwd=repo,
+                   check=True, capture_output=True)
+
+    (repo / "extra").mkdir()
+    (repo / "extra" / "check.sh").write_text("#!/bin/sh\n")
+    _git_commit(repo, "add git-only check")
+
+    remove_git_only_build_triggers(repo)
+    assert not (repo / "extra" / "check.sh").exists()

--- a/tests/corrector/test_ptest.py
+++ b/tests/corrector/test_ptest.py
@@ -211,3 +211,75 @@ class TestComparePtestResults:
         before = "PASSED: 10, FAILED: 0, SKIPPED: 0, ABORTED: 0"
         after = summarize_ptest_log(_JQ_TIMEOUT_LOG.replace("STOP: ptest-runner\n", ""))
         assert compare_ptest_results(before, after) is False
+
+
+class TestLocalConfPreservation:
+    """Tests for local.conf.ptest-debug preservation on failure."""
+
+    @patch("cve_corrector.ptest.run_cmd")
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_debug_conf_created_on_build_failure(
+        self, mock_bp, mock_check, mock_capture, mock_cmd, tmp_path
+    ):
+        """local.conf.ptest-debug is written when the test image build fails."""
+        mock_bp.return_value = tmp_path
+        (tmp_path / "conf").mkdir()
+        conf = tmp_path / "conf" / "local.conf"
+        conf.write_text("# original\n")
+        mock_capture.return_value = MagicMock(stdout="testimage enabled")
+        mock_cmd.return_value = 1  # build fails
+
+        with pytest.raises(BuildPreexistingError):
+            run_ptest("busybox")
+
+        debug_conf = tmp_path / "conf" / "local.conf.ptest-debug"
+        assert debug_conf.exists()
+        # Debug conf should contain the test-modified content (not original)
+        debug_content = debug_conf.read_text()
+        assert "testimage" in debug_content or "ptest" in debug_content
+        # Original local.conf should be restored
+        assert conf.read_text() == "# original\n"
+
+    @patch("cve_corrector.ptest.run_cmd")
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_debug_conf_created_on_testimage_failure(
+        self, mock_bp, mock_check, mock_capture, mock_cmd, tmp_path
+    ):
+        """local.conf.ptest-debug is written when testimage returns non-zero."""
+        mock_bp.return_value = tmp_path
+        (tmp_path / "conf").mkdir()
+        conf = tmp_path / "conf" / "local.conf"
+        conf.write_text("# original\n")
+        mock_capture.return_value = MagicMock(stdout="IMAGE_CLASSES = ''")
+        # Build succeeds, testimage fails
+        mock_cmd.side_effect = [0, 1]
+
+        run_ptest("busybox")
+
+        debug_conf = tmp_path / "conf" / "local.conf.ptest-debug"
+        assert debug_conf.exists()
+        # Original local.conf should be restored
+        assert conf.read_text() == "# original\n"
+
+    @patch("cve_corrector.ptest.run_cmd", return_value=0)
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_no_debug_conf_on_success(
+        self, mock_bp, mock_check, mock_capture, mock_cmd, tmp_path
+    ):
+        """local.conf.ptest-debug is NOT written when everything succeeds."""
+        mock_bp.return_value = tmp_path
+        (tmp_path / "conf").mkdir()
+        conf = tmp_path / "conf" / "local.conf"
+        conf.write_text("# original\n")
+        mock_capture.return_value = MagicMock(stdout="testimage enabled")
+
+        run_ptest("busybox")
+
+        debug_conf = tmp_path / "conf" / "local.conf.ptest-debug"
+        assert not debug_conf.exists()

--- a/tests/corrector/test_ptest.py
+++ b/tests/corrector/test_ptest.py
@@ -283,3 +283,60 @@ class TestLocalConfPreservation:
 
         debug_conf = tmp_path / "conf" / "local.conf.ptest-debug"
         assert not debug_conf.exists()
+
+
+class TestPtestLogRetrieval:
+    """Tests for ptest log path matching and STOP marker injection."""
+
+    def _setup_ptest_log(self, tmp_path, recipe_content, runner_content):
+        """Create the testimage ptest log directory structure."""
+        (tmp_path / "conf").mkdir(exist_ok=True)
+        (tmp_path / "conf" / "local.conf").write_text("# config\n")
+        log_dir = (tmp_path / "tmp-glibc" / "work" / "qemux86_64-oe-linux"
+                   / "core-image-minimal" / "1.0" / "testimage"
+                   / "ptest_log.20260804114023")
+        log_dir.mkdir(parents=True)
+        (log_dir / "gnutls").write_text(recipe_content)
+        (log_dir / "ptest-runner.log").write_text(runner_content)
+
+    @patch("cve_corrector.ptest.run_cmd", return_value=0)
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_completed_run_parses_per_recipe_format(
+        self, mock_bp, mock_check, mock_capture, mock_cmd, tmp_path
+    ):
+        """Matches ptest_log.TIMESTAMP dirs, reads PASSED:/FAILED:/SKIPPED:
+        format from per-recipe log, and injects STOP from ptest-runner.log."""
+        mock_bp.return_value = tmp_path
+        mock_capture.return_value = MagicMock(stdout="testimage enabled")
+        self._setup_ptest_log(tmp_path,
+                              "PASSED: test1\nPASSED: test2\n"
+                              "SKIPPED: test3\nFAILED: test4\n",
+                              "START: ptest-runner\nSTOP: ptest-runner\n")
+
+        result = run_ptest("gnutls")
+
+        assert result is not None
+        assert not result.startswith("WARNING:")
+        assert "PASSED: 2" in result
+        assert "FAILED: 1" in result
+        assert "SKIPPED: 1" in result
+
+    @patch("cve_corrector.ptest.run_cmd", return_value=0)
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_truncated_run_emits_warning(
+        self, mock_bp, mock_check, mock_capture, mock_cmd, tmp_path
+    ):
+        """WARNING when ptest-runner.log has no STOP marker (run cut short)."""
+        mock_bp.return_value = tmp_path
+        mock_capture.return_value = MagicMock(stdout="testimage enabled")
+        self._setup_ptest_log(tmp_path, "", "START: ptest-runner\n")
+
+        result = run_ptest("gnutls")
+
+        assert result is not None
+        assert result.startswith("WARNING:")
+        assert "PASSED: 0" in result

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -32,6 +32,7 @@ from cve_corrector.ui import print_conflict_instructions, print_edit_instruction
 from cve_corrector.workflow import (
     _handle_failed_series,
     _handle_no_clean_apply,
+    _log_ptest_debug_conf,
     _make_should_run,
     _run_build_step,
     _run_ptest_step,
@@ -725,6 +726,31 @@ class TestRunPtestStep:
         state = _state(tmp_path, skip_ptest=False, ptest_before="PASSED: 5, FAILED: 0")
         with pytest.raises(PtestError):
             _run_ptest_step(state)
+
+
+class TestLogPtestDebugConf:
+    """Tests for _log_ptest_debug_conf helper."""
+
+    def test_logs_when_debug_conf_exists(self, tmp_path, monkeypatch):
+        """Logs the debug conf path when the file exists and BBPATH is set."""
+        monkeypatch.setenv("BBPATH", str(tmp_path))
+        conf_dir = tmp_path / "conf"
+        conf_dir.mkdir()
+        debug_conf = conf_dir / "local.conf.ptest-debug"
+        debug_conf.write_text("# debug config\n")
+        # Should not raise; just logs
+        _log_ptest_debug_conf()
+
+    def test_noop_when_no_bbpath(self, monkeypatch):
+        """Does nothing when BBPATH is not set (no crash)."""
+        monkeypatch.delenv("BBPATH", raising=False)
+        _log_ptest_debug_conf()
+
+    def test_noop_when_file_missing(self, tmp_path, monkeypatch):
+        """Does nothing when the debug file doesn't exist."""
+        monkeypatch.setenv("BBPATH", str(tmp_path))
+        (tmp_path / "conf").mkdir()
+        _log_ptest_debug_conf()
 
 
 class TestApplySeries:


### PR DESCRIPTION
Description:
  
  ## Summary
  
  Fix several issues in the corrector's ptest workflow and add handling for
  build failures caused by files present in upstream git but absent from
  release tarballs.
  
  ## Changes
  
  ### Build failure from git-vs-tarball dependency mismatch
  
  Add `remove_git_only_build_triggers()` to detect and remove sentinel files
  that exist in the upstream git tree but not in the release tarball, where
  those files trigger extra build dependencies the recipe doesn't provide
  (e.g. gnutls `tests/suite/prime-check.c` enables `full_test_suite` which
  requires libev4).
  
  ### Ptest reliability fixes
  
  - Fix ptest log glob to match timestamped directories (`ptest_log.*`)
    matching the real testimage output layout
  - Fix STOP marker detection: check `ptest-runner.log` alongside the
    per-recipe log, since only the runner log contains `STOP: ptest-runner`
  - Fix result regex to match both ptest-runner format (`PASS:`) and
    per-recipe log format (`PASSED:`, `FAILED:`, `SKIPPED:`)
  - Handle truncated pre-patch ptest with zero results as unusable baseline
    instead of blocking the workflow
  
  ### Preserve local.conf on ptest/testimage failure
  
  Save a copy of the test-modified `local.conf` as `local.conf.ptest-debug`
  before restoring the original, so users can inspect the insecure test
  settings, IMAGE_CLASSES, TEST_SUITES, etc. when debugging failures.
  
  ## Testing
  
  - New unit tests for `remove_git_only_build_triggers()` (122 lines)
  - New ptest parsing and detection tests (129 lines)
  - Extended workflow integration tests for the debug conf preservation
  
  7 files changed, +440 / -10
