### PR TITLE
corrector: make Signed-off-by opt-in instead of fabricated

### DIFF
--- a/.agents/summary/data_models.md
+++ b/.agents/summary/data_models.md
@@ -25,6 +25,7 @@ classDiagram
         +Optional~str~ subproject
         +bool bbappend
         +Optional~str~ version
+        +bool sign_off
         +to_dict() dict
         +from_dict(data) WorkflowState
     }
@@ -56,6 +57,7 @@ classDiagram
         +Optional~str~ fix_url
         +Optional~str~ recipe
         +str backend
+        +bool sign_off
     }
 ```
 
@@ -131,6 +133,7 @@ classDiagram
         +bool bbappend
         +bool skip_cve_applicability
         +Optional~str~ fix_url
+        +bool sign_off
     }
 ```
 

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -87,6 +87,9 @@ Options:
   --bbappend              Use bbappend instead of modifying recipe
   --dry-run               Show what would be done without executing
   --continue              Resume from saved state (after conflict resolution)
+  --sign-off              Add Signed-off-by trailer (default: off). On
+                          --continue, omitting it preserves the choice made
+                          on the original run; passing it again overrides
   --verbose               Enable debug logging
 ```
 
@@ -116,6 +119,9 @@ Options:
   --mirror-dir DIR        Local git mirror directory
   --meta-layer DIR        Target meta-layer
   --bbappend              Use bbappend mode
+  --sign-off              Passed through to cve-corrector (default: off).
+                          Rejected in combination with --trust — no human
+                          review means no DCO certification to make.
 ```
 
 ## Inter-Process Interface

--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -110,6 +110,7 @@ class AgentConfig:
     recipe: Optional[str] = None
     backend: str = "kiro"
     skip_sources: list[str] = field(default_factory=list)
+    sign_off: bool = False
 
 
 @dataclass

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -233,7 +233,8 @@ def _parse_args() -> argparse.Namespace:
                         default=DEFAULT_SESSION_TIMEOUT,
                         help='Timeout per session in seconds (default: %(default)s)')
     ai_group.add_argument('--trust', action='store_true',
-                        help='Skip human review (NOT recommended)')
+                        help='Skip human review (NOT recommended). Cannot be '
+                             'combined with --sign-off.')
     ai_group.add_argument('-i', '--interactive', action='store_true',
                         help='Enable interactive mode (human-in-the-loop). '
                              'Omit for non-interactive/CI use (default).')
@@ -258,6 +259,13 @@ def _parse_args() -> argparse.Namespace:
     env_group = parser.add_argument_group('environment')
     env_group.add_argument('--mirror-dir', type=Path,
                         help='Directory with bare repository mirrors')
+    env_group.add_argument('--sign-off', action='store_true',
+                        help='Pass --sign-off through to cve-corrector, adding a '
+                             'Signed-off-by trailer to generated patches and '
+                             'commits using the git identity resolved from '
+                             '`git config`. Off by default — only a human who has '
+                             'reviewed the change can certify the DCO. Cannot be '
+                             'combined with --trust.')
 
     return parser.parse_args()
 
@@ -294,6 +302,7 @@ def _config_from_args(args: argparse.Namespace,
         recipe=args.recipe,
         backend=args.backend,
         skip_sources=args.skip_sources,
+        sign_off=args.sign_off,
     )
 
 
@@ -302,6 +311,13 @@ def main() -> None:
     results: list[CveResult] = []
     signal.signal(signal.SIGINT, _sigint_handler(results))
     args = _parse_args()
+
+    if args.trust and args.sign_off:
+        print("Error: --trust and --sign-off cannot be combined — --trust "
+              "skips human review of AI-generated changes, so --sign-off "
+              "would certify a DCO that nobody actually reviewed. Drop one "
+              "of the two flags.", file=sys.stderr)
+        sys.exit(EXIT_AGENT_ERROR)
 
     if not args.cve_info and not args.fix_urls:
         print("Error: --cve-info or --fix-url is required", file=sys.stderr)

--- a/cve_agent/corrector.py
+++ b/cve_agent/corrector.py
@@ -37,8 +37,12 @@ def run_corrector(config: AgentConfig, continue_mode: bool = False,
         ]
         if config.meta_layer:
             cmd += ['--meta-layer', str(config.meta_layer)]
+        if config.sign_off:
+            cmd.append('--sign-off')
     elif continue_mode:
         cmd += ['--continue', '--yes']
+        if config.sign_off:
+            cmd.append('--sign-off')
     else:
         cmd += [
             '--cve-id', config.cve_id,
@@ -64,6 +68,8 @@ def run_corrector(config: AgentConfig, continue_mode: bool = False,
             cmd.append('--skip-cve-applicability')
         for source in config.skip_sources:
             cmd += ['--skip-source', source]
+        if config.sign_off:
+            cmd.append('--sign-off')
 
     output_lines = []
     with subprocess.Popen(

--- a/cve_corrector/__main__.py
+++ b/cve_corrector/__main__.py
@@ -143,6 +143,13 @@ def main():
                         help='Directory containing bare repository mirrors')
     env_group.add_argument('--yes', '-y', action='store_true',
                         help='Skip confirmation prompts')
+    env_group.add_argument('--sign-off', action='store_true', default=None,
+                        help='Add a Signed-off-by trailer to generated patches and '
+                             'commits, using the git identity resolved from '
+                             '`git config`. Off by default — only a human who has '
+                             'reviewed the change can certify the DCO. With '
+                             '--continue, omitting this flag preserves the choice '
+                             'made on the original run; passing it again overrides.')
     env_group.add_argument('--verbose', '-v', action='store_true',
                         help='Show verbose output (live command execution)')
 
@@ -155,6 +162,11 @@ def main():
         try:
             state = continue_from_conflict()
             state.skip_confirm = args.yes
+            # Only override the persisted choice when --sign-off is repeated;
+            # omitting it on --continue must not silently unsign a run that
+            # opted in on its original invocation.
+            if args.sign_off is not None:
+                state.sign_off = args.sign_off
             log_file = setup_logging(state.cve_id, get_build_path(), args.verbose)
             logger.info("Resuming %s for %s...", state.cve_id, state.recipe)
             logger.info("Log file: %s", log_file)
@@ -258,7 +270,8 @@ def main():
         from .meta_layer import write_cve_status
         ok = write_cve_status(meta_layer, recipe_name, args.cve_id,
                               args.mark_not_applicable,
-                              skip_confirm=args.yes)
+                              skip_confirm=args.yes,
+                              sign_off=bool(args.sign_off))
         sys.exit(0 if ok else EXIT_METADATA_ERROR)
 
     mirror_path = None
@@ -322,7 +335,8 @@ def main():
                 manual_mode=args.manual, bbappend=args.bbappend,
                 skip_cve_applicability=args.skip_cve_applicability,
                 skip_confirm=args.yes,
-                require_all_commits=require_all_commits))
+                require_all_commits=require_all_commits,
+                sign_off=bool(args.sign_off)))
         state.skip_confirm = args.yes
 
         finish_cve_workflow(state)

--- a/cve_corrector/cherry_pick.py
+++ b/cve_corrector/cherry_pick.py
@@ -28,7 +28,8 @@ def handle_empty_cherry_pick(state: WorkflowState) -> None:
     reason = (f"Upstream fix ({state.commit_hash[:12]}: {subject}) produces "
               f"no changes — code already matches the fixed version")
     write_cve_status(state.meta_layer, state.recipe, state.cve_id,
-                     reason, skip_confirm=state.skip_confirm)
+                     reason, skip_confirm=state.skip_confirm,
+                     sign_off=state.sign_off)
 
 
 def collect_cve_commits(state: WorkflowState) -> list[str]:

--- a/cve_corrector/meta_layer.py
+++ b/cve_corrector/meta_layer.py
@@ -110,8 +110,15 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
                         ptest_output: Optional[str] = None, skip_confirm: bool = False,
                         hash_details: Optional[list] = None,
                         series_state: Optional[dict] = None,
-                        used_commits: Optional[list] = None) -> bool:
+                        used_commits: Optional[list] = None,
+                        sign_off: bool = False) -> bool:
     """Create git commit in meta-layer with updated recipe and patch.
+
+    Args:
+        sign_off: When True, append a ``Signed-off-by`` trailer using the
+            resolved git identity. Default False — the tool must not
+            fabricate a DCO certification nobody made; only emit one when
+            explicitly requested.
 
     Returns:
         True if a commit was created, False otherwise.
@@ -120,7 +127,6 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
         logger.warning("Meta-layer path invalid: %s", meta_layer)
         return False
 
-    author, email = get_git_user_info()
     commit_msg = f"{recipe}: fix {cve_id}\n\nBackport patch to fix {cve_id}.\n\n"
 
     # Templated per-source tracker references (NVD plus any contributing public
@@ -168,7 +174,9 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
         logger.info(ptest_output)
         commit_msg += f"Tested with ptest:\n{ptest_output}\n\n"
 
-    commit_msg += f"Signed-off-by: {author} <{email}>\n"
+    if sign_off:
+        author, email = get_git_user_info()
+        commit_msg += f"Signed-off-by: {author} <{email}>\n"
 
     logger.info("Commit Message:")
     logger.info(commit_msg)
@@ -292,8 +300,15 @@ def _map_cve_status_reason(reason: str) -> str:
 
 
 def write_cve_status(meta_layer: Optional[Path], recipe: str, cve_id: str,
-                     reason: str, skip_confirm: bool = False) -> bool:
+                     reason: str, skip_confirm: bool = False,
+                     sign_off: bool = False) -> bool:
     """Append a CVE_STATUS line to the recipe's .bb or .bbappend in the meta-layer.
+
+    Args:
+        sign_off: When True, append a ``Signed-off-by`` trailer using the
+            resolved git identity. Default False — the tool must not
+            fabricate a DCO certification nobody made; only emit one when
+            explicitly requested.
 
     Returns:
         True if the CVE_STATUS was written and committed, False otherwise.
@@ -322,12 +337,10 @@ def write_cve_status(meta_layer: Optional[Path], recipe: str, cve_id: str,
     recipe_file.write_text(content, encoding='utf-8')
     logger.info("Wrote CVE_STATUS for %s to %s", cve_id, recipe_file)
 
-    author, email = get_git_user_info()
-    commit_msg = (
-        f"{recipe}: mark {cve_id} as not applicable\n\n"
-        f"{reason}\n\n"
-        f"Signed-off-by: {author} <{email}>\n"
-    )
+    commit_msg = f"{recipe}: mark {cve_id} as not applicable\n\n{reason}\n"
+    if sign_off:
+        author, email = get_git_user_info()
+        commit_msg += f"\nSigned-off-by: {author} <{email}>\n"
 
     if not skip_confirm:
         print(f"\nCVE_STATUS line:\n  {status_line}")

--- a/cve_corrector/patch_ops.py
+++ b/cve_corrector/patch_ops.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 def modify_patch(patch_file: Path, cve_id: str, original_url: str,
-                 include_cve_tag: bool = True) -> None:
+                 include_cve_tag: bool = True, sign_off: bool = False) -> None:
     """Add CVE and/or Upstream-Status metadata to a patch.
 
     Args:
@@ -38,27 +38,50 @@ def modify_patch(patch_file: Path, cve_id: str, original_url: str,
             so it gets ``Upstream-Status: Backport`` **only**. The ``CVE:``
             tag drives ``sbom-cve-check``; tagging a prerequisite with it
             would falsely report that patch as the fix.
+        sign_off: When True, append a ``Signed-off-by`` trailer using the
+            resolved git identity. Default False — the tool must not
+            fabricate a DCO certification nobody made; only emit one when
+            explicitly requested.
     """
     text = patch_file.read_text(encoding="utf-8")
 
-    # Idempotence: skip if the patch already carries the metadata it needs.
+    # Idempotence: skip re-adding metadata the patch already carries.
     # The fix patch needs both tags; a prerequisite needs only Upstream-Status.
     has_upstream = "Upstream-Status:" in text
     has_cve = f"CVE: {cve_id}" in text
-    if has_upstream and (has_cve or not include_cve_tag):
+    metadata_present = has_upstream and (has_cve or not include_cve_tag)
+
+    # Check for our own resolved identity's line specifically, not just any
+    # "Signed-off-by:" text — the upstream commit being backported may carry
+    # its original author's own signoff in the copied commit message, which
+    # must not be mistaken for our local identity already having signed off.
+    own_signoff_line = None
+    has_own_signoff = False
+    if sign_off:
+        author, email = get_git_user_info()
+        own_signoff_line = f"Signed-off-by: {author} <{email}>"
+        has_own_signoff = own_signoff_line in text
+
+    if metadata_present and (not sign_off or has_own_signoff):
         return
 
-    author, email = get_git_user_info()
-
-    cve_line = f"CVE: {cve_id}\n" if include_cve_tag else ""
-    block = (
-        "\n"
-        f"{cve_line}"
-        f"Upstream-Status: Backport [{original_url}]\n\n"
-        f"Signed-off-by: {author} <{email}>\n"
-    )
-
     lines = text.splitlines(keepends=True)
+
+    if metadata_present:
+        # CVE:/Upstream-Status: are already there (e.g. a resumed or
+        # reprocessed patch) — sign_off is the only thing missing. Add just
+        # the trailer instead of re-running the block below, which would
+        # duplicate the existing headers.
+        block = f"\n{own_signoff_line}\n"
+    else:
+        cve_line = f"CVE: {cve_id}\n" if include_cve_tag else ""
+        block = (
+            "\n"
+            f"{cve_line}"
+            f"Upstream-Status: Backport [{original_url}]\n"
+        )
+        if sign_off:
+            block += f"\n{own_signoff_line}\n"
 
     insert_index = None
     for i, line in enumerate(lines):
@@ -245,7 +268,7 @@ def update_patches_with_metadata(state: WorkflowState) -> None:
         kind = "" if include_cve else " (prerequisite, no CVE tag)"
         logger.info("Upstream-Status: Backport [%s]%s", original_url, kind)
         modify_patch(original_patch, state.cve_id, original_url,
-                     include_cve_tag=include_cve)
+                     include_cve_tag=include_cve, sign_off=state.sign_off)
 
         new_name = (f"{state.cve_id}.patch" if len(original_patches) == 1
                     else f"{state.cve_id}-{idx}.patch")

--- a/cve_corrector/state.py
+++ b/cve_corrector/state.py
@@ -115,6 +115,7 @@ class WorkflowState:  # pylint: disable=too-many-instance-attributes
     subproject: Optional[str] = None
     bbappend: bool = False
     version: Optional[str] = None
+    sign_off: bool = False
 
     def to_dict(self) -> dict:
         """Convert to JSON-serializable dict."""
@@ -134,7 +135,8 @@ class WorkflowState:  # pylint: disable=too-many-instance-attributes
             'skip_confirm': self.skip_confirm,
             'subproject': self.subproject,
             'bbappend': self.bbappend,
-            'version': self.version
+            'version': self.version,
+            'sign_off': self.sign_off
         }
 
     @classmethod
@@ -156,7 +158,8 @@ class WorkflowState:  # pylint: disable=too-many-instance-attributes
             skip_confirm=data.get('skip_confirm', False),
             subproject=data.get('subproject'),
             bbappend=data.get('bbappend', False),
-            version=data.get('version')
+            version=data.get('version'),
+            sign_off=data.get('sign_off', False)
         )
 
 

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -350,7 +350,8 @@ def finish_cve_workflow(state: WorkflowState) -> None:
                                     ptest_output, state.skip_confirm,
                                     hash_details=state.hash_details,
                                     series_state=state.series_state,
-                                    used_commits=used_commits)
+                                    used_commits=used_commits,
+                                    sign_off=state.sign_off)
 
     if not committed and state.meta_layer:
         # Check if there were actually no changes (vs user cancelled)
@@ -366,7 +367,8 @@ def finish_cve_workflow(state: WorkflowState) -> None:
                       f"no net changes after conflict resolution — "
                       f"code already matches the fixed version")
             write_cve_status(state.meta_layer, state.recipe, state.cve_id,
-                             reason, skip_confirm=state.skip_confirm)
+                             reason, skip_confirm=state.skip_confirm,
+                             sign_off=state.sign_off)
             if state_file.exists():
                 state_file.unlink()
             logger.info("CVE_STATUS written for %s — no patch needed", state.cve_id)
@@ -487,6 +489,7 @@ class WorkflowConfig:
     skip_cve_applicability: bool = False
     skip_confirm: bool = False
     require_all_commits: bool = False
+    sign_off: bool = False
 
 
 def _handle_failed_series(workspace_path, best_series, make_state, recipe):
@@ -652,11 +655,13 @@ def initialize_cve_workflow(
                         # User disagrees — don't raise, continue with normal workflow
                     else:
                         write_cve_status(config.meta_layer, recipe, cve_id,
-                                         not_applicable, skip_confirm=True)
+                                         not_applicable, skip_confirm=True,
+                                         sign_off=config.sign_off)
                         raise NotApplicableError("CVE not applicable")
                 else:
                     write_cve_status(config.meta_layer, recipe, cve_id,
-                                     not_applicable, skip_confirm=True)
+                                     not_applicable, skip_confirm=True,
+                                     sign_off=config.sign_off)
                     raise NotApplicableError("CVE not applicable")
             else:
                 raise NotApplicableError("CVE not applicable")
@@ -699,7 +704,7 @@ def initialize_cve_workflow(
             skip_build=config.skip_build, skip_ptest=config.skip_ptest,
             ptest_before=ptest_before, series_state=series_state,
             subproject=subproject, bbappend=config.bbappend,
-            version=version)
+            version=version, sign_off=config.sign_off)
 
     if config.manual_mode:
         state = make_state(hashes[0] if hashes else '')

--- a/tests/agent/test_main.py
+++ b/tests/agent/test_main.py
@@ -335,16 +335,20 @@ class TestResolutionLoop:
         assert result.status == ResultStatus.CONFLICT_RESOLVED
 
 
+def _mock_proc(lines=()):
+    proc = MagicMock()
+    proc.stdout = iter(lines)
+    proc.wait.return_value = None
+    proc.returncode = 0
+    proc.__enter__ = lambda s: s
+    proc.__exit__ = MagicMock(return_value=False)
+    return proc
+
+
 class TestRunCorrector:
     @patch("subprocess.Popen")
     def test_initial_mode(self, mock_popen):
-        proc = MagicMock()
-        proc.stdout = iter(["line1\n"])
-        proc.wait.return_value = None
-        proc.returncode = 0
-        proc.__enter__ = lambda s: s
-        proc.__exit__ = MagicMock(return_value=False)
-        mock_popen.return_value = proc
+        mock_popen.return_value = _mock_proc(["line1\n"])
         cfg = _cfg(clean=True, mirror_dir=Path("/m"), meta_layer=Path("/l"), skip_ptest=True)
         code, output = _run_corrector(cfg)
         assert code == 0
@@ -356,18 +360,48 @@ class TestRunCorrector:
         assert "--skip-ptest" in cmd
 
     @patch("subprocess.Popen")
+    def test_initial_mode_no_sign_off_by_default(self, mock_popen):
+        mock_popen.return_value = _mock_proc()
+        _run_corrector(_cfg())
+        cmd = mock_popen.call_args[0][0]
+        assert "--sign-off" not in cmd
+
+    @patch("subprocess.Popen")
+    def test_initial_mode_sign_off_passthrough(self, mock_popen):
+        mock_popen.return_value = _mock_proc()
+        _run_corrector(_cfg(sign_off=True))
+        cmd = mock_popen.call_args[0][0]
+        assert "--sign-off" in cmd
+
+    @patch("subprocess.Popen")
     def test_continue_mode(self, mock_popen):
-        proc = MagicMock()
-        proc.stdout = iter([])
-        proc.wait.return_value = None
-        proc.returncode = 0
-        proc.__enter__ = lambda s: s
-        proc.__exit__ = MagicMock(return_value=False)
-        mock_popen.return_value = proc
+        mock_popen.return_value = _mock_proc()
         code, _ = _run_corrector(_cfg(), continue_mode=True)
         assert code == 0
         cmd = mock_popen.call_args[0][0]
         assert "--continue" in cmd
+
+    @patch("subprocess.Popen")
+    def test_continue_mode_sign_off_passthrough(self, mock_popen):
+        mock_popen.return_value = _mock_proc()
+        _run_corrector(_cfg(sign_off=True), continue_mode=True)
+        cmd = mock_popen.call_args[0][0]
+        assert "--sign-off" in cmd
+
+    @patch("subprocess.Popen")
+    def test_mark_not_applicable_sign_off_passthrough(self, mock_popen):
+        mock_popen.return_value = _mock_proc()
+        _run_corrector(_cfg(sign_off=True), mark_not_applicable="reason")
+        cmd = mock_popen.call_args[0][0]
+        assert "--mark-not-applicable" in cmd
+        assert "--sign-off" in cmd
+
+    @patch("subprocess.Popen")
+    def test_mark_not_applicable_no_sign_off_by_default(self, mock_popen):
+        mock_popen.return_value = _mock_proc()
+        _run_corrector(_cfg(), mark_not_applicable="reason")
+        cmd = mock_popen.call_args[0][0]
+        assert "--sign-off" not in cmd
 
 
 class TestPrintBatchSummary:

--- a/tests/agent/test_main_cli.py
+++ b/tests/agent/test_main_cli.py
@@ -71,6 +71,19 @@ class TestParseArgs:
         args = _parse_args()
         assert args.skip_sources == []
 
+    def test_sign_off_default_false(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-1', '--cve-info', '/tmp/c.json'])
+        args = _parse_args()
+        assert args.sign_off is False
+
+    def test_sign_off_flag(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-1', '--cve-info', '/tmp/c.json',
+            '--sign-off'])
+        args = _parse_args()
+        assert args.sign_off is True
+
 
 class TestConfigFromArgs:
     def test_creates_config(self, monkeypatch):
@@ -90,6 +103,71 @@ class TestConfigFromArgs:
         args = _parse_args()
         config = _config_from_args(args, 'CVE-2025-0001')
         assert config.skip_sources == ['osv', 'ubuntu']
+
+    def test_sign_off_passthrough(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', '/tmp/cve.json', '--sign-off'])
+        args = _parse_args()
+        config = _config_from_args(args, 'CVE-2025-0001')
+        assert config.sign_off is True
+
+    def test_sign_off_default_false(self, monkeypatch):
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', '/tmp/cve.json'])
+        args = _parse_args()
+        config = _config_from_args(args, 'CVE-2025-0001')
+        assert config.sign_off is False
+
+
+class TestTrustSignOffRejected:
+    """--trust auto-approves AI changes with no human review; combined with
+    --sign-off that would certify a DCO nobody actually reviewed. The
+    combination is rejected outright rather than allowed silently."""
+
+    @patch('cve_agent.__main__.ensure_agents')
+    @patch('cve_agent.__main__.process_single_cve')
+    def test_trust_and_sign_off_rejected(self, mock_process, mock_ensure,
+                                         monkeypatch, capsys):
+        from cve_agent import EXIT_AGENT_ERROR
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001', '--cve-info', '/tmp/c.json',
+            '--trust', '--sign-off'])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == EXIT_AGENT_ERROR
+        err = capsys.readouterr().err
+        assert '--trust' in err
+        assert '--sign-off' in err
+        # The rejection must happen before any agent/AI-session setup or CVE
+        # processing — no AI backend touched, no work attempted.
+        mock_ensure.assert_not_called()
+        mock_process.assert_not_called()
+
+    def test_sign_off_alone_not_rejected(self, monkeypatch, capsys):
+        """--sign-off without --trust must pass the combination check and
+        fall through to the next validation (missing --cve-info), not the
+        --trust/--sign-off rejection — distinguished by the error message
+        since both paths share EXIT_AGENT_ERROR."""
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001', '--sign-off'])
+        with pytest.raises(SystemExit):
+            main()
+        err = capsys.readouterr().err
+        assert '--trust and --sign-off cannot be combined' not in err
+        assert '--cve-info or --fix-url is required' in err
+
+    def test_trust_alone_not_rejected(self, monkeypatch, capsys):
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001', '--trust'])
+        with pytest.raises(SystemExit):
+            main()
+        err = capsys.readouterr().err
+        assert '--trust and --sign-off cannot be combined' not in err
 
 
 class TestReadCveList:

--- a/tests/corrector/test_main_cli.py
+++ b/tests/corrector/test_main_cli.py
@@ -67,6 +67,38 @@ class TestMainCli:
             with pytest.raises(SystemExit):
                 main()
 
+    def _resumed_state(self, tmp_path, sign_off):
+        from cve_corrector.state import WorkflowState
+        return WorkflowState(
+            workspace_path=tmp_path / 'ws', cve_id='CVE-2025-0001', recipe='foo',
+            commit_hash='abc123', hash_details=[], meta_layer=None,
+            skip_build=True, skip_ptest=True, sign_off=sign_off)
+
+    def test_continue_preserves_stored_sign_off_when_flag_omitted(self, tmp_path, monkeypatch):
+        """--continue without repeating --sign-off must not silently unsign a
+        run that opted in on its original invocation."""
+        monkeypatch.setattr('sys.argv', ['cve-corrector', '--continue'])
+        monkeypatch.setenv('BBPATH', '/tmp')
+        state = self._resumed_state(tmp_path, sign_off=True)
+        with patch('shutil.which', return_value='/usr/bin/bitbake-layers'), \
+             patch('cve_corrector.__main__.continue_from_conflict', return_value=state), \
+             patch('cve_corrector.__main__.setup_logging', return_value='log.txt'), \
+             patch('cve_corrector.__main__.finish_cve_workflow') as mock_finish:
+            main()
+        assert mock_finish.call_args[0][0].sign_off is True
+
+    def test_continue_sign_off_flag_overrides_stored_value(self, tmp_path, monkeypatch):
+        """Repeating --sign-off on --continue still overrides the stored value."""
+        monkeypatch.setattr('sys.argv', ['cve-corrector', '--continue', '--sign-off'])
+        monkeypatch.setenv('BBPATH', '/tmp')
+        state = self._resumed_state(tmp_path, sign_off=False)
+        with patch('shutil.which', return_value='/usr/bin/bitbake-layers'), \
+             patch('cve_corrector.__main__.continue_from_conflict', return_value=state), \
+             patch('cve_corrector.__main__.setup_logging', return_value='log.txt'), \
+             patch('cve_corrector.__main__.finish_cve_workflow') as mock_finish:
+            main()
+        assert mock_finish.call_args[0][0].sign_off is True
+
     def test_skip_source_removes_only_matching(self, tmp_path, monkeypatch):
         """--skip-source drops the osv-only commit but keeps the debian one."""
         cve_info = tmp_path / 'cve.json'

--- a/tests/corrector/test_meta_layer_export.py
+++ b/tests/corrector/test_meta_layer_export.py
@@ -4,10 +4,11 @@
 LAYERSERIES_CORENAMES-based --subject-prefix used when exporting a patch
 for mailing-list submission.
 """
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from cve_corrector.bitbake_ops import get_layerseries_corename
-from cve_corrector.meta_layer import _export_commit_patch
+from cve_corrector.meta_layer import _export_commit_patch, write_cve_status
 
 
 class TestGetLayerseriesCorename:
@@ -86,3 +87,53 @@ class TestExportCommitPatch:
         with caplog.at_level(logging.WARNING, logger="cve_corrector"):
             _export_commit_patch(meta)
         assert any("Failed to export patch" in r.message for r in caplog.records)
+
+
+class TestWriteCveStatusSignoff:
+    """write_cve_status must not fabricate a Signed-off-by trailer unless
+    explicitly requested — the tool cannot know whether the resolved git
+    identity represents a human who has reviewed this specific change."""
+
+    def _meta_layer_with_recipe(self, tmp_path, recipe="busybox"):
+        meta = tmp_path / "meta"
+        recipe_dir = meta / "recipes-core" / recipe
+        recipe_dir.mkdir(parents=True)
+        recipe_file = recipe_dir / f"{recipe}_1.36.bb"
+        recipe_file.write_text('SUMMARY = "busybox"\n')
+        return meta, recipe_file
+
+    @staticmethod
+    def _capturing_run_cmd(captured):
+        def _run_cmd(cmd, cwd=None):
+            if cmd[:2] == ['git', 'commit']:
+                msg_file = cmd[cmd.index('-F') + 1]
+                captured.append(Path(msg_file).read_text())
+            return 0
+        return _run_cmd
+
+    @patch("cve_corrector.meta_layer._export_commit_patch")
+    @patch("cve_corrector.meta_layer.get_git_user_info", return_value=("A", "a@b.c"))
+    def test_no_signoff_by_default(self, mock_info, mock_export, tmp_path):
+        meta, recipe_file = self._meta_layer_with_recipe(tmp_path)
+        captured = []
+        with patch("cve_corrector.recipe_ops._find_recipe_file",
+                   return_value=recipe_file), \
+             patch("cve_corrector.meta_layer.run_cmd",
+                  side_effect=self._capturing_run_cmd(captured)):
+            write_cve_status(meta, "busybox", "CVE-1", "not applicable",
+                             skip_confirm=True)
+        assert captured and "Signed-off-by" not in captured[0]
+        mock_info.assert_not_called()
+
+    @patch("cve_corrector.meta_layer._export_commit_patch")
+    @patch("cve_corrector.meta_layer.get_git_user_info", return_value=("A", "a@b.c"))
+    def test_signoff_opt_in(self, mock_info, mock_export, tmp_path):
+        meta, recipe_file = self._meta_layer_with_recipe(tmp_path)
+        captured = []
+        with patch("cve_corrector.recipe_ops._find_recipe_file",
+                   return_value=recipe_file), \
+             patch("cve_corrector.meta_layer.run_cmd",
+                  side_effect=self._capturing_run_cmd(captured)):
+            write_cve_status(meta, "busybox", "CVE-1", "not applicable",
+                             skip_confirm=True, sign_off=True)
+        assert captured and "Signed-off-by: A <a@b.c>" in captured[0]

--- a/tests/corrector/test_patch.py
+++ b/tests/corrector/test_patch.py
@@ -18,19 +18,130 @@ Some description.
 diff --git a/file.c b/file.c
 """
 
+UPSTREAM_SIGNED_PATCH = """\
+From abc123 Mon Sep 17 00:00:00 2001
+Subject: Fix something
+
+Some description.
+
+Signed-off-by: Upstream Author <upstream@example.com>
+---
+ file.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/file.c b/file.c
+"""
+
 
 def test_modify_patch_inserts_metadata(tmp_path):
+    p = tmp_path / "test.patch"
+    p.write_text(MINIMAL_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info") as mock_info:
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc")
+        # Default (no sign_off): must never fabricate a DCO certification —
+        # the resolved git identity isn't even looked up.
+        mock_info.assert_not_called()
+    content = p.read_text()
+    assert "CVE: CVE-2025-0001" in content
+    assert "Upstream-Status: Backport [https://example.com/commit/abc]" in content
+    assert "Signed-off-by:" not in content
+    # Metadata should appear before the --- separator
+    assert content.index("CVE: CVE-2025-0001") < content.index("\n---\n")
+
+
+def test_modify_patch_sign_off_opt_in(tmp_path):
+    p = tmp_path / "test.patch"
+    p.write_text(MINIMAL_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc",
+                     sign_off=True)
+    content = p.read_text()
+    assert "CVE: CVE-2025-0001" in content
+    assert "Upstream-Status: Backport [https://example.com/commit/abc]" in content
+    assert "Signed-off-by: Test User <test@example.com>" in content
+
+
+def test_modify_patch_sign_off_added_to_already_annotated_patch(tmp_path):
+    """A patch that already has CVE:/Upstream-Status: (e.g. resumed or
+    reprocessed) must still gain a Signed-off-by trailer on an explicit
+    opt-in call, without duplicating the existing headers."""
     p = tmp_path / "test.patch"
     p.write_text(MINIMAL_PATCH)
     with mock_patch("cve_corrector.patch_ops.get_git_user_info",
                     return_value=("Test User", "test@example.com")):
         modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc")
+        no_signoff = p.read_text()
+        assert "Signed-off-by:" not in no_signoff
+
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc",
+                     sign_off=True)
     content = p.read_text()
-    assert "CVE: CVE-2025-0001" in content
-    assert "Upstream-Status: Backport [https://example.com/commit/abc]" in content
+    assert content.count("CVE: CVE-2025-0001") == 1
+    assert content.count("Upstream-Status:") == 1
     assert "Signed-off-by: Test User <test@example.com>" in content
-    # Metadata should appear before the --- separator
-    assert content.index("CVE: CVE-2025-0001") < content.index("\n---\n")
+
+    # Idempotent: calling again with sign_off=True doesn't duplicate it.
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc",
+                     sign_off=True)
+    assert p.read_text().count("Signed-off-by:") == 1
+
+
+def test_modify_patch_sign_off_not_satisfied_by_upstream_signoff(tmp_path):
+    """An upstream commit's own Signed-off-by, copied into the patch body by
+    format-patch, must not be mistaken for our local identity already having
+    signed off — --sign-off checks for the resolved identity's own line.
+
+    The bug only surfaces once CVE:/Upstream-Status: are already present
+    (metadata_present=True), which is when the idempotence early-return
+    kicks in — so this must be reproduced across two calls, matching a
+    resumed/reprocessed patch, not a single call on a fresh one.
+    """
+    p = tmp_path / "test.patch"
+    p.write_text(UPSTREAM_SIGNED_PATCH)
+    # First pass, sign_off=False (e.g. the default first run): adds CVE:/
+    # Upstream-Status: alongside the upstream author's pre-existing signoff.
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info") as mock_info:
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc")
+        mock_info.assert_not_called()
+    after_first = p.read_text()
+    assert "Signed-off-by: Upstream Author <upstream@example.com>" in after_first
+    assert "Test User" not in after_first
+
+    # Second pass, sign_off=True (e.g. a resumed run with --sign-off): must
+    # add our own trailer, not treat the upstream author's line as already
+    # satisfying it.
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc",
+                     sign_off=True)
+    content = p.read_text()
+    assert "Signed-off-by: Upstream Author <upstream@example.com>" in content
+    assert "Signed-off-by: Test User <test@example.com>" in content
+
+    # Idempotent: re-running doesn't duplicate our own line or touch upstream's.
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc",
+                     sign_off=True)
+    final = p.read_text()
+    assert final.count("Signed-off-by: Upstream Author <upstream@example.com>") == 1
+    assert final.count("Signed-off-by: Test User <test@example.com>") == 1
+
+
+def test_modify_patch_upstream_signoff_alone_does_not_trigger_ours(tmp_path):
+    """Without --sign-off, an upstream commit's own signoff already present
+    in the patch body must not cause us to add our own — default stays off."""
+    p = tmp_path / "test.patch"
+    p.write_text(UPSTREAM_SIGNED_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info") as mock_info:
+        modify_patch(p, "CVE-2025-0001", "https://example.com/commit/abc")
+        mock_info.assert_not_called()
+    content = p.read_text()
+    assert content.count("Signed-off-by:") == 1
+    assert "Signed-off-by: Upstream Author <upstream@example.com>" in content
 
 
 def test_modify_patch_idempotent(tmp_path):
@@ -173,7 +284,8 @@ Prerequisite introducing the helper the fix calls.
 
 
 def test_modify_patch_prerequisite_omits_cve_tag(tmp_path):
-    """A prerequisite patch gets Upstream-Status but NOT a CVE tag."""
+    """A prerequisite patch gets Upstream-Status but NOT a CVE tag, and no
+    Signed-off-by unless explicitly requested."""
     p = tmp_path / "prereq.patch"
     p.write_text(_PREREQ_PATCH)
     with mock_patch("cve_corrector.patch_ops.get_git_user_info",
@@ -183,7 +295,16 @@ def test_modify_patch_prerequisite_omits_cve_tag(tmp_path):
     content = p.read_text()
     assert "CVE: CVE-2025-0001" not in content
     assert "Upstream-Status: Backport [https://example.com/commit/bbb]" in content
-    assert "Signed-off-by: Test User <test@example.com>" in content
+    assert "Signed-off-by:" not in content
+
+    p2 = tmp_path / "prereq2.patch"
+    p2.write_text(_PREREQ_PATCH)
+    with mock_patch("cve_corrector.patch_ops.get_git_user_info",
+                    return_value=("Test User", "test@example.com")):
+        modify_patch(p2, "CVE-2025-0001", "https://example.com/commit/bbb",
+                     include_cve_tag=False, sign_off=True)
+    content2 = p2.read_text()
+    assert "Signed-off-by: Test User <test@example.com>" in content2
 
 
 def test_modify_patch_prerequisite_idempotent(tmp_path):

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -589,6 +589,41 @@ class TestCreateLayerCommit:
         assert 'ubuntu.com/security' not in logged
         assert 'osv.dev' not in logged
 
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("subprocess.run")
+    @patch("cve_corrector.meta_layer.run_cmd", return_value=0)
+    @patch("cve_corrector.meta_layer.get_git_user_info", return_value=("A", "a@b.c"))
+    def test_no_signoff_by_default(self, mock_info, mock_cmd, mock_subrun, mock_bp,
+                                   tmp_path, caplog):
+        """Default behavior must not fabricate a Signed-off-by / DCO certification."""
+        mock_bp.return_value = tmp_path
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        mock_subrun.return_value = MagicMock(returncode=0, stdout="")
+        import logging
+        with caplog.at_level(logging.INFO, logger="cve_corrector"):
+            create_layer_commit(meta, "busybox", "CVE-1", skip_confirm=True)
+        logged = "\n".join(caplog.messages)
+        assert "Signed-off-by" not in logged
+        mock_info.assert_not_called()
+
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("subprocess.run")
+    @patch("cve_corrector.meta_layer.run_cmd", return_value=0)
+    @patch("cve_corrector.meta_layer.get_git_user_info", return_value=("A", "a@b.c"))
+    def test_signoff_opt_in(self, mock_info, mock_cmd, mock_subrun, mock_bp,
+                            tmp_path, caplog):
+        mock_bp.return_value = tmp_path
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        mock_subrun.return_value = MagicMock(returncode=0, stdout="")
+        import logging
+        with caplog.at_level(logging.INFO, logger="cve_corrector"):
+            create_layer_commit(meta, "busybox", "CVE-1", skip_confirm=True,
+                                sign_off=True)
+        logged = "\n".join(caplog.messages)
+        assert "Signed-off-by: A <a@b.c>" in logged
+
 
 class TestContinueFromConflict:
     @patch("cve_corrector.workflow.get_state_dir")


### PR DESCRIPTION
## Problem

`cve_corrector` emits a `Signed-off-by: <name> <email>` trailer on every
generated patch and commit message, using whatever `git config
user.name`/`user.email` resolves in the invoking shell — regardless of
whether the upstream commit being backported carried one at all, or whether
anyone has actually reviewed and consented to certifying this specific
change.

This directly contradicts the project's own `CONTRIBUTING.md`:

> AI agents MUST NOT add `Signed-off-by` tags. Only humans can legally
> certify the Developer Certificate of Origin (DCO).

Run unattended — its primary intended use, hence `--yes`/`--skip-ptest`/
`--skip-build` — the corrector does exactly what this project tells
AI-assisted *contributors* not to do: it manufactures a DCO certification
nobody made.

### Evidence (downstream, live wrynose/Yocto 6.0 build — not synthetic)

- `--cve-id CVE-2026-35535 --bbappend` against `sudo` produced a patch whose
  `Signed-off-by` read `kas User <kas@example.com>` — a placeholder
  identity, not a human's. The real upstream commit
  (`sudo-project/sudo@3e474c2f201484be83d994ae10a4e20e8c81bb69`) carries
  **no** `Signed-off-by` at all.
- Same result for `--cve-id CVE-2026-40164` against `jq`
  (`jqlang/jq@0c7d133c3c7e37c00b6d46b658a02244fdd3c784` — also no original
  signoff).
- Reproduced independently twice, identical fabricated identity, identical
  pattern both times.

`kas User <kas@example.com>` is not the corrector's own fallback —
`get_git_user_info()` only falls back to `'Unknown'`/`'unknown@example.com'`
if `git config` itself fails, and it did not fail here. `KAS_USER_NAME`/
`KAS_USER_EMAIL` are literal constants in the `kas` build tool
(`kas/libcmds.py`), used for kas's own internal commit automation. This run
was inside a kas-managed build environment, which is how those values
reached `git config user.name`/`user.email` for the corrector's own
unrelated git operations. Whichever identity resolves, fabricating a
signoff nobody asked for is the bug, not the specific name that showed up.

Three call sites, all via `get_git_user_info()` in `git_ops.py`:

1. `patch_ops.py`, `modify_patch()` — writes into the generated `.patch`
   file's header (the one that produced the bad patches above).
2. `meta_layer.py`, `create_layer_commit()` — meta-layer commit message.
3. `meta_layer.py`, the `--mark-not-applicable` commit-message builder —
   same pattern, `CVE_STATUS` disposition commits.

## Change

Add a `--sign-off` CLI flag (default off), threaded through
`WorkflowConfig`/`WorkflowState` to all three call sites — the trailer is
only emitted when explicitly requested. `--sign-off` is **not**
unconditionally stripped: someone running the tool interactively, as
themselves, can still opt in to their own attribution. `CVE:`/
`Upstream-Status:` header generation is unchanged.

Two gaps came up in review of the first pass and are fixed here too:

- `--continue` unconditionally replaced the persisted `state.sign_off` with
  `args.sign_off`, whose argparse default is `False` — a run started with
  `--sign-off` silently lost it on the documented resume path. `--sign-off`
  now defaults to `None` (not `False`); `--continue` only overrides the
  persisted value when the flag is repeated, and coerces to `bool` at every
  other use site.
- `modify_patch()`'s idempotence check returned as soon as `CVE:`/
  `Upstream-Status:` were present, without checking `sign_off` — a resumed
  or reprocessed patch could stay unsigned despite an explicit opt-in. It
  now adds just the missing trailer in that case, without duplicating the
  existing headers.

## Out of scope

Two other findings from the same downstream run are independent bugs and
are **not** bundled into this PR:

- `--bbappend` creates a new version-pinned bbappend even when a matching
  wildcard bbappend (`<recipe>_%.bbappend`) already exists, and the
  `SRC_URI` merge can leave a malformed line that breaks bitbake parsing
  for the whole build.
- No workspace-state check across separate `--cve-id` invocations against
  the same recipe — a prior unresolved conflict causes the next
  `devtool modify` call to silently fall back to a non-tag checkout instead
  of failing loud or auto-resetting.

Each will get its own PR.

## Validation

`ruff check .`, `mypy cve_agent cve_corrector cve_metadata_extractor
shared`, and `pytest --cov` all pass — 1141 passed, 3 skipped; coverage
79.31% (was 78.79%, required floor 65%).

## Tests

| file | covers |
|---|---|
| `tests/corrector/test_patch.py` | `modify_patch` — no signoff by default, opt-in, and signoff added to an already-annotated patch without duplicating headers |
| `tests/corrector/test_workflow_full.py` | `create_layer_commit` — no signoff by default, opt-in |
| `tests/corrector/test_meta_layer_export.py` | `write_cve_status` — no signoff by default, opt-in |
| `tests/corrector/test_main_cli.py` | `--continue` preserves a stored `sign_off=True` when the flag isn't repeated, and still honors it when repeated |

All nine new/changed assertions fail on unmodified `main` and pass with the
fix (verified via `git stash` against the pre-fix implementation).
