### PR TITLE
cve_corrector diagnostics and TLS trust store fixes

### DIFF
--- a/cve_corrector/bitbake_ops.py
+++ b/cve_corrector/bitbake_ops.py
@@ -146,14 +146,46 @@ def find_mirror_repo(mirror_dir: Path, recipe_name: str,
 
 
 def deduce_meta_layer_from_recipe(recipe: str) -> Optional[Path]:
-    """Deduce meta-layer path from recipe using bitbake-layers."""
-    result = run_cmd_capture(['bitbake-layers', 'show-recipes', '-f', recipe])
+    """Deduce meta-layer path from recipe using bitbake-layers.
+
+    Returns the layer directory containing the recipe, or None if it cannot
+    be determined. On failure, diagnostics are written to stderr: silently
+    returning None makes the caller report a generic "Could not deduce
+    meta-layer", which is indistinguishable from (and has in practice been
+    confused with) a broken bitbake environment, a parse error, or an
+    unreachable fetch mirror.
+    """
+    cmd = ['bitbake-layers', 'show-recipes', '-f', recipe]
+    result = run_cmd_capture(cmd)
     for line in result.stdout.splitlines():
         if line.startswith('/') and recipe in line and '.bb' in line:
             recipe_path = Path(line.strip())
             for parent in recipe_path.parents:
                 if parent.name.startswith('meta') or parent.name == 'openembedded-core':
                     return parent
+
+    print(f"deduce_meta_layer_from_recipe: no layer found for {recipe!r}",
+          file=sys.stderr)
+    print(f"  command: {' '.join(cmd)} (exit {result.returncode})",
+          file=sys.stderr)
+    if result.returncode != 0:
+        print("  bitbake-layers failed — the environment or metadata is "
+              "broken, this is not a missing recipe", file=sys.stderr)
+    elif not result.stdout.strip():
+        print("  bitbake-layers succeeded but produced no output",
+              file=sys.stderr)
+    else:
+        print("  bitbake-layers produced output, but no line matched "
+              f"'/...{recipe}....bb' — recipe may not exist in any "
+              "configured layer", file=sys.stderr)
+    for stream_name, stream in (('stdout', result.stdout),
+                                ('stderr', result.stderr)):
+        tail = (stream or '').strip().splitlines()[-25:]
+        if tail:
+            print(f"  --- {stream_name} (last {len(tail)} lines) ---",
+                  file=sys.stderr)
+            for line in tail:
+                print(f"  {line}", file=sys.stderr)
     return None
 
 

--- a/cve_corrector/workspace.py
+++ b/cve_corrector/workspace.py
@@ -242,6 +242,13 @@ def _fetch_remote(workspace_path: Path, remote_name: str, url: str) -> bool:
         return True
     alt = _alternate_protocol_url(url)
     if not alt:
+        # Surface the reason: without upstream history every fix commit
+        # later reads as "bad object" and the run ends in a generic
+        # conflict, which hides that the real failure was here.
+        res = run_cmd_capture(['git', 'fetch', remote_name, '--tags'],
+                              cwd=workspace_path)
+        logger.error("Fetch of %s failed and no alternate protocol to retry:\n%s",
+                     url, (res.stderr or res.stdout or '').strip()[-2000:])
         return False
     logger.warning("Fetch of %s failed — retrying via %s", url, alt)
     run_cmd(['git', 'remote', 'set-url', remote_name, alt], cwd=workspace_path)

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -26,6 +26,18 @@ GIT_ENV_ALLOWLIST: frozenset[str] = frozenset({
     'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'GIT_COMMITTER_NAME',
     'GIT_COMMITTER_EMAIL', 'GIT_SSH',
     'SSH_AUTH_SOCK', 'SSH_AGENT_PID',
+    # TLS trust store. Required when git comes from a relocatable SDK
+    # (e.g. Yocto buildtools-extended): its binaries are compiled with a
+    # hardcoded sysroot path that does not exist once relocated, so the
+    # environment-setup script exports these to point at the real one.
+    # Dropping them makes every https fetch fail with
+    #   error setting certificate file:
+    #   /usr/local/oe-sdk-hardcoded-buildpath/.../ca-certificates.crt
+    # which surfaced only as "Failed to fetch upstream — continuing
+    # without upstream history", and then as unusable fix commits
+    # ("bad object") at cherry-pick time.
+    'GIT_SSL_CAINFO', 'GIT_SSL_CAPATH', 'GIT_SSL_NO_VERIFY',
+    'SSL_CERT_FILE', 'SSL_CERT_DIR', 'CURL_CA_BUNDLE', 'REQUESTS_CA_BUNDLE',
     # Proxy
     'http_proxy', 'https_proxy', 'no_proxy',
     'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY',


### PR DESCRIPTION
  ### Summary
  
  Three related bug fixes that improve error reporting and upstream fetch reliability in `cve_corrector`:
  
  1. **shared: keep TLS trust store vars in git env allowlist** — Fixed HTTPS fetch failures when running in relocated Yocto SDKs by preserving `GIT_SSL_CAINFO`, `GIT_SSL_CApath`, and equivalent env vars for curl/requests. Previously these were
  stripped by `GIT_ENV_ALLOWLIST`, causing cryptic "bad object" errors later at cherry-pick time. This is critical for backporting recipes built from release tarballs (no local upstream history).
  
  2. **cve_corrector: report why an upstream fetch failed** — Capture and log the actual git error when `_fetch_remote` fails, making diagnosis immediate instead of deferring to a generic conflict message much later. Directly identified the missing
  TLS vars in the previous fix.
  
  3. **cve_corrector: add debug information for deduce_metalayer** — Add diagnostic output to stderr when recipe layer deduction fails, including the failed command, exit code, and last 25 lines of output. Distinguishes bitbake environment issues
  from layer lookup problems.
  
  ### What's Fixed
  
  - ✅ HTTPS fetches now work in relocated SDKs (buildtools-extended, etc.)
  - ✅ Fetch failures now report the actual error (TLS cert issues, network, etc.)
  - ✅ Recipe layer lookup failures now produce actionable diagnostics
  - ✅ End-to-end backporting verified on libarchive CVE
  
  ### Impact
  
  These changes unblock backporting recipes from release tarballs in SDK environments, and make troubleshooting fetch/layer issues significantly faster.
  
  ### Testing
  
  - Verified end-to-end backport of CVE-2026-15028 (libarchive) in elin-host-container-image
  - All existing tests pass
