### PR TITLE
recipe_ops: skip patches already listed in SRC_URI

### DIFF
--- a/cve_corrector/recipe_ops.py
+++ b/cve_corrector/recipe_ops.py
@@ -113,7 +113,17 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
     - SRC_URI .= "..."
     - SRC_URI:append = "..."
     - SRC_URI:append:class-target = "..."
+
+    Entries already present in the file's SRC_URI are skipped, so callers
+    that don't track what they already merged in (e.g. via
+    ``restore_bbappend_extras``) don't end up with a duplicate ``file://``
+    line for the same patch.
     """
+    existing = _get_src_uri_files(recipe_file)
+    patch_names = [name for name in patch_names if name not in existing]
+    if not patch_names:
+        return
+
     lines = recipe_file.read_text(encoding='utf-8').splitlines()
     insert_at = None
 

--- a/tests/corrector/test_bitbake_ops.py
+++ b/tests/corrector/test_bitbake_ops.py
@@ -125,6 +125,48 @@ def test_append_src_uri_entries_not_confused_by_sha256sum(tmp_path):
         assert idx < sha256_idx, f"Patch at line {idx} should be before sha256sum at {sha256_idx}"
 
 
+def test_append_src_uri_entries_skips_duplicate(tmp_path):
+    """_append_src_uri_entries does not re-add a patch already in SRC_URI.
+
+    Regression test: create_layer_commit() may call this with a patch name
+    that restore_bbappend_extras() already merged back into the bbappend
+    (e.g. because the .patch file is still untracked in git while the
+    bbappend's SRC_URI already lists it), which previously produced two
+    identical ``file://`` lines for the same CVE patch.
+    """
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "foo" / "foo"
+    recipe_dir.mkdir(parents=True)
+    recipe = tmp_path / "recipes-support" / "foo" / "foo_%.bbappend"
+    recipe.write_text(
+        'FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"\n'
+        '\n'
+        'SRC_URI += " \\\n'
+        '           file://CVE-2026-54369.patch \\\n'
+        '           "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-54369.patch"])
+    content = recipe.read_text()
+    assert content.count("file://CVE-2026-54369.patch") == 1
+
+
+def test_append_src_uri_entries_mixed_new_and_duplicate(tmp_path):
+    """_append_src_uri_entries adds only the genuinely new entries."""
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "foo" / "foo"
+    recipe_dir.mkdir(parents=True)
+    recipe = tmp_path / "recipes-support" / "foo" / "foo_%.bbappend"
+    recipe.write_text(
+        'SRC_URI += " \\\n'
+        '           file://CVE-2026-54369.patch \\\n'
+        '           "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-54369.patch", "CVE-2026-99999.patch"])
+    content = recipe.read_text()
+    assert content.count("file://CVE-2026-54369.patch") == 1
+    assert content.count("file://CVE-2026-99999.patch") == 1
+
+
 def test_append_src_uri_entries_override_style(tmp_path):
     """_append_src_uri_entries handles SRC_URI:append override syntax."""
     from cve_corrector.recipe_ops import _append_src_uri_entries


### PR DESCRIPTION
_append_src_uri_entries() inserted new file:// lines unconditionally. create_layer_commit() calls it with patch names derived from untracked .patch files in git, but if restore_bbappend_extras() already merged that same patch back into the bbappend's SRC_URI earlier in the same run (a tracked file left untouched by the reset step), the patch ended up listed twice in SRC_URI.

- Filter patch_names against the file's existing file:// entries before inserting, reusing _get_src_uri_files()
- Return early when nothing new remains to insert
- Add regression tests for the duplicate and mixed new/duplicate cases

Assisted-by: kiro:claude-sonnet-5