### PR TITLE
corrector: fix three CVE-workflow bugs in commit/bbappend handling

### DIFF
--- a/cve_corrector/meta_layer.py
+++ b/cve_corrector/meta_layer.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from .bitbake_ops import get_build_path, get_layerseries_corename
 from .git_ops import get_git_user_info
-from .recipe_ops import _append_src_uri_entries
+from .recipe_ops import _append_src_uri_entries, _find_recipe_file
 from .utils import logger, run_cmd, run_cmd_capture
 
 
@@ -227,18 +227,12 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
             if (f.endswith('.bb') or f.endswith('.inc')) and f'/{recipe}' in f:
                 run_cmd(['git', 'checkout', 'HEAD', '--', f], cwd=meta_layer)
 
-        target = None
-        for pattern in (f'**/{recipe}*.inc', f'**/{recipe}*.bb',
-                        f'**/{recipe}*.bbappend'):
-            for candidate in sorted(meta_layer.glob(pattern)):
-                try:
-                    if 'file://' in candidate.read_text(encoding='utf-8'):
-                        target = candidate
-                        break
-                except (OSError, UnicodeDecodeError):
-                    continue
-            if target:
-                break
+        # Resolve the recipe's actual .bb/.bbappend/.inc file by name, not by
+        # scanning for an existing 'file://' entry — a recipe's *first* CVE
+        # patch has no prior file:// entries, so that check would find no
+        # target and silently drop the new SRC_URI line (and the whole
+        # recipe file, since it would then have no diff to stage).
+        target = _find_recipe_file(meta_layer, recipe)
         if target:
             _append_src_uri_entries(target, sorted(new_patches))
             logger.info("Added %s new SRC_URI entry/entries to %s",
@@ -249,9 +243,20 @@ def create_layer_commit(meta_layer: Optional[Path], recipe: str, cve_id: str,
         ['git', 'diff', '--relative', '--name-only'],
         cwd=meta_layer).stdout.strip().splitlines()
 
+    # Determine the recipe's own directory so its .bb/.bbappend/.inc file is
+    # staged even when that directory is not named after the recipe (e.g.
+    # 'acl' lives under recipes-support/attr/). Falls back to the old
+    # substring match if the recipe file can't be located (e.g. in tests
+    # that don't create one on disk).
     recipe_prefix = 'recipes-'
-    to_stage = [f for f in changed + untracked
-                if recipe_prefix in f and f'/{recipe}/' in f]
+    recipe_file = _find_recipe_file(meta_layer, recipe)
+    if recipe_file:
+        recipe_dir = str(recipe_file.parent.relative_to(meta_layer)) + '/'
+        to_stage = [f for f in changed + untracked
+                    if recipe_prefix in f and (f.startswith(recipe_dir) or f'/{recipe}/' in f)]
+    else:
+        to_stage = [f for f in changed + untracked
+                    if recipe_prefix in f and f'/{recipe}/' in f]
     if to_stage:
         run_cmd(['git', 'add', '--'] + to_stage, cwd=meta_layer)
     else:
@@ -313,8 +318,6 @@ def write_cve_status(meta_layer: Optional[Path], recipe: str, cve_id: str,
     Returns:
         True if the CVE_STATUS was written and committed, False otherwise.
     """
-    from .recipe_ops import _find_recipe_file
-
     if not meta_layer or not meta_layer.exists():
         logger.warning("Meta-layer path invalid: %s", meta_layer)
         return False

--- a/cve_corrector/recipe_ops.py
+++ b/cve_corrector/recipe_ops.py
@@ -123,10 +123,27 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
         r'(?::\w[\w-]*)*'  # optional override suffixes like :append:class-target
         r'\s*(?:\+|\.|\?)?='  # assignment operators: =, +=, .=, ?=
     )
+    # A plain SRC_URI assignment, with no override suffix at all. This is
+    # the block new file:// entries should be spliced into. Override-suffixed
+    # forms (e.g. SRC_URI:append:class-target = "...") are usually a distinct,
+    # narrowly-scoped line (e.g. machine/class specific) and must not be
+    # confused with the recipe's main patch list, or new entries would get
+    # spliced in front of an unrelated line's closing quote, producing a
+    # bare, malformed continuation line that breaks bitbake parsing.
+    base_src_uri_re = re.compile(r'^\s*SRC_URI\s*(?:\+|\.|\?)?=')
+
     src_uri_start = None
     for i, line in enumerate(lines):
-        if src_uri_re.match(line):
+        if base_src_uri_re.match(line):
             src_uri_start = i
+            break
+    if src_uri_start is None:
+        # No plain SRC_URI assignment — fall back to the first override form
+        # (e.g. a bbappend whose only SRC_URI line is ``SRC_URI:append``).
+        for i, line in enumerate(lines):
+            if src_uri_re.match(line):
+                src_uri_start = i
+                break
     if src_uri_start is not None:
         # Scan forward from SRC_URI to find the closing line
         for i in range(src_uri_start, len(lines)):
@@ -138,13 +155,31 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
                     insert_at = i
                 break
     if insert_at is not None:
-        indent = ''
-        for j in range(insert_at - 1, -1, -1):
-            if 'file://' in lines[j]:
-                indent = lines[j][:lines[j].index('file://')]
-                break
-        new_lines = [f'{indent}file://{name} \\' for name in patch_names]
-        lines[insert_at:insert_at] = new_lines
+        if insert_at == src_uri_start:
+            # Single-line assignment (e.g. SRC_URI = "file://a.patch") with
+            # no line continuation — splice the new entries inside its
+            # closing quote instead of inserting a bare line before it,
+            # which would leave the opening line's quote unterminated.
+            line = lines[insert_at]
+            quote_open = line.index('"')
+            quote_close = line.rfind('"')
+            var_part = line[:quote_open + 1]  # e.g. 'SRC_URI = "'
+            existing_content = line[quote_open + 1:quote_close].strip()
+            new_block = [f'{var_part} \\']
+            if existing_content:
+                new_block.append(f'           {existing_content} \\')
+            for name in patch_names:
+                new_block.append(f'           file://{name} \\')
+            new_block.append('           "')
+            lines[insert_at:insert_at + 1] = new_block
+        else:
+            indent = ''
+            for j in range(insert_at - 1, -1, -1):
+                if 'file://' in lines[j]:
+                    indent = lines[j][:lines[j].index('file://')]
+                    break
+            new_lines = [f'{indent}file://{name} \\' for name in patch_names]
+            lines[insert_at:insert_at] = new_lines
     else:
         lines.append('')
         if len(patch_names) == 1:

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -125,6 +125,41 @@ def filter_by_skip_sources(cve_info: dict, skip_sources: list[str]) -> dict:
     return new_info
 
 
+def _existing_wildcard_bbappends(meta_layer: Optional[Path], recipe: str) -> set[Path]:
+    """Return the ``{recipe}_%.bbappend`` files already present in the layer.
+
+    Snapshot this before invoking ``devtool update-recipe -w`` so newly
+    created wildcard bbappends can be distinguished from ones that already
+    existed (e.g. from a previous CVE fix on this recipe).
+    """
+    if not meta_layer:
+        return set()
+    return set(meta_layer.rglob(f'{recipe}_%.bbappend'))
+
+
+def _rename_new_wildcard_bbappends(meta_layer: Optional[Path], recipe: str,
+                                   version: Optional[str],
+                                   pre_existing: set[Path]) -> None:
+    """Rename wildcard bbappends created by this run to a versioned name.
+
+    ``devtool update-recipe -a <layer> -w <recipe>`` always targets a
+    ``{recipe}_%.bbappend`` path. If one already existed before this call
+    (``pre_existing``), devtool merges the new content into it in place —
+    that file must be left as a wildcard bbappend, since it may carry
+    content (e.g. an earlier CVE fix) meant to apply to every recipe
+    version. Only a bbappend that did *not* exist beforehand — i.e. one
+    devtool just created — is renamed to a version-pinned name.
+    """
+    if not version or not meta_layer:
+        return
+    for wc in meta_layer.rglob(f'{recipe}_%.bbappend'):
+        if wc in pre_existing:
+            continue
+        versioned = wc.with_name(f'{recipe}_{version}.bbappend')
+        wc.rename(versioned)
+        logger.info("Renamed %s -> %s", wc.name, versioned.name)
+
+
 def _kill_bitbake_server() -> None:
     """Kill any running bitbake server and all child processes."""
     import os
@@ -309,17 +344,19 @@ def finish_cve_workflow(state: WorkflowState) -> None:
         pre_finish_entries = snapshot_src_uri(state.meta_layer, state.recipe)
         if state.bbappend:
             logger.info("Creating bbappend for %s in %s", state.recipe, state.meta_layer)
+            # Snapshot pre-existing wildcard bbappends so we never rename one
+            # that already existed (e.g. from a previous CVE fix) — devtool
+            # merges new content into it in place when -w/--wildcard-version
+            # finds a matching file already on disk, and renaming it here
+            # would hijack a file meant to apply to every recipe version.
+            pre_existing_wildcards = _existing_wildcard_bbappends(
+                state.meta_layer, state.recipe)
             if run_cmd(['devtool', 'update-recipe', '-a', str(state.meta_layer),
                         '-w', state.recipe]) != 0:
                 save_progress(state, 'finish')
                 raise GitError("Git operation failed")
-            # Rename wildcard bbappend (recipe_%.bbappend) to versioned name
-            if state.version and state.meta_layer:
-                for wc in state.meta_layer.rglob(f'{state.recipe}_%.bbappend'):
-                    versioned = wc.with_name(
-                        f'{state.recipe}_{state.version}.bbappend')
-                    wc.rename(versioned)
-                    logger.info("Renamed %s -> %s", wc.name, versioned.name)
+            _rename_new_wildcard_bbappends(
+                state.meta_layer, state.recipe, state.version, pre_existing_wildcards)
             if run_cmd(['devtool', 'reset', state.recipe]) != 0:
                 logger.warning("devtool reset failed, continuing anyway")
         else:

--- a/tests/corrector/test_bitbake_ops.py
+++ b/tests/corrector/test_bitbake_ops.py
@@ -143,6 +143,98 @@ def test_append_src_uri_entries_override_style(tmp_path):
     assert content.index("CVE-2026-1234.patch") < content.rindex('"')
 
 
+def _assert_valid_bitbake_assignments(content):
+    """Minimal sanity check: every non-continuation, non-comment/blank line
+    that isn't inside a multi-line block must itself look like a complete
+    bitbake statement (an assignment, an override, or a plain keyword line),
+    never a bare orphaned ``file://...`` continuation fragment.
+    """
+    lines = content.splitlines()
+    in_continuation = False
+    for line in lines:
+        stripped = line.strip()
+        if in_continuation:
+            in_continuation = stripped.endswith('\\')
+            continue
+        if not stripped or stripped.startswith('#'):
+            continue
+        assert not stripped.startswith('file://'), (
+            f"Bare orphaned continuation line found (malformed bitbake): {line!r}")
+        in_continuation = stripped.endswith('\\')
+
+
+def test_append_src_uri_entries_ignores_trailing_override_line(tmp_path):
+    """A trailing single-line SRC_URI:append:* override must not be picked
+    as the merge target over the recipe's real, base SRC_URI block —
+    otherwise the new file:// entry gets spliced in as a bare line before
+    the override's closing quote, breaking bitbake parsing (regression test
+    for the reported malformed-SRC_URI-merge bug).
+    """
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "foo"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "foo_1.2.3.bb"
+    recipe.write_text(
+        'SUMMARY = "test"\n'
+        'SRC_URI = "http://example.com/foo.tar.gz \\\n'
+        '           file://existing.patch \\\n'
+        '           "\n'
+        '\n'
+        'SRC_URI:append:class-target = "file://target-only.patch"\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-99999.patch"])
+    content = recipe.read_text()
+    _assert_valid_bitbake_assignments(content)
+    # The new entry must land inside the base SRC_URI block, before its
+    # closing quote and before the unrelated override line.
+    lines = content.splitlines()
+    new_idx = next(i for i, l in enumerate(lines) if 'CVE-2026-99999.patch' in l)
+    override_idx = next(i for i, l in enumerate(lines) if l.startswith('SRC_URI:append'))
+    closing_quote_idx = next(i for i, l in enumerate(lines) if l.strip() == '"')
+    assert new_idx < closing_quote_idx < override_idx
+    # The unrelated override line must be untouched.
+    assert 'file://target-only.patch' in lines[override_idx]
+
+
+def test_append_src_uri_entries_single_line_assignment(tmp_path):
+    """A single-line (non-continued) SRC_URI assignment must be converted
+    into a valid multi-line block, not have a bare line spliced before it.
+    """
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "baz"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "baz_1.0.bb"
+    recipe.write_text('SRC_URI = "file://existing.patch"\n')
+    _append_src_uri_entries(recipe, ["CVE-2026-22222.patch"])
+    content = recipe.read_text()
+    _assert_valid_bitbake_assignments(content)
+    assert "file://existing.patch" in content
+    assert "file://CVE-2026-22222.patch" in content
+    # Original content must not be duplicated.
+    assert content.count("file://existing.patch") == 1
+
+
+def test_append_src_uri_entries_single_line_override_only(tmp_path):
+    """A single-line SRC_URI:append override (the only SRC_URI line present)
+    is used as the merge target and correctly converted to a multi-line
+    block.
+    """
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "bar"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "bar_1.0.bbappend"
+    recipe.write_text(
+        'FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"\n'
+        'SRC_URI:append = " file://old.patch"\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-11111.patch"])
+    content = recipe.read_text()
+    _assert_valid_bitbake_assignments(content)
+    assert content.count("file://old.patch") == 1
+    assert "file://CVE-2026-11111.patch" in content
+
+
+
 def test_find_recipe_file_exact_match(tmp_path):
     """_find_recipe_file does not match busybox-utils when looking for busybox."""
     from cve_corrector.recipe_ops import _find_recipe_file

--- a/tests/corrector/test_wildcard_bbappend_rename.py
+++ b/tests/corrector/test_wildcard_bbappend_rename.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for the wildcard-bbappend rename guard used by the --bbappend flow.
+
+Regression coverage for: --bbappend created a new version-pinned bbappend
+even when a matching wildcard (``recipe_%.bbappend``) already existed,
+hijacking/narrowing a bbappend that was meant to apply to every recipe
+version.
+"""
+from cve_corrector.workflow import (
+    _existing_wildcard_bbappends,
+    _rename_new_wildcard_bbappends,
+)
+
+
+def test_pre_existing_wildcard_bbappend_is_not_renamed(tmp_path):
+    """A wildcard bbappend that already existed before this run must be
+    left as-is — devtool merges new content into it in place, and it may
+    carry content (e.g. an earlier CVE fix) meant for every version.
+    """
+    recipe_dir = tmp_path / "recipes-test" / "foo"
+    recipe_dir.mkdir(parents=True)
+    wildcard = recipe_dir / "foo_%.bbappend"
+    wildcard.write_text(
+        'FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"\n'
+        'SRC_URI += "file://CVE-2025-0001.patch"\n'
+    )
+
+    pre_existing = _existing_wildcard_bbappends(tmp_path, "foo")
+    assert wildcard in pre_existing
+
+    # Simulate devtool merging new content into the same wildcard file
+    # (it does not create a new file when one already matches).
+    wildcard.write_text(
+        wildcard.read_text() + 'SRC_URI += "file://CVE-2026-99999.patch"\n')
+
+    _rename_new_wildcard_bbappends(tmp_path, "foo", "1.2.3", pre_existing)
+
+    assert wildcard.exists(), "pre-existing wildcard bbappend must not be renamed"
+    assert not (recipe_dir / "foo_1.2.3.bbappend").exists()
+    assert "CVE-2025-0001.patch" in wildcard.read_text()
+    assert "CVE-2026-99999.patch" in wildcard.read_text()
+
+
+def test_newly_created_wildcard_bbappend_is_renamed(tmp_path):
+    """A wildcard bbappend that did NOT exist before this run (i.e. one
+    devtool just created) is renamed to a version-pinned name, preserving
+    existing --bbappend behavior for the first CVE fix on a recipe.
+    """
+    recipe_dir = tmp_path / "recipes-test" / "foo"
+    recipe_dir.mkdir(parents=True)
+
+    pre_existing = _existing_wildcard_bbappends(tmp_path, "foo")
+    assert pre_existing == set()
+
+    # Simulate devtool creating a brand new wildcard bbappend.
+    new_wildcard = recipe_dir / "foo_%.bbappend"
+    new_wildcard.write_text('SRC_URI += "file://CVE-2026-99999.patch"\n')
+
+    _rename_new_wildcard_bbappends(tmp_path, "foo", "1.2.3", pre_existing)
+
+    assert not new_wildcard.exists()
+    versioned = recipe_dir / "foo_1.2.3.bbappend"
+    assert versioned.exists()
+    assert "CVE-2026-99999.patch" in versioned.read_text()
+
+
+def test_no_rename_without_version(tmp_path):
+    """No renaming happens when state.version is unset."""
+    recipe_dir = tmp_path / "recipes-test" / "foo"
+    recipe_dir.mkdir(parents=True)
+    wildcard = recipe_dir / "foo_%.bbappend"
+    wildcard.write_text('SRC_URI += "file://CVE-2026-99999.patch"\n')
+
+    _rename_new_wildcard_bbappends(tmp_path, "foo", None, set())
+
+    assert wildcard.exists()
+
+
+def test_no_rename_without_meta_layer():
+    """No error and no-op when meta_layer is None."""
+    assert _existing_wildcard_bbappends(None, "foo") == set()
+    _rename_new_wildcard_bbappends(None, "foo", "1.2.3", set())

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -625,6 +625,62 @@ class TestCreateLayerCommit:
         assert "Signed-off-by: A <a@b.c>" in logged
 
 
+class TestCreateLayerCommitStagesRecipeFile:
+    """Regression test: the recipe's .bb file must be staged even when its
+    directory is not named after the recipe (e.g. 'acl' lives under
+    recipes-support/attr/, not recipes-support/acl/).
+    """
+
+    @staticmethod
+    def _git(args, cwd):
+        import subprocess
+        subprocess.run(["git", *args], cwd=cwd, check=True,
+                       capture_output=True)
+
+    @patch("cve_corrector.meta_layer.get_layerseries_corename", return_value=None)
+    @patch("cve_corrector.meta_layer.get_build_path")
+    @patch("cve_corrector.git_ops.get_git_user_info", return_value=("A", "a@b.c"))
+    def test_bb_file_staged_when_dir_differs_from_recipe(self, mock_info, mock_bp,
+                                                          mock_corename, tmp_path):
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        self._git(["init"], cwd=meta)
+        self._git(["config", "user.email", "a@b.c"], cwd=meta)
+        self._git(["config", "user.name", "A"], cwd=meta)
+
+        recipe_dir = meta / "meta" / "recipes-support" / "attr"
+        recipe_dir.mkdir(parents=True)
+        bb_file = recipe_dir / "acl_2.3.2.bb"
+        bb_file.write_text('SRC_URI = "http://example.com/acl.tar.gz"\n')
+        self._git(["add", "-A"], cwd=meta)
+        self._git(["commit", "-m", "initial"], cwd=meta)
+
+        # Simulate devtool finish: append a new patch reference to the .bb
+        # file and drop the new patch under a same-named subdirectory.
+        bb_file.write_text(
+            'SRC_URI = "http://example.com/acl.tar.gz \\\n'
+            '           file://CVE-2026-54369.patch"\n')
+        patch_dir = recipe_dir / "acl"
+        patch_dir.mkdir()
+        (patch_dir / "CVE-2026-54369.patch").write_text(
+            "--- a/f\n+++ b/f\n---\n")
+
+        mock_bp.return_value = tmp_path
+
+        create_layer_commit(meta, "acl", "CVE-2026-54369", skip_confirm=True)
+
+        committed = subprocess_run(
+            ["git", "show", "--stat", "HEAD"], cwd=meta)
+        assert "acl_2.3.2.bb" in committed
+        assert "CVE-2026-54369.patch" in committed
+
+
+def subprocess_run(args, cwd):
+    import subprocess
+    return subprocess.run(args, cwd=cwd, check=True,
+                          capture_output=True, text=True).stdout
+
+
 class TestContinueFromConflict:
     @patch("cve_corrector.workflow.get_state_dir")
     def test_no_state(self, mock_dir, tmp_path):


### PR DESCRIPTION
  Three related bugs in cve_corrector's meta-layer commit and bbappend handling, found while investigating a CVE fix commit that
  was missing its recipe .bb change:
  
  1. Recipe .bb file dropped from staged commit (4bd5a7d) — create_layer_commit() used a naive /{recipe}/ substring match to
  decide what to stage, which fails when a recipe's directory isn't named after the recipe (e.g. acl lives under
  recipes-support/attr/). A deeper instance of the same root cause also silently dropped the SRC_URI append for any recipe's
  first CVE patch. Both now resolve the recipe's actual file via the existing _find_recipe_file() helper instead of
  directory-name or content-based heuristics.
  2. Wildcard bbappend hijacked into a version-pinned name (ae4b172) — with --bbappend, our code unconditionally renamed any
  {recipe}_%.bbappend it found after devtool update-recipe -w into a version-pinned name, even when that wildcard bbappend
  already existed from an earlier CVE fix and devtool had just merged the new patch into it in place. This silently narrowed a
  bbappend meant to apply to every recipe version down to a single one. Fixed by snapshotting pre-existing wildcard bbappends
  and only renaming ones devtool just created.
  3. Malformed SRC_URI line from bbappend merge (d783596) — _append_src_uri_entries() could pick a trailing single-line override
  (e.g. SRC_URI:append:class-target = "...") as its merge target instead of the recipe's real SRC_URI += "..." block, splicing
  the new file:// entry in as a bare orphaned line — invalid bitbake syntax that breaks parsing for the whole build. Also fixes
  a related case: single-line (non-continued) SRC_URI assignments were spliced incorrectly regardless of which line was picked.
  
  Testing
  
  - Added regression tests for all three bugs (tests/corrector/test_workflow_full.py,
  tests/corrector/test_wildcard_bbappend_rename.py, tests/corrector/test_bitbake_ops.py); each fails without its corresponding
  fix and passes with it.
  - ruff check ., mypy cve_agent cve_corrector cve_metadata_extractor shared, and pytest --cov all pass (1159 passed, 7 skipped,
  79.27% coverage).
  
  Blocked / not in scope
  
  Not fixed here (flagged only): save_bbappend_extras() silently drops SRC_URI:append = "..." lines (no override suffix) when
  snapshotting a bbappend before devtool overwrites it — a separate data-loss issue, not a malformed-line issue, and outside the
  scope of this report.
