### PR TITLE
corrector: honour the cpe: scope in CVE_STATUS

### DIFF
--- a/.agents/summary/workflows.md
+++ b/.agents/summary/workflows.md
@@ -62,7 +62,7 @@ stateDiagram-v2
     LoadMetadata --> CheckCveStatus : metadata valid
     LoadMetadata --> EXIT_METADATA_ERROR : invalid
 
-    CheckCveStatus --> SetupWorkspace : Unpatched / not set
+    CheckCveStatus --> SetupWorkspace : Unpatched / not set / cpe: scope mismatch
     CheckCveStatus --> EXIT_IGNORED_BY_STATUS : Ignored or Patched
 
     SetupWorkspace --> CheckApplicability

--- a/cve_corrector/bitbake_ops.py
+++ b/cve_corrector/bitbake_ops.py
@@ -249,6 +249,78 @@ _CVE_STATUS_PATCHED_REASONS = frozenset({
 })
 
 
+def _decode_cve_status_cpe(raw_value: str) -> tuple[str, str]:
+    """Extract the ``cpe:`` scope from a CVE_STATUS value.
+
+    Mirrors ``decode_cve_status()`` in oe-core's ``meta/lib/oe/cve_check.py``.
+    The grammar is ``<detail>: cpe:<vendor>:<product>:<description>``, where
+    vendor and product are both mandatory when ``cpe:`` is present. Anything
+    else (no ``cpe:`` segment, or a malformed one, which oe-core warns about
+    and then ignores) leaves the scope unrestricted.
+
+    Args:
+        raw_value: The full CVE_STATUS value.
+
+    Returns:
+        A ``(vendor, product)`` tuple, each ``"*"`` when unrestricted.
+    """
+    parts = raw_value.split(':', 4)
+    if len(parts) >= 4 and parts[1].strip() == 'cpe':
+        return parts[2].strip(), parts[3].strip()
+    return '*', '*'
+
+
+def get_cve_product(recipe: str) -> Optional[str]:
+    """Get the recipe's CVE_PRODUCT — the CPE product(s) it is scanned as.
+
+    The recipe name is deliberately *not* used as a fallback: it is often not
+    the CPE product (zstd is scanned as ``zstandard``, tcpdump as
+    ``tcpdump:tcpdump``), so substituting it could invent a scope match that
+    oe-core would not make.
+
+    Args:
+        recipe: Recipe name to query.
+
+    Returns:
+        The CVE_PRODUCT value, a space-separated list whose entries are
+        either ``<product>`` or ``<vendor>:<product>``. An empty string is
+        returned as-is — oe-core excludes such recipes from CVE checking, so
+        no scope matches. Returns None if the product could not be
+        determined.
+    """
+    result = run_cmd_capture(['bitbake-getvar', 'CVE_PRODUCT', '-r', recipe, '--value'])
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _has_cve_product_match(vendor: str, product: str, cve_products: str) -> bool:
+    """Check a CVE_STATUS ``cpe:`` scope against a recipe's CVE_PRODUCT.
+
+    Mirrors ``has_cve_product_match()`` in oe-core's
+    ``meta/lib/oe/cve_check.py``: a ``"*"`` on the CVE_STATUS side matches
+    anything, and CVE_PRODUCT entries may be ``<vendor>:<product>`` pairs.
+
+    Args:
+        vendor: Vendor from the CVE_STATUS ``cpe:`` scope.
+        product: Product from the CVE_STATUS ``cpe:`` scope.
+        cve_products: The recipe's CVE_PRODUCT value.
+
+    Returns:
+        True if any CVE_PRODUCT entry falls within the scope.
+    """
+    for entry in cve_products.split():
+        entry_vendor = '*'
+        entry_product = entry
+        if ':' in entry:
+            entry_vendor, entry_product = entry.split(':', 1)
+
+        if ((entry_vendor == vendor or vendor == '*')
+                and (entry_product == product or product == '*')):
+            return True
+    return False
+
+
 def check_cve_status(recipe: str, cve_id: str) -> Optional[tuple[str, str]]:
     """Check the recipe's existing CVE_STATUS flag for this CVE.
 
@@ -256,6 +328,14 @@ def check_cve_status(recipe: str, cve_id: str) -> Optional[tuple[str, str]]:
     if set, maps the "reason: description" value to the final CVE state
     (``Patched``, ``Unpatched``, or ``Ignored``) using the same reason
     keywords as oe-core's ``cve-check-map.conf``.
+
+    A CVE_STATUS value may carry a ``cpe:<vendor>:<product>:`` scope that
+    limits it to matching recipes. Such entries are typically set distro-wide
+    (oe-core's own ``cve-extra-exclusions.inc`` is entirely scoped this way),
+    which makes the varflag visible from *every* recipe's datastore —
+    ``bitbake-getvar`` returns it regardless of the scope. A scope that does
+    not match this recipe's CVE_PRODUCT is therefore treated as no status
+    being set, exactly as oe-core's cve-check does.
 
     Args:
         recipe: Recipe name to query.
@@ -265,7 +345,8 @@ def check_cve_status(recipe: str, cve_id: str) -> Optional[tuple[str, str]]:
         A ``(state, raw_value)`` tuple where ``state`` is one of
         ``"Patched"``, ``"Unpatched"``, or ``"Ignored"``, and ``raw_value``
         is the full ``CVE_STATUS`` value as set in the recipe. Returns
-        None if CVE_STATUS is not set for this CVE or could not be
+        None if CVE_STATUS is not set for this CVE, does not apply to this
+        recipe, or if either it or the recipe's CVE_PRODUCT could not be
         determined.
     """
     result = run_cmd_capture([
@@ -277,6 +358,16 @@ def check_cve_status(recipe: str, cve_id: str) -> Optional[tuple[str, str]]:
     raw_value = result.stdout.strip()
     if not raw_value:
         return None
+
+    vendor, product = _decode_cve_status_cpe(raw_value)
+    if (vendor, product) != ('*', '*'):
+        cve_products = get_cve_product(recipe)
+        # An undeterminable CVE_PRODUCT means the scope cannot be evaluated.
+        # Report no status rather than guess: honouring an entry that may not
+        # apply skips the CVE silently, which is the failure this scope check
+        # exists to prevent.
+        if cve_products is None or not _has_cve_product_match(vendor, product, cve_products):
+            return None
 
     reason = raw_value.split(':', 1)[0].strip().lower()
     if reason in _CVE_STATUS_IGNORED_REASONS:

--- a/tests/corrector/test_bitbake_ops.py
+++ b/tests/corrector/test_bitbake_ops.py
@@ -226,6 +226,7 @@ class TestCheckCveStatus:
         result = check_cve_status("foo", "CVE-2025-0001")
         assert result == ("Ignored", "Not-Applicable-Config: disabled feature")
 
+
     """Tests for check_cve_patch_in_src_uri — pre-flight already-applied check."""
 
     @patch("cve_corrector.bitbake_ops.run_cmd_capture")
@@ -273,3 +274,163 @@ class TestCheckCveStatus:
     def test_bitbake_getvar_failure_returns_none(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stdout="")
         assert check_cve_patch_in_src_uri("busybox", "CVE-2024-1234") is None
+
+
+class TestCheckCveStatusCpeScope:
+    """CVE_STATUS entries scoped with ``cpe:<vendor>:<product>:`` apply only to
+    recipes whose CVE_PRODUCT matches, per oe-core's ``decode_cve_status()`` and
+    ``has_cve_product_match()`` (meta/lib/oe/cve_check.py).
+
+    Such entries are typically set distro-wide (e.g. oe-core's own
+    ``cve-extra-exclusions.inc``), so ``bitbake-getvar CVE_STATUS -r <recipe>``
+    returns the value from *every* recipe's datastore — the ``cpe:`` segment is
+    the only thing limiting which recipe it applies to.
+    """
+
+    @staticmethod
+    def _mock_getvar(cve_status: str, cve_product: str):
+        """Answer the CVE_STATUS query then the CVE_PRODUCT query."""
+        return [
+            MagicMock(returncode=0, stdout=cve_status + "\n"),
+            MagicMock(returncode=0, stdout=cve_product + "\n"),
+        ]
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_scoped_entry_does_not_apply_to_unrelated_recipe(self, mock_run):
+        """A distro-wide entry scoped to selinux must not suppress zstd's CVE.
+
+        Reproduces the real downstream case: iotgw sets this entry in a distro
+        .inc, so it is visible from zstd's datastore even though the scope names
+        selinux_project:selinux.
+        """
+        mock_run.side_effect = self._mock_getvar(
+            "cpe-incorrect: cpe:selinux_project:selinux:Red Hat selinux-policy "
+            "RPM flaw, not SELinux upstream; CPE collision",
+            "zstd")
+        assert check_cve_status("zstd", "CVE-2015-3170") is None
+        assert mock_run.call_args_list[1][0][0] == [
+            'bitbake-getvar', 'CVE_PRODUCT', '-r', 'zstd', '--value']
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_scoped_entry_applies_to_matching_recipe(self, mock_run):
+        """The same entry must still be honoured for the recipe it scopes to.
+
+        meta-selinux's selinux_common.inc sets
+        ``CVE_PRODUCT ?= "selinux_project:selinux"``, the vendor-qualified form
+        the scope names.
+        """
+        raw = ("cpe-incorrect: cpe:selinux_project:selinux:Red Hat "
+               "selinux-policy RPM flaw, not SELinux upstream; CPE collision")
+        mock_run.side_effect = self._mock_getvar(raw, "selinux_project:selinux")
+        assert check_cve_status("libselinux", "CVE-2015-3170") == ("Ignored", raw)
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_wildcard_scope_applies_to_every_recipe(self, mock_run):
+        raw = "fixed-version: cpe:*:*:applies everywhere"
+        mock_run.side_effect = self._mock_getvar(raw, "zstd")
+        assert check_cve_status("zstd", "CVE-2025-0001") == ("Patched", raw)
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_entry_without_cpe_segment_is_honoured(self, mock_run):
+        """No cpe: segment means vendor/product "*" — applies to all recipes.
+
+        CVE_PRODUCT is not queried at all in this case.
+        """
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="ignored: no scope, applies to this recipe\n")
+        result = check_cve_status("zstd", "CVE-2025-0001")
+        assert result == ("Ignored", "ignored: no scope, applies to this recipe")
+        mock_run.assert_called_once_with([
+            'bitbake-getvar', 'CVE_STATUS', '-f', 'CVE-2025-0001',
+            '-r', 'zstd', '--value', '--ignore-undefined'])
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_vendor_wildcard_matches_named_product_only(self, mock_run):
+        raw = "ignored: cpe:*:glibc:only the glibc CPE is affected"
+        mock_run.side_effect = self._mock_getvar(raw, "glibc")
+        assert check_cve_status("glibc", "CVE-2010-4756") == ("Ignored", raw)
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_vendor_wildcard_does_not_match_other_product(self, mock_run):
+        mock_run.side_effect = self._mock_getvar(
+            "ignored: cpe:*:glibc:only the glibc CPE is affected", "curl")
+        assert check_cve_status("curl", "CVE-2010-4756") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_named_vendor_scope_does_not_match_bare_cve_product(self, mock_run):
+        """A scope naming a vendor requires CVE_PRODUCT to name it too.
+
+        oe-core's has_cve_product_match() only wildcards the CVE_STATUS side, so
+        a bare ``CVE_PRODUCT = "selinux"`` is outside a
+        ``cpe:selinux_project:selinux:`` scope. Pinned here because it is the
+        one place these semantics are counter-intuitive.
+        """
+        mock_run.side_effect = self._mock_getvar(
+            "ignored: cpe:selinux_project:selinux:scoped", "selinux")
+        assert check_cve_status("some-recipe", "CVE-2015-3170") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_cve_product_vendor_qualified_entry_rejects_other_vendor(self, mock_run):
+        mock_run.side_effect = self._mock_getvar(
+            "ignored: cpe:selinux_project:selinux:scoped", "otherproject:selinux")
+        assert check_cve_status("libselinux", "CVE-2015-3170") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_any_of_several_cve_products_may_match(self, mock_run):
+        """CVE_PRODUCT is a space-separated list; one match is enough."""
+        raw = "ignored: cpe:*:openssl:scoped"
+        mock_run.side_effect = self._mock_getvar(raw, "openssl-native openssl")
+        assert check_cve_status("openssl", "CVE-2025-0001") == ("Ignored", raw)
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_malformed_cpe_segment_is_honoured(self, mock_run):
+        """oe-core warns and leaves vendor/product unset for a truncated cpe:
+        segment, so the entry keeps applying to every recipe."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="ignored: cpe:vendor-only\n")
+        assert check_cve_status("zstd", "CVE-2025-0001") == (
+            "Ignored", "ignored: cpe:vendor-only")
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_scope_without_description_still_matched(self, mock_run):
+        """``detail: cpe:vendor:product:`` with an empty description."""
+        raw = "ignored: cpe:*:zstd:"
+        mock_run.side_effect = self._mock_getvar(raw, "zstd")
+        assert check_cve_status("zstd", "CVE-2025-0001") == ("Ignored", raw)
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_recipe_name_is_not_used_as_a_product_fallback(self, mock_run):
+        """A failed CVE_PRODUCT query must not fall back to the recipe name.
+
+        The recipe name is frequently not the CPE product — zstd is scanned as
+        "zstandard" — so substituting it would invent a match oe-core would not
+        make, silently skipping the CVE. That is the very failure this scope
+        check exists to prevent, so an undeterminable product reports no status.
+        """
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="ignored: cpe:*:zstd:scoped\n"),
+            MagicMock(returncode=1, stdout=""),
+        ]
+        assert check_cve_status("zstd", "CVE-2025-0001") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_empty_cve_product_matches_nothing(self, mock_run):
+        """oe-core excludes recipes with an empty CVE_PRODUCT from CVE
+        checking, so no scope can match one."""
+        mock_run.side_effect = self._mock_getvar("ignored: cpe:*:zstd:scoped", "")
+        assert check_cve_status("zstd", "CVE-2025-0001") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_scope_is_matched_against_cve_product_not_recipe_name(self, mock_run):
+        """zstd's real CVE_PRODUCT is "zstandard" (measured on a live build):
+        a scope naming the *recipe* does not apply to it..."""
+        mock_run.side_effect = self._mock_getvar(
+            "ignored: cpe:*:zstd:names the recipe, not the product", "zstandard")
+        assert check_cve_status("zstd", "CVE-2025-0001") is None
+
+    @patch("cve_corrector.bitbake_ops.run_cmd_capture")
+    def test_scope_naming_the_real_product_applies(self, mock_run):
+        """...while a scope naming the product it is actually scanned as does."""
+        raw = "ignored: cpe:*:zstandard:names the real CPE product"
+        mock_run.side_effect = self._mock_getvar(raw, "zstandard")
+        assert check_cve_status("zstd", "CVE-2025-0001") == ("Ignored", raw)


### PR DESCRIPTION
## Problem

A `CVE_STATUS` value may carry a scope that limits it to matching recipes:

```
CVE_STATUS[<cve>] = "<detail>: cpe:<vendor>:<product>:<description>"
```

`check_cve_status()` took `raw_value.split(':', 1)[0]` — correct for reading the
detail keyword, but the scope was then dropped on the floor.

Scoped entries are normally set **distro-wide**, which makes the varflag part of
every recipe's datastore, and `bitbake-getvar` applies no scope filtering — it
returns the value whether or not the scope matches. oe-core ships such entries
itself, e.g. in `meta/conf/distro/include/cve-extra-exclusions.inc`:

```
CVE_STATUS[CVE-2000-0006] = "upstream-wontfix: cpe:*:strace: CVE is more than
20 years old with no resolution evident. ..."
```

For any distro that `require`s that file — the intended usage — the corrector
reads that entry from *every* recipe's datastore, maps `upstream-wontfix` to
`Ignored`, and exits 16 (`EXIT_IGNORED_BY_STATUS`) for a CVE the scope had
limited to strace alone.

It fails **silent and closed**. Not a crash and not a warning, but a confident
skip printed as:

```
CVE <id>: CVE_STATUS marks recipe as Ignored — upstream-wontfix: ...
```

That message reads like a deliberate human decision recorded in the recipe, so
the only symptom is a CVE quietly missing from the output — in exactly the
workflow this tool exists to make trustworthy. It also misreads the one field
that exists to prevent over-broad suppression: oe-core honours the scope, and
the corrector read it as if it were not there.

`cve-extra-exclusions.inc` currently ships **43 CVEs across 12 `cpe:`-scoped
assignments, with zero unscoped** — including glibc `CVE-2010-4756`, two
`linux_kernel` entries and strace `CVE-2000-0006`. Every one is a candidate
false skip for any other recipe a scan reports that CVE against.

## Change

Parse the optional `cpe:` segment and match it against the recipe's
`CVE_PRODUCT`, mirroring `meta/lib/oe/cve_check.py` (read at tag `yocto-6.0`)
rather than inventing matching semantics — divergence here would reintroduce
the same class of mismatch one layer down:

- `_decode_cve_status_cpe()` mirrors `decode_cve_status()` — `split(':', 4)`,
  vendor and product both mandatory when `cpe:` is present, malformed segments
  ignored (oe-core warns and leaves the scope unrestricted).
- `_has_cve_product_match()` mirrors `has_cve_product_match()` — `*` on the
  `CVE_STATUS` side matches anything, `CVE_PRODUCT` entries may be
  `vendor:product` pairs, any one match is enough.
- `get_cve_product()` runs `bitbake-getvar CVE_PRODUCT -r <recipe> --value`.

A non-matching scope is treated as no status being set. `CVE_PRODUCT` is only
queried when a scope is actually present, so the common unscoped path costs no
extra bitbake call.

The recipe name is deliberately **not** used as a fallback when `CVE_PRODUCT`
cannot be determined. It is frequently not the CPE product — zstd is scanned as
`zstandard`, tcpdump as `tcpdump:tcpdump` — so substituting it could invent a
match oe-core would not make, silently skipping the CVE and recreating the very
failure this check exists to prevent. A failed query reports no status; an empty
`CVE_PRODUCT` is preserved as empty and matches nothing, since oe-core excludes
such recipes from CVE checking entirely.

The disposition vocabulary (`_CVE_STATUS_IGNORED_REASONS` /
`_CVE_STATUS_PATCHED_REASONS`) is unchanged — only the scope handling was
missing.

## Validation

The unit tests mock `run_cmd_capture`, so the fix was additionally measured
against a live Yocto 6.0 (wrynose) build whose distro sets four `cpe:`-scoped
`CVE_STATUS` entries distro-wide, all scoped to `selinux_project:selinux`.

`CVE_PRODUCT` as the build actually reports it:

```
zstd         CVE_PRODUCT=zstandard
strace       CVE_PRODUCT=strace
tcpdump      CVE_PRODUCT=tcpdump:tcpdump
libselinux   CVE_PRODUCT=selinux_project:selinux
mosquitto    CVE_PRODUCT=mosquitto
```

Note that neither `zstandard` nor `tcpdump:tcpdump` equals its recipe name,
which is why the scope is matched against `CVE_PRODUCT`. The same query the
corrector makes returns the selinux-scoped value from unrelated recipes,
confirming the varflag is visible regardless of scope:

```console
$ bitbake-getvar CVE_STATUS -f CVE-2015-3170 -r zstd --value --ignore-undefined
cpe-incorrect: cpe:selinux_project:selinux:Red Hat selinux-policy RPM flaw, not SELinux upstream; CPE collision
```

`check_cve_status()` over all four scoped entries, against every recipe the scan
reported them for, plus an unscoped control — 12 recipe/CVE pairs:

| recipe / CVE | before | after |
|---|---|---|
| zstd / CVE-2015-3170 | `Ignored` | `None` |
| zstd / CVE-2018-1063 | `Patched` | `None` |
| zstd / CVE-2021-36086 | `Patched` | `None` |
| strace / CVE-2015-3170 | `Ignored` | `None` |
| strace / CVE-2021-36086 | `Patched` | `None` |
| tcpdump / CVE-2015-3170 | `Ignored` | `None` |
| tcpdump / CVE-2018-1063 | `Patched` | `None` |
| libselinux / CVE-2015-3170 (**in scope**) | `Ignored` | `Ignored` |
| libselinux / CVE-2016-7545 (**in scope**) | `Patched` | `Patched` |
| libselinux / CVE-2018-1063 (**in scope**) | `Patched` | `Patched` |
| libselinux / CVE-2021-36086 (**in scope**) | `Patched` | `Patched` |
| mosquitto / CVE-2021-34432 (**unscoped**) | `Patched` | `Patched` |

Every scoped entry had been suppressing its CVE for recipes it was never meant
to cover, while the recipe it *was* meant to cover keeps its status in all four
cases, and the unscoped entry is unaffected. Most of the false results are
`Patched` rather than `Ignored` — an assertion that the CVE is already fixed.

The "after" column agrees with what oe-core's own `do_create_recipe_spdx`
reports for those recipes: 0 hits for zstd, strace and tcpdump, 1 hit for
libselinux. End to end, for zstd / CVE-2015-3170:

```
before: CVE CVE-2015-3170: CVE_STATUS marks recipe as Ignored — cpe-incorrect: ...
        exit=16  (EXIT_IGNORED_BY_STATUS)
after:  proceeds past the pre-flight check; exit=6 at a deliberately bogus
        --meta-layer, i.e. the gate no longer fires
```

## Tests

15 tests in `TestCheckCveStatusCpeScope`; seven fail on unmodified `main`, the
rest are regression cover for behaviour that must not change:

| case | expected |
|---|---|
| scoped entry, unrelated recipe | `None` — **failed before** |
| scoped entry, matching `CVE_PRODUCT` | honoured |
| wildcard scope `cpe:*:*:` | honoured everywhere |
| no `cpe:` segment | honoured, `CVE_PRODUCT` never queried |
| vendor wildcard `cpe:*:glibc:` | matches glibc, not curl — **failed before** |
| vendor-qualified `CVE_PRODUCT` pairs | vendor and product both matched |
| malformed / truncated `cpe:` segment | honoured, as oe-core does |
| `CVE_PRODUCT` query fails | `None` — no fallback to the recipe name |
| `CVE_PRODUCT` empty | `None` — matches nothing |
| scope names the recipe (`cpe:*:zstd:`) vs the product (`cpe:*:zstandard:`) | only the product form applies |

The matching-scope case uses `CVE_PRODUCT = "selinux_project:selinux"`, the
value meta-selinux's `selinux_common.inc` sets.

`ruff check .`, `mypy cve_agent cve_corrector cve_metadata_extractor shared` and
`pytest --cov` all pass; coverage 78.78% (was 78.70%).
