### PR TITLE
CVE backport correctness fixes, agent branch handling, and dead-code cleanup

### DIFF
--- a/.kiro/agents/yocto-cve-backport-interactive.json
+++ b/.kiro/agents/yocto-cve-backport-interactive.json
@@ -15,6 +15,7 @@
       "allowedCommands": [
         "^git status$",
         "^git status --porcelain$",
+        "^git status --porcelain -- [^-;&|$`\\s][^;&|$`\\s]*$",
         "^git diff$",
         "^git diff .*$",
         "^git log .*$",

--- a/.kiro/agents/yocto-cve-backport.json
+++ b/.kiro/agents/yocto-cve-backport.json
@@ -16,6 +16,7 @@
       "allowedCommands": [
         "^git status$",
         "^git status --porcelain$",
+        "^git status --porcelain -- [^-;&|$`\\s][^;&|$`\\s]*$",
         "^git diff$",
         "^git diff .*$",
         "^git log .*$",

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -44,7 +44,8 @@ of tool names:
 
 Bash commands you CAN run:
 
-- Inspect: `git status`, `git status --porcelain`, `git diff[ *]`, `git log *`,
+- Inspect: `git status`, `git status --porcelain`, `git status --porcelain -- <path>`,
+  `git diff[ *]`, `git log *`,
   `git show *`, `git rev-parse *`, `git merge-base *`, `git ls-files[ *]`
   (`git ls-files -u` lists the unmerged stage entries of a conflict directly),
   `git submodule status[ *]` (diagnoses a gitlink recorded upstream that does
@@ -86,6 +87,13 @@ listing the directory first to confirm it exists.
 
 You may ONLY modify files listed in the **Allowed Files** section of the context header.
 A git pre-commit hook enforces this — commits with unauthorized files will be rejected.
+
+**Untracked files from tarball extraction:** The workspace will contain many
+untracked files (configure, Makefile.in, m4/*.m4, aclocal.m4, etc.) copied
+from the devtool branch. These are generated autotools/build files from the
+release tarball that don't exist in the upstream git history. **Ignore them** —
+do not stage, commit, or worry about them. They are intentionally untracked
+and exist only so `devtool build` succeeds.
 
 **NEVER do any of these:**
 - `git add .` or `git add -A`
@@ -231,10 +239,16 @@ git cherry-pick --no-edit --continue
 ```
 
 ### 3. Fix Build Errors (exit code 4)
-Read the last 50 lines of the build log. If the failing task belongs to a
-**different recipe** than the one being patched, **abort immediately** — do not
-attempt to fix it. This indicates a pre-existing or environmental issue.
-Otherwise, fix the code and amend the commit.
+Run the build to reproduce the failure:
+```bash
+devtool build <recipe> 2>&1 > <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
+```
+Only read log output on failure (`Exit code:` is non-zero). On failure, read
+the **last 50 lines** of `<agent_dir>/build.log` to identify the error.
+If the failing task belongs to a **different recipe** than the one being
+patched, **abort immediately** — do not attempt to fix it. This indicates a
+pre-existing or environmental issue.
+Otherwise, fix the code, amend the commit, and re-run the build to verify.
 
 ### 4. Fix Test Failures (exit code 3)
 Fix the **backported code in the allowed files only**.
@@ -243,6 +257,11 @@ flag for human review. Document which tests failed and what code change
 fixed them in the commit message.
 
 ### 5. Build Verification (mandatory after every change)
+**You MUST verify the build passes before finishing.** Do not declare success
+without confirming `devtool build` exits with code 0. This is a hard
+requirement — the orchestrator will reject your session if the build still
+fails.
+
 Run the build as a **single command on ONE line** — do NOT split it across
 lines and do NOT wrap it in a `BUILD_LOG=` variable. A multi-line submission
 matches no allowed command and is rejected outright:
@@ -256,18 +275,27 @@ Do **not** rewrite this as `devtool build <recipe> > <agent_dir>/build.log
 2>&1` — `>` redirection is refused by the command guard (see "Available
 Tools"). The `| tee` form is the only way to get a build log.
 
+**Handling the output:** The command will produce hundreds of lines of
+bitbake progress output (NOTE: Starting bitbake server, Parsing recipes,
+Sstate summary, etc.). **Ignore all of this.** Do NOT read or process the
+tool's stdout — it pollutes your context for no benefit. The only line that
+matters is the **last line**: `Exit code: <N>`.
+
 Read the exit code from the `echo "Exit code: ..."` line, **not** from the
 tool's own reported exit status: in a pipeline the tool reports `tee`'s
 status, which is `0` even when the build failed. `${PIPESTATUS[0]}` is
 `devtool`'s real status — a non-zero value there means the build FAILED,
 regardless of what the tool result says.
 
-On failure: `tail -50 <agent_dir>/build.log`, fix, `git commit --amend
---no-edit`, retry.
-If `devtool build` logs are insufficient, check Yocto task logs at:
-`<yocto_tmp>/work/<arch>/<recipe>/*/temp/log.do_compile`
-(paths are in the context header).
-On success: **stop — your work is done.**
+**After running the build:**
+- **Exit code 0**: the build passed. **Stop — your work is done.** Do not
+  read or tail the log file.
+- **Exit code non-zero**: the build failed. Read ONLY the error:
+  `tail -50 <agent_dir>/build.log`. Fix the code, `git commit --amend
+  --no-edit`, and re-run the build.
+  If `devtool build` logs are insufficient, check Yocto task logs at:
+  `<yocto_tmp>/work/<arch>/<recipe>/*/temp/log.do_compile`
+  (paths are in the context header).
 
 For cross-compilation: use `bitbake -c devshell <recipe>`, never run
 make/cmake/gcc directly.

--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -71,15 +71,6 @@ def resolve_agent_instructions() -> Path:
     return PACKAGED_AGENT_INSTRUCTIONS
 
 
-# Kept for backward compatibility (existing tests/callers patch this
-# constant directly). Computed once at import time; DO NOT use in new code —
-# call resolve_agent_instructions() instead, which re-checks the stable
-# synced copy on every call and picks up a sync that happens later in the
-# same process (e.g. ensure_agents() runs before context building in the
-# real CLI flow).
-AGENT_INSTRUCTIONS = resolve_agent_instructions()
-
-
 class ResultStatus(Enum):
     """Outcome status for a CVE processing attempt."""
     SUCCESS = "success"
@@ -161,7 +152,7 @@ __all__ = [
     'AgentConfig', 'CveResult', 'ResultStatus',
     'RECOVERABLE_EXITS', 'UNRECOVERABLE_EXITS',
     'DEFAULT_KNOWLEDGE_PATH', 'DEFAULT_MAX_RETRIES', 'DEFAULT_SESSION_TIMEOUT',
-    'CORRECTOR_CMD', 'AGENT_INSTRUCTIONS', 'resolve_agent_instructions',
+    'CORRECTOR_CMD', 'resolve_agent_instructions',
     'get_build_dir', 'get_agent_dir',
     'EXIT_SUCCESS', 'EXIT_CONFLICT', 'EXIT_CHECKOUT_ERROR', 'EXIT_PTEST_ERROR',
     'EXIT_BUILD_ERROR', 'EXIT_PATCH_ERROR', 'EXIT_METADATA_ERROR', 'EXIT_GIT_ERROR',

--- a/cve_agent/agents/yocto-cve-backport-interactive.json
+++ b/cve_agent/agents/yocto-cve-backport-interactive.json
@@ -15,6 +15,7 @@
       "allowedCommands": [
         "^git status$",
         "^git status --porcelain$",
+        "^git status --porcelain -- [^-;&|$`\\s][^;&|$`\\s]*$",
         "^git diff$",
         "^git diff .*$",
         "^git log .*$",

--- a/cve_agent/agents/yocto-cve-backport.json
+++ b/cve_agent/agents/yocto-cve-backport.json
@@ -16,6 +16,7 @@
       "allowedCommands": [
         "^git status$",
         "^git status --porcelain$",
+        "^git status --porcelain -- [^-;&|$`\\s][^;&|$`\\s]*$",
         "^git diff$",
         "^git diff .*$",
         "^git log .*$",

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -10,9 +10,11 @@ from typing import Optional
 
 from . import (
     EXIT_ALREADY_APPLIED,
+    EXIT_BUILD_ERROR,
     EXIT_BUILD_PREEXISTING,
     EXIT_IGNORED_BY_STATUS,
     EXIT_NOT_APPLICABLE,
+    EXIT_PTEST_ERROR,
     EXIT_PTEST_PREEXISTING,
     EXIT_SUCCESS,
     RECOVERABLE_EXITS,
@@ -149,11 +151,18 @@ def _run_single_resolution_attempt(
         cve_info: dict, knowledge_base: KnowledgeBase,
         attempt: int, start_time: float) -> _AttemptOutcome:
     """Execute one resolution attempt: context -> session -> approval -> continue."""
+    print("Building AI context (upstream diffs, knowledge, conflict details)...")
     context_file = build_context(
         workspace_path, exit_code, config.cve_id, cve_info, knowledge_base,
         model=config.model, backend=config.backend
     )
     upstream_sha = get_upstream_sha(cve_info, workspace_path)
+
+    # Snapshot HEAD before the session to detect no-op resolutions
+    pre_session_head = run_git_stdout(
+        ['rev-parse', 'HEAD'], workspace_path
+    ).strip()
+
     session_result = guarded_session(
         context_file, workspace_path, upstream_sha, cve_info, config.model,
         config.session_timeout, config.cve_id, config.interactive,
@@ -199,6 +208,28 @@ def _run_single_resolution_attempt(
             f"Resolved via {config.backend} (workspace finalized)"
         ))
 
+    # Detect no-op sessions: if the AI didn't change HEAD and the failure
+    # was a build or ptest error, skip approval and retry immediately.
+    # There's nothing for the human to review — the AI didn't fix anything.
+    post_session_head = run_git_stdout(
+        ['rev-parse', 'HEAD'], workspace_path
+    ).strip()
+    if (pre_session_head == post_session_head
+            and exit_code in (EXIT_BUILD_ERROR, EXIT_PTEST_ERROR)):
+        print(f"AI session made no changes to resolve exit code {exit_code}, "
+              f"retrying...")
+        return _AttemptOutcome()
+
+    # The AI made a real change (HEAD moved, or this is a conflict resolution).
+    # Show the human the review *before* finalizing: request_approval runs
+    # against the still-present workspace, and only on approval does
+    # _finalize_resolution run --continue (build + ptest + devtool finish).
+    # Verifying the build before approval is not done here — it would require
+    # running --continue, whose devtool finish removes the workspace and leaves
+    # nothing to review, and it would also finalize a change the human has not
+    # yet approved. The agent self-verifies its build before finishing (see
+    # AGENT_INSTRUCTIONS.md "Build Verification"), and --continue re-verifies
+    # authoritatively after approval, retrying on a recoverable failure.
     approval, feedback = request_approval(workspace_path, upstream_sha, config)
 
     if approval == "edit":

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -62,10 +62,6 @@ def _expand_path_variants(allowed: set[str], workspace_path: Path) -> set[str]:
             stripped = '/'.join(parts[2:])
             if (workspace_path / stripped).exists():
                 expanded.add(stripped)
-        else:
-            # Try adding subprojects/<name>/ prefix by finding matching dirs
-            # Don't scan workspace_path.parent — too expensive
-            pass
 
         for prefix in _COMMON_PREFIXES:
             if filepath.startswith(prefix):

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -9,6 +9,8 @@ import difflib
 from datetime import datetime, timezone
 from pathlib import Path
 
+from shared.git_runner import copy_missing_files_from_devtool, force_checkout_branch
+
 from . import get_agent_dir
 from .backend import SessionResult, get_backend
 from .git import (
@@ -77,6 +79,52 @@ def _expand_path_variants(allowed: set[str], workspace_path: Path) -> set[str]:
     return expanded
 
 
+def _ensure_cve_branch(workspace_path: Path, cve_id: str) -> None:
+    """Check out the CVE branch so the agent commits onto the source of truth.
+
+    The CVE branch is named after the CVE id (see
+    ``cve_corrector.workspace.prepare_cve_branch``). It holds the cherry-picked
+    upstream fix and is the branch ``cherry_pick_to_devtool`` transfers to the
+    throwaway ``devtool`` branch. If the agent were left on ``devtool`` (where
+    the corrector's build step leaves it), any amend would be discarded on the
+    next resume.
+
+    After landing on the CVE branch, restore the files the devtool branch
+    tracks but the (upstream-history) CVE branch does not — generated autotools
+    output (configure, Makefile.in, ...) and secondary-tarball payloads such as
+    libxml2's ``xmlconf/`` W3C conformance suite. Switching branches drops
+    them, and without them the agent's own ``devtool build`` verification fails
+    in do_configure/do_compile before it can even test the fix. They are
+    restored as untracked working-tree files, exactly as the corrector does
+    before each build step.
+
+    A no-op when ``cve_id`` is empty, the workspace is gone, or the branch does
+    not exist (e.g. some unit-test setups).
+
+    Args:
+        workspace_path: Path to the devtool workspace.
+        cve_id: CVE identifier, which is also the CVE branch name.
+    """
+    if not cve_id or not workspace_path.exists():
+        return
+    current = run_git_stdout(
+        ['rev-parse', '--abbrev-ref', 'HEAD'], cwd=workspace_path
+    ).strip()
+    if current != cve_id:
+        branch_exists = run_capture(
+            ['git', 'rev-parse', '--verify', '--quiet', f'refs/heads/{cve_id}'],
+            cwd=workspace_path,
+        ).returncode == 0
+        if not branch_exists:
+            return
+        if not force_checkout_branch(workspace_path, cve_id):
+            print(f"\u26a0 Failed to check out CVE branch {cve_id} before "
+                  f"session (currently on {current}) — the agent's fix may "
+                  f"not persist")
+            return
+    copy_missing_files_from_devtool(workspace_path)
+
+
 def guarded_session(context_file: Path, workspace_path: Path,
                     upstream_sha: str, cve_info: dict,
                     model: str = "claude-sonnet-5",
@@ -90,6 +138,19 @@ def guarded_session(context_file: Path, workspace_path: Path,
     AI session via the configured backend, then verifies and reverts any
     unauthorized changes.
     """
+    # Ensure the agent operates on the CVE branch — the source of truth that
+    # cherry_pick_to_devtool transfers to the devtool branch. The corrector's
+    # build step leaves the *devtool* branch checked out, and the agent's
+    # command allow-list forbids switching branches, so without this the agent
+    # would amend its fix onto devtool. That fix is then orphaned when the
+    # session forces back to the CVE branch, and wiped entirely on the next
+    # resume when reset_devtool_to_base + cherry_pick_to_devtool re-apply the
+    # unfixed CVE-branch commit — silently reverting the agent's work every
+    # round. Landing the amend on the CVE branch keeps the fix on the branch
+    # that actually feeds the final patch.
+    print("Preparing workspace (CVE branch checkout, restoring build files)...")
+    _ensure_cve_branch(workspace_path, cve_id)
+
     all_shas = get_all_upstream_shas(cve_info, workspace_path)
     allowed: set[str] = set()
     # Snapshot upstream diffs per file before the session (single pass per SHA)
@@ -139,13 +200,19 @@ def guarded_session(context_file: Path, workspace_path: Path,
     prompt = (
         f"Read the file {context_file} and follow all instructions in it. "
         f"The file contains conflict context, patch details, and resolution "
-        f"steps for a CVE backport. Complete all tasks described in the file."
+        f"steps for a CVE backport. Complete all tasks described in the file.\n\n"
+        f"Key details (also in the file):\n"
+        f"- Recipe: {workspace_path.name}\n"
+        f"- Agent dir: {get_agent_dir(workspace_path)}\n"
+        f"- Workspace: {workspace_path}\n"
+        f"- Allowed files: {', '.join(sorted(allowed))}\n"
     )
 
     backend = get_backend(backend_name)
     agent_dir = get_agent_dir(workspace_path)
     _log_session_start(agent_dir, context_file)
 
+    print(f"Starting {backend_name} session (timeout {timeout}s)...")
     try:
         result = backend.run_session(
             prompt, workspace_path, allowed, model, timeout, interactive)

--- a/cve_corrector/__init__.py
+++ b/cve_corrector/__init__.py
@@ -6,6 +6,7 @@ from .bitbake_ops import (
     deduce_meta_layer_from_recipe,
     find_mirror_repo,
     resolve_meta_layer,
+    rewrite_url_for_premirror,
 )
 from .state import (
                     EXIT_ALREADY_APPLIED,
@@ -45,4 +46,5 @@ __all__ = [
     'continue_from_conflict', 'WorkflowConfig', 'find_mirror_repo',
     'deduce_meta_layer_from_recipe', 'resolve_meta_layer',
     'filter_by_skip_sources', 'check_cve_status',
+    'rewrite_url_for_premirror',
 ]

--- a/cve_corrector/__main__.py
+++ b/cve_corrector/__main__.py
@@ -141,6 +141,12 @@ def main():
     env_group = parser.add_argument_group('environment')
     env_group.add_argument('--mirror-dir', type=Path,
                         help='Directory containing bare repository mirrors')
+    env_group.add_argument('--premirror', type=str,
+                        help='Base URL for premirror. The upstream git URL is '
+                             'rewritten by stripping protocol and .git suffix, '
+                             'joining components with dots, and appending to this '
+                             'base (e.g. https://host/path → <base>/host.path.repo)')
+
     env_group.add_argument('--yes', '-y', action='store_true',
                         help='Skip confirmation prompts')
     env_group.add_argument('--sign-off', action='store_true', default=None,
@@ -336,7 +342,8 @@ def main():
                 skip_cve_applicability=args.skip_cve_applicability,
                 skip_confirm=args.yes,
                 require_all_commits=require_all_commits,
-                sign_off=bool(args.sign_off)))
+                sign_off=bool(args.sign_off),
+                premirror=args.premirror))
         state.skip_confirm = args.yes
 
         finish_cve_workflow(state)

--- a/cve_corrector/bitbake_ops.py
+++ b/cve_corrector/bitbake_ops.py
@@ -99,6 +99,51 @@ def cleanup_workspace(bbpath: str, full: bool = False) -> None:
             print(f"Warning: Failed to update bblayers.conf: {e}", file=sys.stderr)
 
 
+def rewrite_url_for_premirror(upstream_url: str, premirror_base: str) -> str:
+    """Rewrite an upstream git URL into a premirror URL.
+
+    Strips the protocol scheme and ``.git`` suffix, joins host and path
+    components with dots, and appends the result to *premirror_base*.
+
+    Examples:
+        >>> rewrite_url_for_premirror(
+        ...     'https://sourceware.org/git/binutils-gdb',
+        ...     'https://git.example.com/mirror')
+        'https://git.example.com/mirror/sourceware.org.git.binutils-gdb'
+        >>> rewrite_url_for_premirror(
+        ...     'git://git.savannah.gnu.org/grub.git',
+        ...     'https://git.example.com/mirror/')
+        'https://git.example.com/mirror/git.savannah.gnu.org.grub'
+
+    Args:
+        upstream_url: Original upstream git URL (https, git, or http).
+        premirror_base: Base URL to prepend (trailing slash is handled).
+
+    Returns:
+        The rewritten premirror URL.
+    """
+    # Strip protocol scheme
+    url = upstream_url
+    for prefix in ('https://', 'http://', 'git://'):
+        if url.startswith(prefix):
+            url = url[len(prefix):]
+            break
+
+    # Strip trailing .git suffix
+    url = url.removesuffix('.git')
+
+    # Strip trailing slash
+    url = url.rstrip('/')
+
+    # Join host + path with dots: split on '/' and rejoin with '.'
+    parts = url.split('/')
+    mirror_name = '.'.join(parts)
+
+    # Ensure base has no trailing slash, then join
+    base = premirror_base.rstrip('/')
+    return f"{base}/{mirror_name}"
+
+
 _MIRROR_ALIASES = {
     'glib-2.0': 'glib',
     'go-runtime': 'go',

--- a/cve_corrector/blame.py
+++ b/cve_corrector/blame.py
@@ -192,12 +192,30 @@ def find_introducing_version(workspace_path: Path,
     return earliest
 
 
+# Patterns for tags that are NOT release versions (development artifacts)
+_NON_RELEASE_TAG_RE = re.compile(
+    r'(?:^|[-_])'                    # at start or after separator
+    r'(?:branchpoint|branch[-_]?point|'
+    r'rc\d*|alpha\d*|beta\d*|'       # pre-release labels
+    r'dev|snapshot|nightly|'         # development builds
+    r'start|base|root|fork|merge)'   # branch management tags
+    r'(?:$|[-_])',                    # at end or before separator
+    re.IGNORECASE,
+)
+
+
+def _is_release_tag(tag: str) -> bool:
+    """Return True if the tag looks like a release version, not a branch marker."""
+    return not _NON_RELEASE_TAG_RE.search(tag)
+
+
 def _resolve_tag_for_commit(workspace_path: Path,
                             commit: str) -> Optional[str]:
-    """Find the earliest tag containing a commit.
+    """Find the earliest release tag containing a commit.
 
     Tries ``git describe --contains`` first (fast), falls back to
     ``git tag --contains`` (slower but works when describe fails).
+    Filters out non-release tags (branchpoint, rc, alpha, etc.).
     """
     # Lazy import
     from .version import Version  # noqa: E402
@@ -206,7 +224,7 @@ def _resolve_tag_for_commit(workspace_path: Path,
         ['git', 'describe', '--contains', commit], cwd=workspace_path)
     if result.returncode == 0:
         tag = _DESCRIBE_SUFFIX_RE.sub('', result.stdout.strip())
-        if tag:
+        if tag and _is_release_tag(tag):
             return tag
 
     # Fallback: git tag --contains
@@ -216,7 +234,11 @@ def _resolve_tag_for_commit(workspace_path: Path,
         logger.debug("No tag found containing %s", commit[:8])
         return None
 
-    tags = result.stdout.strip().splitlines()
+    tags = [t for t in result.stdout.strip().splitlines() if _is_release_tag(t)]
+    if not tags:
+        logger.debug("No release tags found containing %s (all filtered)", commit[:8])
+        return None
+
     # Pick the earliest version tag
     best = None
     for tag in tags:

--- a/cve_corrector/cherry_pick.py
+++ b/cve_corrector/cherry_pick.py
@@ -17,6 +17,63 @@ from .state import AlreadyAppliedError, GitError, PatchError, WorkflowState, sav
 from .utils import logger, run_cmd, run_cmd_capture
 
 
+def reset_devtool_to_base(workspace_path: Path) -> bool:
+    """Reset the devtool branch back to its recipe-patched base commit.
+
+    Used when re-transferring CVE commits on a build/ptest-error resume:
+    the AI agent may have amended the CVE-branch commit to fix the error,
+    so the devtool branch needs a clean re-application of the (updated)
+    patch rather than another commit stacked on top of the stale one from
+    the previous attempt. Without this, ``git cherry`` in
+    :func:`collect_cve_commits` compares against a devtool branch that
+    already contains the stale patch-id and incorrectly concludes the CVE
+    commit is already applied, aborting the whole resume with
+    :class:`AlreadyAppliedError`.
+
+    The reset target is ``devtool-patched`` — the source with **all** of the
+    recipe's ``SRC_URI`` patches applied but without the CVE fix
+    cve_corrector transfers on top. It is *not* ``devtool-base`` (the pristine
+    upstream tarball import): resetting to ``devtool-base`` strips every
+    recipe patch, and since :func:`cherry_pick_to_devtool` only re-applies the
+    CVE commits, those recipe patches would never come back. That silently
+    drops files the build and ptest steps depend on — e.g. libxml2's
+    ``install-tests.patch``, which adds the ``install-test-data`` make target
+    that ``do_install_ptest_base`` invokes, so ptest fails with
+    "No rule to make target 'install-test-data'". ``devtool-patched`` keeps
+    those patches and drops only the previously-transferred CVE commits.
+
+    ``devtool-patched`` is created by ``devtool modify`` whenever the recipe
+    has ``SRC_URI`` patches. When a recipe has none, devtool omits it and
+    ``devtool-base`` already *is* the fully-patched tree, so fall back to it.
+    ``main``/``master`` are never used here (unlike ``workspace.py``'s
+    non-CVE-branch search): they point at upstream's own history, which may
+    already contain the CVE fix or unrelated later commits — exactly the
+    stale/wrong content this reset must avoid.
+
+    Args:
+        workspace_path: Path to workspace.
+
+    Returns:
+        True if a base ref was found and devtool was reset, False otherwise.
+    """
+    base_ref = None
+    for ref in ('devtool-patched', 'devtool-base'):
+        if run_cmd_capture(['git', 'rev-parse', '--verify', ref],
+                           cwd=workspace_path).returncode == 0:
+            base_ref = ref
+            break
+    if base_ref is None:
+        logger.error("Failed to find devtool-patched or devtool-base to reset "
+                     "devtool before re-transfer")
+        return False
+
+    git_clean_workspace(workspace_path, remove_ignored=True)
+    run_cmd(['git', 'checkout', '.'], cwd=workspace_path)
+    if run_cmd(['git', 'checkout', '-f', 'devtool'], cwd=workspace_path) != 0:
+        return False
+    return run_cmd(['git', 'reset', '--hard', base_ref], cwd=workspace_path) == 0
+
+
 def handle_empty_cherry_pick(state: WorkflowState) -> None:
     """Write CVE_STATUS when cherry-pick produces no changes."""
     if not state.meta_layer:

--- a/cve_corrector/git_ops.py
+++ b/cve_corrector/git_ops.py
@@ -22,15 +22,34 @@ def get_git_user_info() -> tuple[str, str]:
 
 def find_exact_tag(tags: list[str], version: str) -> Optional[str]:
     """Find exact tag matching version."""
-    norm = version.replace('.', '_')
+    norm_underscore = version.replace('.', '_')
+    norm_dot = version.replace('_', '.')
     escaped = re.escape(version)
-    escaped_norm = re.escape(norm)
+    escaped_underscore = re.escape(norm_underscore)
+    escaped_dot = re.escape(norm_dot)
+    # Match version at end of tag, with any prefix (e.g. v, release-, libfoo-)
+    # The prefix is optional and can end with a letter, dash, or underscore.
+    # Try all separator variants: original, all-underscore, all-dot
     pattern = re.compile(
-        rf'{escaped}$|{escaped_norm}$|.*{escaped_norm}$|.*{escaped}$'
+        rf'^(?:.*[-_]|v)?(?:{escaped}|{escaped_underscore}|{escaped_dot})$'
     )
     for tag in tags:
         if pattern.match(tag):
             return tag
+
+    # Retry with separator-normalized comparison: collapse both dots and
+    # underscores to a common form so mixed tags (e.g. binutils-2_46.1)
+    # match version 2.46.1.
+    def normalize_seps(s):
+        return s.replace('_', '.').replace('-', '.')
+
+    v_norm = normalize_seps(version)
+    for tag in tags:
+        # Strip common prefixes before comparing
+        tag_suffix = re.sub(r'^[a-zA-Z][\w]*[-_]', '', tag)
+        if normalize_seps(tag_suffix) == v_norm:
+            return tag
+
     # Retry with leading-zero-stripped comparison (e.g. 2024.2.2 vs 2024.02.02)
     def strip_zeros(s):
         return '.'.join(p.lstrip('0') or '0' for p in s.split('.'))
@@ -93,6 +112,13 @@ def checkout_version(repo_path: Path, version: str, branch_name: str,
     logger.info("Searching %s -> Matched: %s", search_version, target_tag)
 
     if not target_tag:
+        if tags:
+            logger.warning("No tag matched version %s among %d available tags",
+                           search_version, len(tags))
+            logger.debug("Available tags (first 10): %s", ', '.join(tags[:10]))
+        else:
+            logger.warning("No tags available in repository — "
+                           "upstream fetch may have failed")
         return False
 
     if subproject:

--- a/cve_corrector/git_ops.py
+++ b/cve_corrector/git_ops.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Optional
 
 from shared import TEXT_ENCODING, TEXT_ERRORS
+from shared.git_runner import (  # noqa: F401  (re-exported for callers/tests)
+    _get_submodule_paths,
+    copy_missing_files_from_devtool,
+)
 
 from .utils import logger, run_cmd, run_cmd_capture
 
@@ -235,84 +239,6 @@ def deduce_repo_from_patches(patches: list[str]) -> Optional[str]:
         if result:
             return result
     return None
-
-
-def _get_submodule_paths(workspace_path: Path) -> set[str]:
-    """Return registered submodule paths from .gitmodules, if any."""
-    gitmodules = workspace_path / '.gitmodules'
-    if not gitmodules.exists():
-        return set()
-    paths: set[str] = set()
-    for line in gitmodules.read_text().splitlines():
-        stripped = line.strip()
-        if stripped.startswith('path'):
-            # e.g. "path = modules/oniguruma"
-            _, _, value = stripped.partition('=')
-            if value.strip():
-                paths.add(value.strip())
-    return paths
-
-
-def copy_missing_files_from_devtool(workspace_path: Path) -> None:
-    """Copy files present in devtool but missing from the CVE branch.
-
-    Release tarballs contain generated autotools files (configure, Makefile.in,
-    m4/*.m4, etc.) that don't exist in the upstream git repo. This copies them
-    from the devtool branch without tracking them, so builds succeed.
-
-    Files under registered submodule paths are skipped — those are tracked
-    by git submodule and must not be overwritten with regular file copies.
-
-    Files under paths that HEAD tracks as symlinks are also skipped — release
-    tarballs dereference symlinks into real directories, and copying those
-    files would clobber the symlink and break subsequent cherry-picks.
-    """
-    devtool_files = run_cmd_capture(
-        ['git', 'ls-tree', '-r', '--name-only', 'devtool'], cwd=workspace_path)
-    if devtool_files.returncode != 0:
-        return
-    cve_files = run_cmd_capture(
-        ['git', 'ls-tree', '-r', '--name-only', 'HEAD'], cwd=workspace_path)
-    if cve_files.returncode != 0:
-        return
-
-    cve_set = set(cve_files.stdout.strip().splitlines())
-    submodule_paths = _get_submodule_paths(workspace_path)
-
-    # Collect paths that HEAD tracks as symlinks (git mode 120000). Release
-    # tarballs dereference symlinks into real directories, so the devtool
-    # branch lists the symlink target's contents (e.g.
-    # tutorial/swift/swift-dep/Sources/*.swift) as regular files. Copying
-    # those out of devtool would clobber the symlink with a real directory,
-    # leaving a staged deletion + untracked dir that blocks every subsequent
-    # cherry-pick. Skip anything living under a HEAD symlink: the symlink
-    # already resolves to an in-tree path, so nothing is actually missing.
-    symlink_prefixes: tuple[str, ...] = ()
-    cve_tree = run_cmd_capture(
-        ['git', 'ls-tree', '-r', 'HEAD'], cwd=workspace_path)
-    if cve_tree.returncode == 0:
-        symlinks = []
-        for line in cve_tree.stdout.strip().splitlines():
-            # Format: "<mode> <type> <hash>\t<path>"
-            meta, _, path = line.partition('\t')
-            if path and meta.split(' ', 1)[0] == '120000':
-                symlinks.append(path + '/')
-        symlink_prefixes = tuple(symlinks)
-
-    missing = [f for f in devtool_files.stdout.strip().splitlines()
-               if f not in cve_set
-               and not any(f == sm or f.startswith(sm + '/')
-                           for sm in submodule_paths)
-               and not (symlink_prefixes and f.startswith(symlink_prefixes))]
-    if not missing:
-        return
-
-    logger.info("Copying %s missing file(s) from devtool branch", len(missing))
-    for filepath in missing:
-        run_cmd_capture(['git', 'checkout', 'devtool', '--', filepath],
-                        cwd=workspace_path)
-    # Unstage so they remain as untracked working-tree files
-    run_cmd_capture(['git', 'reset', 'HEAD'] + missing, cwd=workspace_path)
 
 
 def remove_git_only_build_triggers(workspace_path: Path) -> None:

--- a/cve_corrector/meta_layer.py
+++ b/cve_corrector/meta_layer.py
@@ -284,14 +284,16 @@ def _map_cve_status_reason(reason: str) -> str:
     """Map a human-readable reason to the correct CVE_STATUS keyword.
 
     Uses Yocto CVE_CHECK_STATUSMAP values:
-    - fixed-version: fix already present via version or backport
+    - fixed-version: fix already present via version or backport, or
+      vulnerable code not present in this version
     - not-applicable-platform: platform-specific, doesn't affect this target
     - not-applicable-config: requires config/feature not enabled
     - cpe-incorrect: CVE doesn't actually apply to this component
     """
     lower = reason.lower()
     if any(kw in lower for kw in ('already', 'matches the fixed', 'no net changes',
-                                   'backport', 'patched')):
+                                   'backport', 'patched', 'introduced in',
+                                   'recipe version', 'not affected')):
         return 'fixed-version'
     if any(kw in lower for kw in ('platform', 'architecture', 'target')):
         return 'not-applicable-platform'

--- a/cve_corrector/patch_ops.py
+++ b/cve_corrector/patch_ops.py
@@ -138,8 +138,21 @@ def _normalize_subject(subject: str) -> str:
 
 
 def _git_commit_subject(workspace_path: Path, commit_hash: str) -> str | None:
-    """Return the subject line of ``commit_hash``, or None if unavailable."""
+    """Return the subject line of ``commit_hash``, or None if unavailable.
+
+    ``workspace_path`` may already be gone by the time this runs: in
+    ``--bbappend`` mode, ``finish_cve_workflow`` calls ``devtool reset``
+    (which deletes the whole devtool workspace directory) before calling
+    ``update_patches_with_metadata`` -> ``_compute_cve_tag_flags`` ->
+    here. Checking existence up front avoids an uncaught
+    ``FileNotFoundError`` from ``subprocess`` trying to chdir into a
+    missing ``cwd`` and returns None instead, matching the existing
+    "can't determine subject" contract so the caller's documented
+    fallback (tag every patch with CVE) still applies.
+    """
     if not commit_hash:
+        return None
+    if not workspace_path.exists():
         return None
     result = run_cmd_capture(
         ["git", "log", "-1", "--format=%s", commit_hash], cwd=workspace_path)

--- a/cve_corrector/recipe_ops.py
+++ b/cve_corrector/recipe_ops.py
@@ -114,6 +114,12 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
     - SRC_URI:append = "..."
     - SRC_URI:append:class-target = "..."
 
+    When the recipe file has no plain SRC_URI assignment, sibling ``.inc``
+    files in the same directory are checked for the main SRC_URI block.
+    If only scoped override forms exist (e.g. ``SRC_URI:append:class-nativesdk``),
+    a new ``SRC_URI:append`` line is appended rather than inserting into
+    the scoped override (which would limit the patch to that class/machine).
+
     Entries already present in the file's SRC_URI are skipped, so callers
     that don't track what they already merged in (e.g. via
     ``restore_bbappend_extras``) don't end up with a duplicate ``file://``
@@ -124,15 +130,10 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
     if not patch_names:
         return
 
-    lines = recipe_file.read_text(encoding='utf-8').splitlines()
+    target_file = recipe_file
+    lines = target_file.read_text(encoding='utf-8').splitlines()
     insert_at = None
 
-    # Match all SRC_URI assignment forms including override syntax
-    src_uri_re = re.compile(
-        r'^\s*SRC_URI\s*'
-        r'(?::\w[\w-]*)*'  # optional override suffixes like :append:class-target
-        r'\s*(?:\+|\.|\?)?='  # assignment operators: =, +=, .=, ?=
-    )
     # A plain SRC_URI assignment, with no override suffix at all. This is
     # the block new file:// entries should be spliced into. Override-suffixed
     # forms (e.g. SRC_URI:append:class-target = "...") are usually a distinct,
@@ -142,18 +143,41 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
     # bare, malformed continuation line that breaks bitbake parsing.
     base_src_uri_re = re.compile(r'^\s*SRC_URI\s*(?:\+|\.|\?)?=')
 
-    src_uri_start = None
-    for i, line in enumerate(lines):
-        if base_src_uri_re.match(line):
-            src_uri_start = i
-            break
+    # An unscoped override — SRC_URI:append or SRC_URI:prepend with no
+    # further class/machine suffix. Safe to insert into since it applies
+    # globally.
+    unscoped_override_re = re.compile(
+        r'^\s*SRC_URI:(append|prepend)\s*(?:\+|\.|\?)?='
+    )
+
+    src_uri_start = _find_base_src_uri_line(lines, base_src_uri_re)
+
     if src_uri_start is None:
-        # No plain SRC_URI assignment — fall back to the first override form
-        # (e.g. a bbappend whose only SRC_URI line is ``SRC_URI:append``).
+        # No plain SRC_URI in the .bb — check sibling .inc files
+        inc_file = _find_inc_with_base_src_uri(recipe_file, base_src_uri_re)
+        if inc_file:
+            target_file = inc_file
+            # Also check .inc doesn't already have these patches
+            inc_existing = _get_src_uri_files(inc_file)
+            patch_names = [name for name in patch_names if name not in inc_existing]
+            if not patch_names:
+                return
+            lines = inc_file.read_text(encoding='utf-8').splitlines()
+            src_uri_start = _find_base_src_uri_line(lines, base_src_uri_re)
+
+    if src_uri_start is None:
+        # Still no plain SRC_URI — try unscoped override (SRC_URI:append = ...)
         for i, line in enumerate(lines):
-            if src_uri_re.match(line):
+            if unscoped_override_re.match(line):
                 src_uri_start = i
                 break
+
+    if src_uri_start is None:
+        # Only scoped overrides remain — do NOT insert into them.
+        # Append a new SRC_URI:append line to the original recipe file.
+        _append_new_src_uri_append(recipe_file, patch_names)
+        return
+
     if src_uri_start is not None:
         # Scan forward from SRC_URI to find the closing line
         for i in range(src_uri_start, len(lines)):
@@ -191,14 +215,56 @@ def _append_src_uri_entries(recipe_file: Path, patch_names: list[str]) -> None:
             new_lines = [f'{indent}file://{name} \\' for name in patch_names]
             lines[insert_at:insert_at] = new_lines
     else:
-        lines.append('')
-        if len(patch_names) == 1:
-            lines.append(f'SRC_URI += "file://{patch_names[0]}"')
-        else:
-            lines.append('SRC_URI += " \\')
-            for name in patch_names:
-                lines.append(f'            file://{name} \\')
-            lines.append('            "')
+        # No closing quote found — append as a new block
+        _append_new_src_uri_append(target_file, patch_names)
+        return
+    target_file.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+def _find_base_src_uri_line(lines: list[str], base_src_uri_re: re.Pattern) -> Optional[int]:
+    """Find the first line matching a plain SRC_URI assignment."""
+    for i, line in enumerate(lines):
+        if base_src_uri_re.match(line):
+            return i
+    return None
+
+
+def _find_inc_with_base_src_uri(recipe_file: Path,
+                                base_src_uri_re: re.Pattern) -> Optional[Path]:
+    """Find a sibling .inc file that contains the main SRC_URI block.
+
+    Searches the same directory as recipe_file for .inc files and returns
+    the first one that has a plain SRC_URI assignment.
+    """
+    recipe_dir = recipe_file.parent
+    recipe_stem = recipe_file.stem.split('_')[0]  # e.g. 'binutils' from 'binutils_2.46'
+    # Prefer .inc files whose name matches the recipe base name
+    inc_files = sorted(
+        recipe_dir.glob('*.inc'),
+        key=lambda p: (0 if p.stem.startswith(recipe_stem) else 1, p.name),
+    )
+    for inc in inc_files:
+        try:
+            content = inc.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in content.splitlines():
+            if base_src_uri_re.match(line):
+                return inc
+    return None
+
+
+def _append_new_src_uri_append(recipe_file: Path, patch_names: list[str]) -> None:
+    """Append a new SRC_URI:append line with the given patches to the file."""
+    lines = recipe_file.read_text(encoding='utf-8').splitlines()
+    lines.append('')
+    if len(patch_names) == 1:
+        lines.append(f'SRC_URI:append = " file://{patch_names[0]}"')
+    else:
+        lines.append('SRC_URI:append = " \\')
+        for name in patch_names:
+            lines.append(f'           file://{name} \\')
+        lines.append('           "')
     recipe_file.write_text('\n'.join(lines) + '\n', encoding='utf-8')
 
 

--- a/cve_corrector/ui.py
+++ b/cve_corrector/ui.py
@@ -56,6 +56,24 @@ def print_edit_instructions(workspace_path: Path, recipe: str, commit_hash: str)
     print("=" * 60 + "\n")
 
 
+def print_build_failure_instructions(workspace_path: Path, recipe: str) -> None:
+    """Print instructions for resolving build failures after patch application."""
+    print("=" * 60)
+    print("BUILD FAILED - Manual fix required")
+    print("=" * 60)
+    print(f"\nSource directory: {workspace_path}")
+    print(f"\nThe patch applied cleanly but the build failed for {recipe}.")
+    print("\nDebug and fix the build using:")
+    print(f"  cd {workspace_path}")
+    print(f"  devtool build {recipe}        # Reproduce the failure")
+    print("  # Fix the source code")
+    print("  git add <file>                # Stage your changes")
+    print("  git commit --amend            # Amend the patch commit")
+    print("\nAfter fixing the build, resume with:")
+    print("  cve-corrector --continue")
+    print("=" * 60 + "\n")
+
+
 def print_manual_instructions(workspace_path: Path, recipe: str,
                               hashes: list, series: list) -> None:
     """Print instructions for manual patching mode.

--- a/cve_corrector/utils.py
+++ b/cve_corrector/utils.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from shared import build_git_env
 from shared.git_runner import is_git_cmd
-from shared.git_runner import run_capture as _shared_run_capture
+from shared.git_runner import run_capture as run_cmd_capture  # noqa: F401  (re-exported)
 
 # Module-level config — set by setup_logging(), used by run_cmd()
 _verbose = True
@@ -86,8 +86,3 @@ def run_cmd(cmd: list[str], cwd: Optional[Path] = None,
             with open(_log_file, 'a', encoding='utf-8') as log:
                 log.write(f'=== TIMEOUT after {timeout}s ===\n\n')
         return -1
-
-
-def run_cmd_capture(cmd: list[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
-    """Execute command and capture output."""
-    return _shared_run_capture(cmd, cwd)

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -534,6 +534,7 @@ class WorkflowConfig:
     skip_confirm: bool = False
     require_all_commits: bool = False
     sign_off: bool = False
+    premirror: Optional[str] = None
 
 
 def _handle_failed_series(workspace_path, best_series, make_state, recipe):
@@ -649,7 +650,8 @@ def initialize_cve_workflow(
     mirror_name = setup_upstream_remote(
         workspace_path, config.mirror_path, config.mirror_dir,
         recipe, hash_details, series,
-        references=cve_info.get('references', []))
+        references=cve_info.get('references', []),
+        premirror=config.premirror)
 
     # Detect monorepo layout (e.g. GStreamer monorepo with subprojects/)
     subproject = None

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -15,6 +15,7 @@ from .cherry_pick import (
     apply_single_commits,
     cherry_pick_to_devtool,
     find_least_conflict_commit,
+    reset_devtool_to_base,
 )
 from .git_ops import (
     copy_missing_files_from_devtool,
@@ -318,7 +319,19 @@ def finish_cve_workflow(state: WorkflowState) -> None:
     """
     should_run = _make_should_run(state)
 
+    # Always re-transfer CVE commits when resuming from build/ptest errors.
+    # The AI agent may have amended the commit on the CVE branch to fix the
+    # error, so the devtool branch needs the updated patch. Reset devtool
+    # back to its pre-patch base first — reusing cherry_pick_to_devtool's
+    # git-am transfer against a devtool branch that still holds the stale
+    # patch from the previous attempt makes collect_cve_commits' git-cherry
+    # patch-id comparison see it as already applied and abort the resume
+    # with AlreadyAppliedError instead of re-transferring the updated fix.
     if should_run('cherry_pick_to_devtool'):
+        cherry_pick_to_devtool(state)
+    elif state.current_step in ('build_after_patch', 'ptest_after_patch'):
+        if not reset_devtool_to_base(state.workspace_path):
+            raise GitError("Failed to reset devtool branch before re-transfer")
         cherry_pick_to_devtool(state)
 
     if should_run('build_after_patch'):

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -49,7 +49,12 @@ from .state import (
     save_progress,
     save_workflow_state,
 )
-from .ui import print_conflict_instructions, print_edit_instructions, print_manual_instructions
+from .ui import (
+    print_build_failure_instructions,
+    print_conflict_instructions,
+    print_edit_instructions,
+    print_manual_instructions,
+)
 from .utils import logger, run_cmd, run_cmd_capture
 from .workspace import prepare_cve_branch, setup_devtool_workspace, setup_upstream_remote
 
@@ -238,6 +243,7 @@ def _run_build_step(state: WorkflowState) -> None:
     run_cmd(['bitbake', '-c', 'clean', state.recipe])
     if run_cmd(['devtool', 'build', state.recipe]) != 0:
         save_progress(state, 'build_after_patch')
+        print_build_failure_instructions(state.workspace_path, state.recipe)
         raise BuildError(f"Build failed for {state.recipe}")
 
 
@@ -264,6 +270,7 @@ def _run_ptest_step(state: WorkflowState) -> Optional[str]:
         ptest_after = run_ptest(state.recipe)
     except BuildPreexistingError:
         save_progress(state, 'build_after_patch')
+        print_build_failure_instructions(state.workspace_path, state.recipe)
         raise BuildError(f"Test image build failed for {state.recipe}") from None
     if ptest_after:
         logger.info("✓ Ptest completed: %s", ptest_after)

--- a/cve_corrector/workspace.py
+++ b/cve_corrector/workspace.py
@@ -83,7 +83,8 @@ def setup_upstream_remote(workspace_path: Path, mirror_path: Optional[Path],
                           mirror_dir: Optional[Path], recipe: str,
                           hash_details: list[dict],
                           series: Optional[list[dict]] = None,
-                          references: Optional[list[dict]] = None) -> Optional[str]:
+                          references: Optional[list[dict]] = None,
+                          premirror: Optional[str] = None) -> Optional[str]:
     """Configure upstream git remote and fetch references.
 
     Priority for upstream URL:
@@ -167,17 +168,39 @@ def setup_upstream_remote(workspace_path: Path, mirror_path: Optional[Path],
     logger.info("Adding upstream remote: %s", upstream_url)
     assert upstream_url is not None
     result = run_cmd_capture(['git', 'remote'], cwd=workspace_path)
+
+    # Determine the fetch URL — try premirror first when configured and
+    # the upstream URL is a remote (not a local mirror path).
+    fetch_url = upstream_url
+    using_premirror = False
+    if premirror and not mirror_path:
+        from .bitbake_ops import rewrite_url_for_premirror
+        premirror_url = rewrite_url_for_premirror(upstream_url, premirror)
+        logger.info("Trying premirror: %s", premirror_url)
+        fetch_url = premirror_url
+        using_premirror = True
+
     if 'upstream' not in result.stdout:
-        run_cmd(['git', 'remote', 'add', 'upstream', upstream_url], cwd=workspace_path)
+        run_cmd(['git', 'remote', 'add', 'upstream', fetch_url], cwd=workspace_path)
     else:
         logger.debug("Upstream remote already exists, skipping...")
 
     logger.info("Fetching upstream references")
-    if not _fetch_remote(workspace_path, 'upstream', upstream_url):
-        logger.error("Failed to fetch upstream from %s — version checkout and "
-                     "blame analysis will be unavailable", upstream_url)
-        run_cmd(['git', 'remote', 'remove', 'upstream'], cwd=workspace_path)
-        return None
+    if not _fetch_remote(workspace_path, 'upstream', fetch_url):
+        if using_premirror:
+            logger.warning("Premirror fetch failed, falling back to %s", upstream_url)
+            run_cmd(['git', 'remote', 'set-url', 'upstream', upstream_url],
+                    cwd=workspace_path)
+            if not _fetch_remote(workspace_path, 'upstream', upstream_url):
+                logger.error("Failed to fetch upstream from %s — version checkout "
+                             "and blame analysis will be unavailable", upstream_url)
+                run_cmd(['git', 'remote', 'remove', 'upstream'], cwd=workspace_path)
+                return None
+        else:
+            logger.error("Failed to fetch upstream from %s — version checkout and "
+                         "blame analysis will be unavailable", upstream_url)
+            run_cmd(['git', 'remote', 'remove', 'upstream'], cwd=workspace_path)
+            return None
 
     # When the fix commits live in a different repo than the recipe fetches,
     # add that repo as a secondary remote and fetch it so the fix commits and

--- a/cve_corrector/workspace.py
+++ b/cve_corrector/workspace.py
@@ -174,7 +174,8 @@ def setup_upstream_remote(workspace_path: Path, mirror_path: Optional[Path],
 
     logger.info("Fetching upstream references")
     if not _fetch_remote(workspace_path, 'upstream', upstream_url):
-        logger.warning("Failed to fetch upstream — continuing without upstream history")
+        logger.error("Failed to fetch upstream from %s — version checkout and "
+                     "blame analysis will be unavailable", upstream_url)
         run_cmd(['git', 'remote', 'remove', 'upstream'], cwd=workspace_path)
         return None
 
@@ -252,8 +253,11 @@ def _fetch_remote(workspace_path: Path, remote_name: str, url: str) -> bool:
         return False
     logger.warning("Fetch of %s failed — retrying via %s", url, alt)
     run_cmd(['git', 'remote', 'set-url', remote_name, alt], cwd=workspace_path)
-    return run_cmd(['git', 'fetch', remote_name, '--tags', '--progress'],
-                   cwd=workspace_path) == 0
+    if run_cmd(['git', 'fetch', remote_name, '--tags', '--progress'],
+               cwd=workspace_path) == 0:
+        return True
+    logger.error("Fetch of %s also failed (tried both %s and %s)", remote_name, url, alt)
+    return False
 
 
 def _init_submodules(workspace_path: Path) -> None:

--- a/cve_metadata_extractor/__init__.py
+++ b/cve_metadata_extractor/__init__.py
@@ -4,7 +4,7 @@
 from .config import load_config
 from .cve_sources import load_cves_from_sources
 from .debian import extract_debian_source_patches, load_debian_tracker, load_debian_tracker_extended
-from .mirrors import create_mirrors, ensure_data_repo
+from .mirrors import ensure_data_repo
 from .processing import extract_metadata_from_sources, process_cve
 from .sources import SOURCE_REGISTRY, CveSource
 from .utils import PR_CACHE, load_pr_cache
@@ -12,7 +12,7 @@ from .utils import PR_CACHE, load_pr_cache
 __all__ = [
     'load_config', 'SOURCE_REGISTRY', 'CveSource',
     'process_cve', 'extract_metadata_from_sources',
-    'load_cves_from_sources', 'create_mirrors', 'ensure_data_repo',
+    'load_cves_from_sources', 'ensure_data_repo',
     'load_pr_cache', 'PR_CACHE',
     'load_debian_tracker', 'load_debian_tracker_extended',
     'extract_debian_source_patches',

--- a/cve_metadata_extractor/mirrors.py
+++ b/cve_metadata_extractor/mirrors.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
-'''Git repository management: mirrors and data repo cloning.'''
+'''Git repository management: data repo cloning.'''
 import logging
-import os
 import subprocess
 import time
 from pathlib import Path
@@ -64,80 +63,3 @@ def ensure_data_repo(repo_dir, clone_url, name, branch=None):
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         logging.error("Failed to clone %s: %s", name, e)
         return None
-
-
-def extract_repo_url_from_patch(url):
-    '''Extract repository URL from a patch URL'''
-    from shared.url_parser import deduce_repo_url  # pylint: disable=import-outside-toplevel
-    return deduce_repo_url(url)
-
-
-def find_repo_urls_from_metadata(metadata):
-    '''Find repository URLs from hash_details in metadata'''
-    urls = set()
-    for hash_detail in metadata.get('hash_details', []):
-        url = hash_detail.get('url')
-        if url:
-            repo_url = extract_repo_url_from_patch(url)
-            if repo_url:
-                urls.add(repo_url)
-    return list(urls)
-
-
-def create_or_update_mirror(repo_url, component_name,
-                            mirrors_dir='data/mirrors'):
-    '''Create or update a bare git mirror repository'''
-    os.makedirs(mirrors_dir, exist_ok=True)
-    mirror_path = os.path.join(mirrors_dir, f"{component_name}.git")
-
-    if os.path.isdir(mirror_path):
-        print(f"  Updating mirror: {component_name}")
-        try:
-            subprocess.run(['git', 'remote', 'update'], cwd=mirror_path,
-                          check=True, capture_output=True, timeout=300)
-            return mirror_path
-        except subprocess.CalledProcessError as e:
-            print(f"  Failed to update mirror: {e}")
-            return None
-    else:
-        print(f"  Creating mirror: {component_name}")
-        try:
-            subprocess.run(
-                ['git', 'clone', '--mirror', '--', repo_url, mirror_path],
-                check=True, capture_output=True, timeout=300)
-            return mirror_path
-        except subprocess.CalledProcessError as e:
-            print(f"  Failed to create mirror: {e}")
-            return None
-
-
-def create_mirrors(results, args):
-    '''Create or update git mirrors for repositories'''
-    print(f"\nCreating/updating mirrors for {len(results)} CVEs...")
-    all_repos = {}
-    for metadata in results.values():
-        if not metadata.get('hashes'):
-            continue
-        repo_urls = find_repo_urls_from_metadata(metadata)
-        component_name = metadata.get('name', 'unknown')
-        for repo_url in repo_urls:
-            if component_name not in all_repos:
-                all_repos[component_name] = repo_url
-
-    print(f"Found {len(all_repos)} unique repositories to mirror")
-    failed_repos = []
-    for idx, (component, repo_url) in enumerate(all_repos.items(), 1):
-        print(f"[{idx}/{len(all_repos)}] {component}: {repo_url}")
-        result = create_or_update_mirror(
-            repo_url, component, args.repo_dir)
-        if result is None:
-            failed_repos.append((component, repo_url))
-
-    print(f"Mirrors created/updated in {args.repo_dir}")
-
-    if failed_repos:
-        print(f"\nFailed to mirror {len(failed_repos)} repositories:")
-        for component, repo_url in failed_repos:
-            print(f"  - {component}: {repo_url}")
-
-    return failed_repos

--- a/shared/git_runner.py
+++ b/shared/git_runner.py
@@ -6,11 +6,14 @@ Provides two levels of abstraction:
 - run_capture(): low-level, returns CompletedProcess (for corrector)
 - run_git_stdout(): high-level git-only, returns stdout str (for agent)
 """
+import logging
 import subprocess
 from pathlib import Path
 from typing import Optional
 
 from shared import TEXT_ENCODING, TEXT_ERRORS, build_git_env
+
+logger = logging.getLogger(__name__)
 
 
 def is_git_cmd(cmd: list[str]) -> bool:
@@ -130,3 +133,87 @@ def run_git_display(args: list[str], cwd: Path) -> None:
         ['git', '--no-pager'] + args, cwd=cwd, env=build_git_env(),
         check=False
     )
+
+
+def _get_submodule_paths(workspace_path: Path) -> set[str]:
+    """Return registered submodule paths from .gitmodules, if any."""
+    gitmodules = workspace_path / '.gitmodules'
+    if not gitmodules.exists():
+        return set()
+    paths: set[str] = set()
+    for line in gitmodules.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith('path'):
+            # e.g. "path = modules/oniguruma"
+            _, _, value = stripped.partition('=')
+            if value.strip():
+                paths.add(value.strip())
+    return paths
+
+
+def copy_missing_files_from_devtool(workspace_path: Path) -> None:
+    """Copy files present in devtool but missing from the CVE branch.
+
+    Release tarballs contain generated autotools files (configure, Makefile.in,
+    m4/*.m4, etc.) and secondary-tarball payloads (e.g. libxml2's ``xmlconf/``
+    W3C conformance suite fetched via a second ``SRC_URI`` entry) that are
+    committed on the devtool branch but do not exist on the upstream-history
+    CVE branch. Switching to the CVE branch therefore strips them, and the
+    build (do_configure/do_compile) then fails on the missing files. This
+    copies them across from the devtool branch without tracking them, so the
+    build succeeds on the CVE branch too. It is a no-op when nothing is
+    missing (e.g. when already on the devtool branch).
+
+    Files under registered submodule paths are skipped — those are tracked
+    by git submodule and must not be overwritten with regular file copies.
+
+    Files under paths that HEAD tracks as symlinks are also skipped — release
+    tarballs dereference symlinks into real directories, and copying those
+    files would clobber the symlink and break subsequent cherry-picks.
+    """
+    devtool_files = run_capture(
+        ['git', 'ls-tree', '-r', '--name-only', 'devtool'], cwd=workspace_path)
+    if devtool_files.returncode != 0:
+        return
+    cve_files = run_capture(
+        ['git', 'ls-tree', '-r', '--name-only', 'HEAD'], cwd=workspace_path)
+    if cve_files.returncode != 0:
+        return
+
+    cve_set = set(cve_files.stdout.strip().splitlines())
+    submodule_paths = _get_submodule_paths(workspace_path)
+
+    # Collect paths that HEAD tracks as symlinks (git mode 120000). Release
+    # tarballs dereference symlinks into real directories, so the devtool
+    # branch lists the symlink target's contents (e.g.
+    # tutorial/swift/swift-dep/Sources/*.swift) as regular files. Copying
+    # those out of devtool would clobber the symlink with a real directory,
+    # leaving a staged deletion + untracked dir that blocks every subsequent
+    # cherry-pick. Skip anything living under a HEAD symlink: the symlink
+    # already resolves to an in-tree path, so nothing is actually missing.
+    symlink_prefixes: tuple[str, ...] = ()
+    cve_tree = run_capture(
+        ['git', 'ls-tree', '-r', 'HEAD'], cwd=workspace_path)
+    if cve_tree.returncode == 0:
+        symlinks = []
+        for line in cve_tree.stdout.strip().splitlines():
+            # Format: "<mode> <type> <hash>\t<path>"
+            meta, _, path = line.partition('\t')
+            if path and meta.split(' ', 1)[0] == '120000':
+                symlinks.append(path + '/')
+        symlink_prefixes = tuple(symlinks)
+
+    missing = [f for f in devtool_files.stdout.strip().splitlines()
+               if f not in cve_set
+               and not any(f == sm or f.startswith(sm + '/')
+                           for sm in submodule_paths)
+               and not (symlink_prefixes and f.startswith(symlink_prefixes))]
+    if not missing:
+        return
+
+    logger.info("Copying %s missing file(s) from devtool branch", len(missing))
+    for filepath in missing:
+        run_capture(['git', 'checkout', 'devtool', '--', filepath],
+                    cwd=workspace_path)
+    # Unstage so they remain as untracked working-tree files
+    run_capture(['git', 'reset', 'HEAD'] + missing, cwd=workspace_path)

--- a/shared/url_parser.py
+++ b/shared/url_parser.py
@@ -294,8 +294,9 @@ def deduce_repo_url(url: str) -> Optional[str]:
     parsed = urlparse(url)
     host = parsed.hostname or ''
 
-    # Gitweb ?p=<repo>;a=commit style
-    if '?p=' in url and ';a=' in url:
+    # Gitweb ?p=<repo> style (e.g. ?p=binutils-gdb.git;a=commit;h=... or
+    # ?p=binutils-gdb.git;h=...)
+    if '?p=' in url:
         repo_name = url.split('?p=')[1].split(';', maxsplit=1)[0]
         if host == 'sourceware.org' or host.endswith('.sourceware.org'):
             return f'https://sourceware.org/git/{repo_name}'

--- a/tests/agent/test_ensure_cve_branch.py
+++ b/tests/agent/test_ensure_cve_branch.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Regression tests for cve_agent.session._ensure_cve_branch.
+
+The agent must operate on the CVE branch (the source of truth that
+cherry_pick_to_devtool transfers to the throwaway devtool branch). The
+corrector's build step leaves the *devtool* branch checked out, and the
+agent's command allow-list forbids switching branches. Without an explicit
+switch, the agent would amend its fix onto devtool, where it is orphaned when
+the session forces back to the CVE branch and then wiped on the next resume by
+reset_devtool_to_base + cherry_pick_to_devtool re-applying the unfixed
+CVE-branch commit — silently reverting the fix every round.
+"""
+import subprocess
+
+import pytest
+
+from cve_agent.session import _ensure_cve_branch
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ['git', *args], cwd=cwd, check=True,
+        capture_output=True, text=True,
+    )
+
+
+def _current_branch(cwd):
+    return subprocess.run(
+        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        cwd=cwd, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def devtool_repo(tmp_path):
+    """A workspace mirroring a devtool-modify tree mid-CVE-workflow.
+
+    Branches: ``devtool-base`` (pristine), ``CVE-2025-6021`` (the CVE fix
+    commit, source of truth), and ``devtool`` (throwaway build branch). The
+    tree is left on ``devtool`` — exactly how the corrector's build step
+    leaves it before the AI session starts.
+    """
+    repo = tmp_path / "libxml2"
+    repo.mkdir()
+    _git(repo, 'init', '-q')
+    _git(repo, 'config', 'user.email', 'test@example.com')
+    _git(repo, 'config', 'user.name', 'Test')
+    (repo / 'tree.c').write_text("#include <limits.h>\nint main(void){return 0;}\n")
+    _git(repo, 'add', 'tree.c')
+    _git(repo, 'commit', '-q', '-m', 'Initial commit from upstream at 2.12.10')
+    _git(repo, 'branch', 'devtool-base')
+    # CVE branch carries the cherry-picked fix commit (source of truth).
+    _git(repo, 'checkout', '-q', '-b', 'CVE-2025-6021')
+    (repo / 'tree.c').write_text(
+        "#include <limits.h>\nint main(void){return 0;}\n/* fix */\n")
+    _git(repo, 'add', 'tree.c')
+    _git(repo, 'commit', '-q', '-m', 'Fix: Integer Overflow in xmlBuildQName()')
+    # devtool branch is the build branch; leave the tree checked out on it.
+    _git(repo, 'checkout', '-q', '-b', 'devtool', 'devtool-base')
+    # xmlconf/ mirrors libxml2's secondary-tarball W3C conformance suite:
+    # tracked on devtool (committed from the unpacked tarball) but absent from
+    # the upstream-history CVE branch. do_configure needs it present.
+    (repo / 'xmlconf').mkdir()
+    (repo / 'xmlconf' / 'test.xml').write_text("<x/>\n")
+    _git(repo, 'add', 'xmlconf/test.xml')
+    _git(repo, 'commit', '-q', '-m', 'unpack xmlconf test suite from tarball')
+    return repo
+
+
+def test_switches_from_devtool_to_cve_branch(devtool_repo):
+    assert _current_branch(devtool_repo) == 'devtool'
+    _ensure_cve_branch(devtool_repo, 'CVE-2025-6021')
+    assert _current_branch(devtool_repo) == 'CVE-2025-6021'
+
+
+def test_restores_devtool_tracked_files_missing_on_cve(devtool_repo):
+    """Tarball payloads tracked on devtool but not on the CVE branch (e.g.
+    xmlconf/) must be restored after the switch, or the agent's own
+    ``devtool build`` fails in do_configure looking for them."""
+    # Present on devtool (where the fixture leaves the tree).
+    assert (devtool_repo / 'xmlconf' / 'test.xml').exists()
+
+    _ensure_cve_branch(devtool_repo, 'CVE-2025-6021')
+
+    assert _current_branch(devtool_repo) == 'CVE-2025-6021'
+    # Restored into the working tree even though the CVE branch never tracked it.
+    assert (devtool_repo / 'xmlconf' / 'test.xml').exists(), \
+        "devtool-tracked tarball file was not restored on the CVE branch"
+    # ...and left untracked (not committed onto the CVE branch).
+    status = subprocess.run(
+        ['git', 'status', '--porcelain', '--', 'xmlconf/test.xml'],
+        cwd=devtool_repo, capture_output=True, text=True, check=True,
+    ).stdout
+    assert status.startswith('??'), \
+        f"expected xmlconf/test.xml untracked, got: {status!r}"
+
+
+def test_switches_even_with_dirty_worktree(devtool_repo):
+    """A dirty tree (e.g. regenerated autotools output) must not block the
+    switch — force_checkout_branch escalates cleanup as needed."""
+    (devtool_repo / 'tree.c').write_text("locally modified, would block checkout\n")
+    _ensure_cve_branch(devtool_repo, 'CVE-2025-6021')
+    assert _current_branch(devtool_repo) == 'CVE-2025-6021'
+
+
+def test_noop_when_already_on_cve_branch(devtool_repo):
+    _git(devtool_repo, 'checkout', '-q', 'CVE-2025-6021')
+    head_before = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'], cwd=devtool_repo,
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    _ensure_cve_branch(devtool_repo, 'CVE-2025-6021')
+    assert _current_branch(devtool_repo) == 'CVE-2025-6021'
+    head_after = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'], cwd=devtool_repo,
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head_before == head_after
+
+
+def test_noop_when_cve_branch_missing(devtool_repo):
+    """If the named branch doesn't exist, stay put rather than error."""
+    _ensure_cve_branch(devtool_repo, 'CVE-9999-0000')
+    assert _current_branch(devtool_repo) == 'devtool'
+
+
+def test_noop_when_cve_id_empty(devtool_repo):
+    _ensure_cve_branch(devtool_repo, '')
+    assert _current_branch(devtool_repo) == 'devtool'
+
+
+def test_noop_when_workspace_missing(tmp_path):
+    # Must not raise when the workspace directory does not exist.
+    _ensure_cve_branch(tmp_path / 'gone', 'CVE-2025-6021')

--- a/tests/agent/test_noop_session_skip_approval.py
+++ b/tests/agent/test_noop_session_skip_approval.py
@@ -1,0 +1,420 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Test the orchestrator's approval flow for build/ptest resolutions.
+
+Reproduces the double-approval bug: when the AI session doesn't fix the
+build error, the orchestrator should skip the approval prompt and retry
+rather than asking the human to approve a non-existent fix.
+
+Behaviour:
+1. No-op detection: if HEAD is unchanged after a build/ptest session, skip
+   approval and retry — there is nothing for the human to review.
+2. Real change: show the human the review *before* finalizing (same path as
+   conflict resolution). Only on approval does the corrector run --continue
+   (build + ptest + devtool finish). This keeps the workspace present for the
+   review and never asks the human to approve a change already committed.
+   --continue re-verifies the build authoritatively and retries on a
+   recoverable failure.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+from cve_agent import AgentConfig, ResultStatus
+from cve_agent.knowledge import KnowledgeBase
+from cve_agent.orchestrator import process_single_cve
+from cve_agent.session import SessionResult
+from tests.helpers import git
+
+
+def _cfg(cve_id, cve_info_path, meta_layer=None, **kwargs):
+    defaults = dict(trust_mode=True, skip_ptest=True, skip_cve_applicability=True)
+    defaults.update(kwargs)
+    return AgentConfig(cve_id=cve_id, cve_info_path=cve_info_path,
+                       meta_layer=meta_layer, **defaults)
+
+
+def _write_cve_json(tmp_path, cve_id, recipe, hashes):
+    data = {cve_id: {
+        'name': recipe, 'hashes': hashes,
+        'hash_details': [{'hash': h, 'url': f'https://example.com/commit/{h}',
+                          'source': 'test'} for h in hashes]}}
+    p = tmp_path / f'{cve_id}.json'
+    p.write_text(json.dumps(data))
+    return p
+
+
+class TestNoopSessionSkipsApproval:
+    """AI session that makes no changes should not trigger approval for build/ptest."""
+
+    def test_build_error_noop_skips_approval_then_fix_succeeds(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """Simulate: build fails -> AI does nothing -> no approval -> retry ->
+        AI fixes -> build verified -> approval shown once.
+
+        This is the exact scenario from the libxml2 cast recording where the
+        user was asked to approve twice.
+        """
+        bare, hashes = make_upstream_repo(
+            files={'src/tree.c': 'int lenn, lenp;\n'},
+            version_tag='v2.12.10',
+            fix_commits=[{'files': {'src/tree.c': 'size_t lenn, lenp;\n'},
+                          'message': 'Fix integer overflow'}])
+
+        ws = make_workspace(bare, 'libxml2', 'v2.12.10')
+        meta = make_meta_layer('libxml2', '2.12.10')
+        mock_bitbake_env(ws, meta, 'libxml2', '2.12.10')
+
+        cve_id = 'CVE-2025-6021'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'libxml2', hashes)
+        config = _cfg(cve_id, cve_info_path, meta)
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        # Track calls to request_approval
+        approval_mock = MagicMock(return_value=('approved', ''))
+
+        session_call_count = [0]
+
+        def _session_side_effect(context_file, workspace_path, upstream_sha,
+                                 cve_info, model, timeout, cve_id,
+                                 interactive=False, backend_name="kiro"):
+            """First call: do nothing (no-op). Second call: amend commit."""
+            session_call_count[0] += 1
+            if session_call_count[0] == 1:
+                # Simulate AI session that talks but doesn't change anything
+                return SessionResult(resolved=True, duration=1.0)
+            else:
+                # Simulate AI session that actually fixes the build error
+                # by amending the commit (e.g. adding #include <stdint.h>)
+                (workspace_path / 'src' / 'tree.c').write_text(
+                    '#include <stdint.h>\nsize_t lenn, lenp;\n')
+                git(workspace_path, 'add', '-A', check=False)
+                git(workspace_path, 'commit', '--amend', '--no-edit',
+                    check=False)
+                return SessionResult(resolved=True, duration=2.0)
+
+        corrector_calls = [0]
+
+        def _mock_corrector(config, continue_mode=False, mark_not_applicable=None):
+            if mark_not_applicable:
+                return (0, '')
+            corrector_calls[0] += 1
+            if corrector_calls[0] == 1:
+                # Initial run: cherry-pick succeeds but build fails (exit 4)
+                git(ws, 'checkout', '-B', 'CVE-2025-6021', 'v2.12.10')
+                git(ws, 'branch', 'original-version', 'v2.12.10')
+                git(ws, 'cherry-pick', hashes[0])
+                return (4, 'Build failed for libxml2')
+            elif continue_mode:
+                # --continue called after AI made changes: build passes
+                return (0, '')
+            return (0, '')
+
+        with patch('cve_agent.orchestrator.run_corrector',
+                   side_effect=_mock_corrector), \
+             patch('cve_agent.orchestrator.request_approval', approval_mock), \
+             patch('cve_agent.orchestrator.guarded_session',
+                   side_effect=_session_side_effect), \
+             patch('cve_agent.__main__._log_result'):
+            result = process_single_cve(config, kb)
+
+        # The fix should ultimately succeed
+        assert result.status == ResultStatus.CONFLICT_RESOLVED
+
+        # Key assertion: approval should only be called ONCE — after the
+        # second attempt where the AI actually fixed the build.
+        assert approval_mock.call_count == 1
+
+        # AI session was called twice (first no-op, second with fix)
+        assert session_call_count[0] == 2
+
+    def test_build_error_workspace_finalized_by_continue_no_crash(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """--continue finalizes (removes) the workspace on success, without crash.
+
+        The review is shown *before* --continue while the workspace still
+        exists, so request_approval is called exactly once and never runs
+        against a removed directory (the earlier design showed approval after
+        --continue and crashed with FileNotFoundError from `git commit --amend`
+        inside a nonexistent cwd). Finalization removing the workspace
+        afterwards must not affect the successful outcome.
+        """
+        bare, hashes = make_upstream_repo(
+            files={'src/tree.c': 'int lenn, lenp;\n'},
+            version_tag='v2.12.10',
+            fix_commits=[{'files': {'src/tree.c': 'size_t lenn, lenp;\n'},
+                          'message': 'Fix integer overflow'}])
+
+        ws = make_workspace(bare, 'libxml2', 'v2.12.10')
+        meta = make_meta_layer('libxml2', '2.12.10')
+        mock_bitbake_env(ws, meta, 'libxml2', '2.12.10')
+
+        cve_id = 'CVE-2025-6023'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'libxml2', hashes)
+        config = _cfg(cve_id, cve_info_path, meta)
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        approval_mock = MagicMock(return_value=('approved', ''))
+
+        def _session_fix(context_file, workspace_path, upstream_sha,
+                         cve_info, model, timeout, cve_id,
+                         interactive=False, backend_name="kiro"):
+            (workspace_path / 'src' / 'tree.c').write_text(
+                '#include <stdint.h>\nsize_t lenn, lenp;\n')
+            git(workspace_path, 'add', '-A', check=False)
+            git(workspace_path, 'commit', '--amend', '--no-edit', check=False)
+            return SessionResult(resolved=True, duration=1.0)
+
+        corrector_calls = [0]
+
+        def _mock_corrector(config, continue_mode=False, mark_not_applicable=None):
+            if mark_not_applicable:
+                return (0, '')
+            corrector_calls[0] += 1
+            if corrector_calls[0] == 1:
+                git(ws, 'checkout', '-B', 'CVE-2025-6023', 'v2.12.10')
+                git(ws, 'branch', 'original-version', 'v2.12.10')
+                git(ws, 'cherry-pick', hashes[0])
+                return (4, 'Build failed for libxml2')
+            elif continue_mode:
+                # Simulate devtool finish removing the workspace on success,
+                # exactly like the real corrector does after finalizing.
+                import shutil
+                if ws.exists():
+                    shutil.rmtree(ws)
+                return (0, '')
+            return (0, '')
+
+        with patch('cve_agent.orchestrator.run_corrector',
+                   side_effect=_mock_corrector), \
+             patch('cve_agent.orchestrator.request_approval', approval_mock), \
+             patch('cve_agent.orchestrator.guarded_session',
+                   side_effect=_session_fix), \
+             patch('cve_agent.__main__._log_result'):
+            result = process_single_cve(config, kb)
+
+        # Must not crash, and must report success. The review is shown once,
+        # before --continue removes the workspace.
+        assert result.status == ResultStatus.CONFLICT_RESOLVED
+        approval_mock.assert_called_once()
+
+    def test_build_error_ai_changes_reviewed_each_attempt_until_build_passes(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """AI makes a real change each attempt -> review shown before each
+        finalize; --continue fails twice then passes.
+
+        Each real change is reviewed before finalizing (same as conflict
+        resolution). --continue re-verifies the build after approval and, on a
+        recoverable failure, the loop retries with a fresh session and a fresh
+        review. No-op sessions (unchanged HEAD) would be filtered out earlier
+        and never reach approval.
+        """
+        bare, hashes = make_upstream_repo(
+            files={'src/tree.c': 'int lenn, lenp;\n'},
+            version_tag='v2.12.10',
+            fix_commits=[{'files': {'src/tree.c': 'size_t lenn, lenp;\n'},
+                          'message': 'Fix integer overflow'}])
+
+        ws = make_workspace(bare, 'libxml2', 'v2.12.10')
+        meta = make_meta_layer('libxml2', '2.12.10')
+        mock_bitbake_env(ws, meta, 'libxml2', '2.12.10')
+
+        cve_id = 'CVE-2025-6022'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'libxml2', hashes)
+        config = _cfg(cve_id, cve_info_path, meta)
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        approval_mock = MagicMock(return_value=('approved', ''))
+        session_call_count = [0]
+
+        def _session_side_effect(context_file, workspace_path, upstream_sha,
+                                 cve_info, model, timeout, cve_id,
+                                 interactive=False, backend_name="kiro"):
+            session_call_count[0] += 1
+            if session_call_count[0] <= 2:
+                # Both first and second attempts: make a change that doesn't
+                # fully fix the build
+                (workspace_path / 'src' / 'tree.c').write_text(
+                    f'// attempt {session_call_count[0]}\nsize_t lenn, lenp;\n')
+                git(workspace_path, 'add', '-A', check=False)
+                git(workspace_path, 'commit', '--amend', '--no-edit',
+                    check=False)
+                return SessionResult(resolved=True, duration=1.0)
+            else:
+                # Third attempt finally fixes it
+                (workspace_path / 'src' / 'tree.c').write_text(
+                    '#include <stdint.h>\nsize_t lenn, lenp;\n')
+                git(workspace_path, 'add', '-A', check=False)
+                git(workspace_path, 'commit', '--amend', '--no-edit',
+                    check=False)
+                return SessionResult(resolved=True, duration=2.0)
+
+        corrector_calls = [0]
+
+        def _mock_corrector(config, continue_mode=False, mark_not_applicable=None):
+            if mark_not_applicable:
+                return (0, '')
+            corrector_calls[0] += 1
+            if corrector_calls[0] == 1:
+                # Initial: build error
+                git(ws, 'checkout', '-B', 'CVE-2025-6022', 'v2.12.10')
+                git(ws, 'branch', 'original-version', 'v2.12.10')
+                git(ws, 'cherry-pick', hashes[0])
+                return (4, 'Build failed')
+            elif continue_mode:
+                # First two --continue calls fail, third succeeds
+                if corrector_calls[0] <= 3:
+                    return (4, 'Build still failing')
+                return (0, '')
+            return (0, '')
+
+        with patch('cve_agent.orchestrator.run_corrector',
+                   side_effect=_mock_corrector), \
+             patch('cve_agent.orchestrator.request_approval', approval_mock), \
+             patch('cve_agent.orchestrator.guarded_session',
+                   side_effect=_session_side_effect), \
+             patch('cve_agent.__main__._log_result'):
+            result = process_single_cve(config, kb)
+
+        assert result.status == ResultStatus.CONFLICT_RESOLVED
+        # A real change is reviewed before each finalize attempt: two failed
+        # --continue builds then a passing one => three reviews.
+        assert approval_mock.call_count == 3
+        # AI was called 3 times (first two changes didn't fix build)
+        assert session_call_count[0] == 3
+
+    def test_ptest_error_noop_also_skips_approval(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """Same behavior for ptest failures: no-op sessions skip approval."""
+        bare, hashes = make_upstream_repo(
+            files={'src/parser.c': 'void parse() { /* vuln */ }\n'},
+            version_tag='v1.0',
+            fix_commits=[{'files': {'src/parser.c': 'void parse() { /* fixed */ }\n'},
+                          'message': 'Fix ptest regression'}])
+
+        ws = make_workspace(bare, 'testpkg', 'v1.0')
+        meta = make_meta_layer('testpkg', '1.0')
+        mock_bitbake_env(ws, meta, 'testpkg', '1.0')
+
+        cve_id = 'CVE-2025-9999'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'testpkg', hashes)
+        config = _cfg(cve_id, cve_info_path, meta)
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        approval_mock = MagicMock(return_value=('approved', ''))
+        call_count = [0]
+
+        def _session_side_effect(context_file, workspace_path, upstream_sha,
+                                 cve_info, model, timeout, cve_id,
+                                 interactive=False, backend_name="kiro"):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return SessionResult(resolved=True, duration=1.0)
+            else:
+                # Second attempt: amend commit to fix ptest
+                (workspace_path / 'src' / 'parser.c').write_text(
+                    'void parse() { /* fixed properly */ }\n')
+                git(workspace_path, 'add', '-A', check=False)
+                git(workspace_path, 'commit', '--amend', '--no-edit',
+                    check=False)
+                return SessionResult(resolved=True, duration=2.0)
+
+        corrector_calls = [0]
+
+        def _mock_corrector(config, continue_mode=False, mark_not_applicable=None):
+            if mark_not_applicable:
+                return (0, '')
+            corrector_calls[0] += 1
+            if corrector_calls[0] == 1:
+                # Initial: ptest error (3)
+                git(ws, 'checkout', '-B', 'CVE-2025-9999', 'v1.0')
+                git(ws, 'branch', 'original-version', 'v1.0')
+                git(ws, 'cherry-pick', hashes[0])
+                return (3, 'Ptest failed for testpkg')
+            elif continue_mode:
+                return (0, '')
+            return (0, '')
+
+        with patch('cve_agent.orchestrator.run_corrector',
+                   side_effect=_mock_corrector), \
+             patch('cve_agent.orchestrator.request_approval', approval_mock), \
+             patch('cve_agent.orchestrator.guarded_session',
+                   side_effect=_session_side_effect), \
+             patch('cve_agent.__main__._log_result'):
+            result = process_single_cve(config, kb)
+
+        assert result.status == ResultStatus.CONFLICT_RESOLVED
+        assert approval_mock.call_count == 1
+
+    def test_conflict_noop_still_shows_approval(
+            self, make_upstream_repo, make_workspace, make_meta_layer,
+            mock_bitbake_env, tmp_path):
+        """For conflict resolution (exit 1), even unchanged HEAD shows approval.
+
+        Conflicts are different — the AI may have resolved the conflict by
+        accepting the existing version verbatim (no net diff from HEAD),
+        which is a valid resolution that should still be reviewed. The
+        build-verification path only applies to exit codes 3 and 4.
+        """
+        bare, hashes = make_upstream_repo(
+            files={'src/file.c': 'line1\nline2\nvulnerable\nline4\n'},
+            version_tag='v1.0',
+            fix_commits=[{'files': {'src/file.c': 'line1\nline2\nfixed\nline4\n'},
+                          'message': 'Fix vuln'}])
+
+        ws = make_workspace(bare, 'conflictpkg', 'v1.0',
+                            existing_patch_commits=[
+                                {'files': {'src/file.c': 'line1\nline2\npatched\nline4\n'},
+                                 'message': 'Existing patch'}])
+        meta = make_meta_layer('conflictpkg', '1.0',
+                               existing_patches={'0001-Existing-patch.patch': 'p\n'})
+        mock_bitbake_env(ws, meta, 'conflictpkg', '1.0')
+
+        cve_id = 'CVE-2025-8888'
+        cve_info_path = _write_cve_json(tmp_path, cve_id, 'conflictpkg', hashes)
+        config = _cfg(cve_id, cve_info_path, meta)
+        kb = KnowledgeBase(tmp_path / 'kb.json')
+
+        approval_mock = MagicMock(return_value=('approved', ''))
+
+        def _session_resolve(context_file, workspace_path, upstream_sha,
+                             cve_info, model, timeout, cve_id,
+                             interactive=False, backend_name="kiro"):
+            """Session resolves conflict by taking theirs."""
+            git(workspace_path, 'checkout', '--theirs', '.', check=False)
+            git(workspace_path, 'add', '-A', check=False)
+            git(workspace_path, '-c', 'core.editor=true', 'cherry-pick',
+                '--continue', check=False)
+            return SessionResult(resolved=True, duration=1.0)
+
+        corrector_calls = [0]
+
+        def _mock_corrector(config, continue_mode=False, mark_not_applicable=None):
+            if mark_not_applicable:
+                return (0, '')
+            corrector_calls[0] += 1
+            if corrector_calls[0] == 1:
+                # Initial: conflict (exit 1)
+                git(ws, 'checkout', '-B', 'CVE-2025-8888', 'v1.0')
+                git(ws, 'branch', 'original-version', 'v1.0')
+                git(ws, 'cherry-pick', hashes[0], check=False)
+                # Leave conflict unresolved for AI to handle
+                return (1, 'CONFLICT in src/file.c')
+            elif continue_mode:
+                return (0, '')
+            return (0, '')
+
+        with patch('cve_agent.orchestrator.run_corrector',
+                   side_effect=_mock_corrector), \
+             patch('cve_agent.orchestrator.request_approval', approval_mock), \
+             patch('cve_agent.orchestrator.guarded_session',
+                   side_effect=_session_resolve), \
+             patch('cve_agent.__main__._log_result'):
+            result = process_single_cve(config, kb)
+
+        # For conflicts, approval SHOULD be called (no build-verify shortcut)
+        assert approval_mock.call_count == 1
+        assert result.status == ResultStatus.CONFLICT_RESOLVED

--- a/tests/corrector/test_bitbake_ops.py
+++ b/tests/corrector/test_bitbake_ops.py
@@ -276,6 +276,101 @@ def test_append_src_uri_entries_single_line_override_only(tmp_path):
     assert "file://CVE-2026-11111.patch" in content
 
 
+def test_append_src_uri_entries_inc_file_fallback(tmp_path):
+    """When .bb has no plain SRC_URI, insert into the sibling .inc file."""
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-devtools" / "binutils"
+    recipe_dir.mkdir(parents=True)
+    # The .inc file has the main SRC_URI
+    inc = recipe_dir / "binutils.inc"
+    inc.write_text(
+        'SUMMARY = "GNU binary utilities"\n'
+        'SRC_URI = "https://ftp.gnu.org/gnu/binutils/binutils-${PV}.tar.gz \\\n'
+        '           file://0001-fix-something.patch \\\n'
+        '           "\n'
+    )
+    # The .bb file only has a scoped override
+    recipe = recipe_dir / "binutils_2.46.bb"
+    recipe.write_text(
+        'require binutils.inc\n'
+        '\n'
+        'SRC_URI:append:class-nativesdk = " file://0003-nativesdk.patch "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-18220.patch"])
+    # Patch must end up in the .inc file, not the .bb
+    inc_content = inc.read_text()
+    bb_content = recipe.read_text()
+    assert "CVE-2026-18220.patch" in inc_content
+    assert "CVE-2026-18220.patch" not in bb_content
+    # Verify it's inside the SRC_URI block of the .inc
+    _assert_valid_bitbake_assignments(inc_content)
+
+
+def test_append_src_uri_entries_scoped_override_only_fallback(tmp_path):
+    """When only scoped overrides exist (no .inc, no plain SRC_URI),
+    append a new SRC_URI:append line rather than inserting into the scoped one.
+    """
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-devtools" / "binutils"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "binutils_2.46.bb"
+    recipe.write_text(
+        'require binutils.inc\n'
+        '\n'
+        'SRC_URI:append:class-nativesdk = " file://0003-nativesdk.patch "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-18220.patch"])
+    content = recipe.read_text()
+    # The nativesdk line must be untouched
+    assert 'SRC_URI:append:class-nativesdk = " file://0003-nativesdk.patch "' in content
+    # A new SRC_URI:append line must be added
+    assert 'SRC_URI:append = " file://CVE-2026-18220.patch"' in content
+    _assert_valid_bitbake_assignments(content)
+
+
+def test_append_src_uri_entries_scoped_override_multiple_patches(tmp_path):
+    """Multiple patches with scoped-override fallback produce a multi-line block."""
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-devtools" / "binutils"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "binutils_2.46.bb"
+    recipe.write_text(
+        'require binutils.inc\n'
+        '\n'
+        'SRC_URI:append:class-nativesdk = " file://0003-nativesdk.patch "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-18220.patch", "CVE-2026-18221.patch"])
+    content = recipe.read_text()
+    assert 'SRC_URI:append:class-nativesdk = " file://0003-nativesdk.patch "' in content
+    assert "file://CVE-2026-18220.patch" in content
+    assert "file://CVE-2026-18221.patch" in content
+    assert "SRC_URI:append = " in content
+    _assert_valid_bitbake_assignments(content)
+
+
+def test_append_src_uri_entries_unscoped_override_is_used(tmp_path):
+    """An unscoped SRC_URI:append (no class/machine suffix) is a valid target."""
+    from cve_corrector.recipe_ops import _append_src_uri_entries
+    recipe_dir = tmp_path / "recipes-support" / "foo"
+    recipe_dir.mkdir(parents=True)
+    recipe = recipe_dir / "foo_1.0.bb"
+    recipe.write_text(
+        'require foo.inc\n'
+        '\n'
+        'SRC_URI:append = " \\\n'
+        '    file://existing.patch \\\n'
+        '    "\n'
+        'SRC_URI:append:class-nativesdk = " file://sdk.patch "\n'
+    )
+    _append_src_uri_entries(recipe, ["CVE-2026-55555.patch"])
+    content = recipe.read_text()
+    # Must insert into the unscoped SRC_URI:append, not into class-nativesdk
+    assert "CVE-2026-55555.patch" in content
+    # The nativesdk line must remain unchanged
+    assert 'SRC_URI:append:class-nativesdk = " file://sdk.patch "' in content
+    _assert_valid_bitbake_assignments(content)
+
+
 
 def test_find_recipe_file_exact_match(tmp_path):
     """_find_recipe_file does not match busybox-utils when looking for busybox."""

--- a/tests/corrector/test_bitbake_ops.py
+++ b/tests/corrector/test_bitbake_ops.py
@@ -663,3 +663,35 @@ class TestCheckCveStatusCpeScope:
         raw = "ignored: cpe:*:zstandard:names the real CPE product"
         mock_run.side_effect = self._mock_getvar(raw, "zstandard")
         assert check_cve_status("zstd", "CVE-2025-0001") == ("Ignored", raw)
+
+
+class TestRewriteUrlForPremirror:
+    """Tests for rewrite_url_for_premirror URL transformation."""
+
+    def test_sourceware_url(self):
+        from cve_corrector.bitbake_ops import rewrite_url_for_premirror
+        result = rewrite_url_for_premirror(
+            'https://sourceware.org/git/binutils-gdb',
+            'https://git.example.com/mirror')
+        assert result == 'https://git.example.com/mirror/sourceware.org.git.binutils-gdb'
+
+    def test_github_url(self):
+        from cve_corrector.bitbake_ops import rewrite_url_for_premirror
+        result = rewrite_url_for_premirror(
+            'https://github.com/libexpat/libexpat',
+            'https://git.example.com/mirror')
+        assert result == 'https://git.example.com/mirror/github.com.libexpat.libexpat'
+
+    def test_git_protocol_with_dot_git_suffix(self):
+        from cve_corrector.bitbake_ops import rewrite_url_for_premirror
+        result = rewrite_url_for_premirror(
+            'git://git.savannah.gnu.org/grub.git',
+            'https://git.example.com/mirror')
+        assert result == 'https://git.example.com/mirror/git.savannah.gnu.org.grub'
+
+    def test_trailing_slash_on_base_url(self):
+        from cve_corrector.bitbake_ops import rewrite_url_for_premirror
+        result = rewrite_url_for_premirror(
+            'https://github.com/libexpat/libexpat',
+            'https://git.example.com/mirror/')
+        assert result == 'https://git.example.com/mirror/github.com.libexpat.libexpat'

--- a/tests/corrector/test_blame.py
+++ b/tests/corrector/test_blame.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from cve_corrector.blame import (
+    _is_release_tag,
     _tag_to_version_str,
     blame_line_ranges,
     check_vulnerability_origin,
@@ -381,3 +382,63 @@ class TestCheckVulnerabilityOrigin:
         series = [{'commits': [fix_hash]}]
         reason = check_vulnerability_origin(repo, [], '1.0.0', series=series)
         assert reason is not None
+
+
+# --- _is_release_tag ---
+
+class TestIsReleaseTag:
+    def test_release_tags(self):
+        assert _is_release_tag('v2.42') is True
+        assert _is_release_tag('binutils-2_42') is True
+        assert _is_release_tag('release-3.7.9') is True
+        assert _is_release_tag('libxml2-2.13.0') is True
+        assert _is_release_tag('V_9_6_P1') is True
+
+    def test_branchpoint_tags(self):
+        assert _is_release_tag('binutils-2_15-branchpoint') is False
+        assert _is_release_tag('binutils-2_42-branchpoint') is False
+        assert _is_release_tag('foo-branchpoint') is False
+
+    def test_rc_tags(self):
+        assert _is_release_tag('v2.42-rc1') is False
+        assert _is_release_tag('binutils-2_42-rc3') is False
+
+    def test_alpha_beta_tags(self):
+        assert _is_release_tag('v1.0-alpha') is False
+        assert _is_release_tag('v1.0-beta2') is False
+        assert _is_release_tag('foo-alpha1') is False
+
+    def test_dev_tags(self):
+        assert _is_release_tag('v1.0-dev') is False
+        assert _is_release_tag('v2.0-snapshot') is False
+        assert _is_release_tag('nightly-build') is False
+
+    def test_branch_management_tags(self):
+        assert _is_release_tag('binutils-2_15-start') is False
+        assert _is_release_tag('foo-base') is False
+        assert _is_release_tag('merge-point') is False
+
+
+class TestFindIntroducingVersionFiltersBranchpoints:
+    def test_skips_branchpoint_tag(self, tmp_path):
+        """Non-release tags like branchpoint are skipped."""
+        repo = _init_repo(tmp_path)
+        _git(repo, 'tag', 'binutils-2_15-branchpoint')
+        _git(repo, 'tag', 'binutils-2_42')
+        initial_hash = _git(repo, 'rev-parse', 'HEAD')
+
+        version = find_introducing_version(repo, {initial_hash})
+        # Should pick 2.42, not 2.15-branchpoint
+        assert version is not None
+        assert 'branchpoint' not in version
+        assert '42' in version
+
+    def test_only_branchpoint_tags_returns_none(self, tmp_path):
+        """If only non-release tags exist, return None."""
+        repo = _init_repo(tmp_path)
+        _git(repo, 'tag', 'binutils-2_15-branchpoint')
+        _git(repo, 'tag', 'foo-rc1')
+        initial_hash = _git(repo, 'rev-parse', 'HEAD')
+
+        version = find_introducing_version(repo, {initial_hash})
+        assert version is None

--- a/tests/corrector/test_cherry_pick_devtool_git.py
+++ b/tests/corrector/test_cherry_pick_devtool_git.py
@@ -73,6 +73,9 @@ def workspace(tmp_path: Path) -> Path:
     _git(repo, 'checkout', '-q', '-b', 'devtool')
     for idx in (1, 2):
         _commit(repo, f'recipe-patch-{idx}.txt', f'{idx}\n', f'recipe patch {idx}')
+    # devtool modify tags the fully SRC_URI-patched source as devtool-patched
+    # (devtool-base is the pristine tarball import, before recipe patches).
+    _git(repo, 'tag', 'devtool-patched', 'devtool')
 
     # CVE branch: version tag + cherry-picked devtool commits + CVE series.
     _git(repo, 'checkout', '-q', '-b', CVE_ID, 'R_2_6_4')
@@ -137,3 +140,148 @@ def test_skips_commits_already_on_devtool(workspace: Path) -> None:
         'lib: refactor helper',
         'lib: Introduce an integer overflow check for tag buffer',
     ]
+
+
+def test_resume_after_ai_amend_single_commit_requires_devtool_reset(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: re-transferring onto a stale devtool branch is unsafe.
+
+    Reproduces the real-world libxml2/CVE-2025-6021 bug: a *single*-commit
+    CVE fix is transferred to devtool, the build fails, and the AI agent
+    fixes it with ``git commit --amend`` on the CVE branch (not a new
+    commit). Naively calling ``cherry_pick_to_devtool`` again on the same
+    (already-patched) devtool branch fails outright — its ``git am``
+    strip-level detection assumes devtool is still at its pre-patch base, so
+    a second pass on top of the first transfer's changes can't apply
+    cleanly. Resetting devtool back to its pre-patch base
+    (``reset_devtool_to_base``) before re-transferring is what lets the
+    amended content actually reach devtool.
+    """
+    from cve_corrector.cherry_pick import reset_devtool_to_base
+    from cve_corrector.state import PatchError
+
+    monkeypatch.setenv('BBPATH', str(tmp_path))
+
+    repo = tmp_path / 'libxml2'
+    repo.mkdir()
+    _git(repo, 'init', '-q', '-b', 'main')
+    _git(repo, 'config', 'user.email', 'test@example.com')
+    _git(repo, 'config', 'user.name', 'Test')
+    _git(repo, 'config', 'commit.gpgsign', 'false')
+
+    _commit(repo, 'Makefile', 'all:\n', 'build: add Makefile')
+    _commit(repo, 'tree.c', 'int lenn, lenp;\n', 'release 2.12.10')
+    _git(repo, 'tag', 'v2.12.10')
+
+    _commit(repo, 'tree.c', 'size_t lenn, lenp;\n',
+            'Fix: Integer Overflow in xmlBuildQName()')
+    fix_sha = _git(repo, 'rev-parse', 'HEAD')
+
+    _git(repo, 'checkout', '-q', '--orphan', 'devtool-base')
+    _git(repo, 'rm', '-q', '-rf', '.')
+    _git(repo, 'checkout', 'v2.12.10', '--', '.')
+    _git(repo, 'commit', '-m', 'Initial commit from upstream tarball')
+    _git(repo, 'checkout', '-q', '-b', 'devtool')
+
+    cve_id = 'CVE-2025-6021'
+    _git(repo, 'checkout', '-q', '-b', cve_id, 'v2.12.10')
+    _git(repo, 'tag', '-f', 'original-version')
+    _git(repo, 'cherry-pick', fix_sha)
+
+    state = WorkflowState(
+        workspace_path=repo, cve_id=cve_id, recipe='libxml2',
+        commit_hash=fix_sha, hash_details=[], meta_layer=None,
+        skip_build=True, skip_ptest=True)
+
+    # First transfer — build fails afterward (simulated by the AI amending).
+    cherry_pick_to_devtool(state)
+
+    # AI agent amends the CVE-branch commit to add the missing #include.
+    _git(repo, 'checkout', '-q', cve_id)
+    (repo / 'tree.c').write_text('#include <stdint.h>\nsize_t lenn, lenp;\n')
+    _git(repo, 'add', '-A')
+    _git(repo, 'commit', '--amend', '--no-edit')
+
+    # Naive re-transfer without resetting devtool first: fails outright,
+    # because devtool is no longer at the state git-am's strip-level
+    # detection expects.
+    with pytest.raises(PatchError):
+        cherry_pick_to_devtool(state)
+
+    # Reset devtool to base, then re-transfer — this is the production fix:
+    # a clean re-application that picks up the amended content.
+    assert reset_devtool_to_base(repo) is True
+    cherry_pick_to_devtool(state)
+    assert _git(repo, 'rev-parse', '--abbrev-ref', 'HEAD') == 'devtool'
+    assert (repo / 'tree.c').read_text() == (
+        '#include <stdint.h>\nsize_t lenn, lenp;\n')
+
+
+def test_reset_to_patched_preserves_recipe_patches(workspace: Path) -> None:
+    """reset_devtool_to_base must reset to devtool-patched, not devtool-base.
+
+    Regression for the real libxml2/CVE-2025-6021 ptest failure: the recipe's
+    SRC_URI patches (e.g. install-tests.patch, which adds the
+    ``install-test-data`` make target that ``do_install_ptest_base`` invokes)
+    live between ``devtool-base`` and ``devtool-patched``. Resetting a
+    build/ptest-error resume all the way back to ``devtool-base`` strips them,
+    and since ``cherry_pick_to_devtool`` only re-applies the CVE commits they
+    never return — the ptest step then dies with
+    "No rule to make target 'install-test-data'". The reset must land on
+    ``devtool-patched`` so those recipe patches survive.
+    """
+    from cve_corrector.cherry_pick import reset_devtool_to_base
+
+    # First transfer: devtool = recipe patches + the CVE series.
+    cherry_pick_to_devtool(_state(workspace))
+    assert (workspace / 'recipe-patch-1.txt').exists()
+    assert (workspace / 'recipe-patch-2.txt').exists()
+    assert (workspace / 'tag.c').read_text() == 'fix1\nfix2\nfix3\n'
+
+    # AI agent amends the CVE-branch tip (build/ptest-fix retry).
+    _git(workspace, 'checkout', '-q', CVE_ID)
+    (workspace / 'tag.c').write_text('fix1\nfix2\nfix3\nfix4\n')
+    _git(workspace, 'add', '-A')
+    _git(workspace, 'commit', '--amend', '--no-edit')
+
+    # The reset must land on devtool-patched (recipe patches preserved), NOT
+    # devtool-base (which would strip them).
+    assert reset_devtool_to_base(workspace) is True
+    assert _git(workspace, 'rev-parse', 'HEAD') == \
+        _git(workspace, 'rev-parse', 'devtool-patched')
+    assert (workspace / 'recipe-patch-1.txt').exists(), \
+        "recipe SRC_URI patch was stripped by the reset"
+    assert (workspace / 'recipe-patch-2.txt').exists(), \
+        "recipe SRC_URI patch was stripped by the reset"
+
+    # Re-transfer lands the amended CVE content on top of the recipe patches.
+    cherry_pick_to_devtool(_state(workspace))
+    assert (workspace / 'recipe-patch-1.txt').exists()
+    assert (workspace / 'recipe-patch-2.txt').exists()
+    assert (workspace / 'tag.c').read_text() == 'fix1\nfix2\nfix3\nfix4\n'
+
+
+def test_reset_falls_back_to_base_without_patched(tmp_path: Path) -> None:
+    """When the recipe has no SRC_URI patches, devtool modify omits
+    devtool-patched and devtool-base already is the fully-patched tree, so the
+    reset falls back to devtool-base."""
+    from cve_corrector.cherry_pick import reset_devtool_to_base
+
+    repo = tmp_path / 'norecipe'
+    repo.mkdir()
+    _git(repo, 'init', '-q', '-b', 'main')
+    _git(repo, 'config', 'user.email', 'test@example.com')
+    _git(repo, 'config', 'user.name', 'Test')
+    _git(repo, 'config', 'commit.gpgsign', 'false')
+    _commit(repo, 'a.c', 'x\n', 'release')
+    _git(repo, 'tag', 'v1')
+    _git(repo, 'checkout', '-q', '--orphan', 'devtool-base')
+    _git(repo, 'rm', '-q', '-rf', '.')
+    _git(repo, 'checkout', 'v1', '--', '.')
+    _git(repo, 'commit', '-m', 'Initial commit from upstream tarball')
+    _git(repo, 'checkout', '-q', '-b', 'devtool')
+    # No devtool-patched tag and no recipe patches: devtool == devtool-base.
+    _commit(repo, 'a.c', 'x\ncve\n', 'transferred CVE fix')
+
+    assert reset_devtool_to_base(repo) is True
+    assert _git(repo, 'rev-parse', 'HEAD') == _git(repo, 'rev-parse', 'devtool-base')

--- a/tests/corrector/test_git_ops.py
+++ b/tests/corrector/test_git_ops.py
@@ -56,6 +56,13 @@ def test_deduce_repo_sourceware():
     assert "sourceware.org/git/binutils-gdb.git" in result
 
 
+def test_deduce_repo_sourceware_gitweb_without_action():
+    """Gitweb URL with ?p= and ;h= but no ;a= must still extract the repo."""
+    url = "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150"
+    result = deduce_repo_from_patches([url])
+    assert result == "https://sourceware.org/git/binutils-gdb.git"
+
+
 def test_deduce_repo_rejects_sourceware_lookalike_host():
     url = "https://sourceware.org.evil.com/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=abc123"
     assert deduce_repo_from_patches([url]) is None

--- a/tests/corrector/test_git_ops.py
+++ b/tests/corrector/test_git_ops.py
@@ -25,6 +25,24 @@ def test_find_exact_tag_empty_list():
     assert find_exact_tag([], "3.7.9") is None
 
 
+def test_find_exact_tag_mixed_separators():
+    """binutils-style: tag uses underscore+dot mix like binutils-2_46.1"""
+    tags = ["binutils-2_46.1", "binutils-2_46", "binutils-2_45"]
+    assert find_exact_tag(tags, "2.46.1") == "binutils-2_46.1"
+
+
+def test_find_exact_tag_all_underscore_binutils():
+    """binutils-style: tag uses all underscores like binutils-2_46_1"""
+    tags = ["binutils-2_46_1", "binutils-2_46", "binutils-2_45"]
+    assert find_exact_tag(tags, "2.46.1") == "binutils-2_46_1"
+
+
+def test_find_exact_tag_does_not_match_branchpoint():
+    """branchpoint tags should not match (they contain extra text)."""
+    tags = ["binutils-2_46-branchpoint", "binutils-2_46"]
+    assert find_exact_tag(tags, "2.46") == "binutils-2_46"
+
+
 # --- deduce_repo_from_patches ---
 
 def test_deduce_repo_github():

--- a/tests/corrector/test_meta_layer_export.py
+++ b/tests/corrector/test_meta_layer_export.py
@@ -137,3 +137,43 @@ class TestWriteCveStatusSignoff:
             write_cve_status(meta, "busybox", "CVE-1", "not applicable",
                              skip_confirm=True, sign_off=True)
         assert captured and "Signed-off-by: A <a@b.c>" in captured[0]
+
+
+# --- _map_cve_status_reason ---
+
+class TestMapCveStatusReason:
+    def setup_method(self):
+        from cve_corrector.meta_layer import _map_cve_status_reason
+        self.map = _map_cve_status_reason
+
+    def test_version_based_reason_maps_to_fixed_version(self):
+        reason = ("Vulnerable code introduced in 2.15, "
+                  "recipe version is 2.42 — not affected")
+        assert self.map(reason) == 'fixed-version'
+
+    def test_introduced_in_keyword(self):
+        assert self.map("introduced in 3.0, too new") == 'fixed-version'
+
+    def test_recipe_version_keyword(self):
+        assert self.map("recipe version predates vuln") == 'fixed-version'
+
+    def test_not_affected_keyword(self):
+        assert self.map("not affected by this issue") == 'fixed-version'
+
+    def test_already_patched(self):
+        assert self.map("already patched in this version") == 'fixed-version'
+
+    def test_backport(self):
+        assert self.map("backport applied") == 'fixed-version'
+
+    def test_platform(self):
+        assert self.map("only affects ARM platform") == 'not-applicable-platform'
+
+    def test_config_disabled(self):
+        assert self.map("feature disabled in config") == 'not-applicable-config'
+
+    def test_cpe_incorrect(self):
+        assert self.map("CPE mismatch, wrong component") == 'cpe-incorrect'
+
+    def test_default_fallback(self):
+        assert self.map("generic reason with no keywords") == 'not-applicable-config'

--- a/tests/corrector/test_patch.py
+++ b/tests/corrector/test_patch.py
@@ -374,6 +374,29 @@ def test_compute_flags_prerequisite_only_fix_tagged(tmp_path):
     assert flags == [False, True]
 
 
+def test_git_commit_subject_missing_workspace_returns_none(tmp_path):
+    """workspace_path may already be deleted by the time this runs (in
+    --bbappend mode, devtool reset removes the whole devtool workspace
+    before update_patches_with_metadata is called). Must return None
+    instead of raising FileNotFoundError from subprocess."""
+    from cve_corrector.patch_ops import _git_commit_subject
+    missing = tmp_path / "does-not-exist"
+    assert not missing.exists()
+    assert _git_commit_subject(missing, "abc123") is None
+
+
+def test_compute_flags_missing_workspace_falls_back_to_all(tmp_path):
+    """End-to-end: when workspace_path doesn't exist (devtool reset already
+    ran), _compute_cve_tag_flags must not crash and must fall back to
+    tagging every patch, same as the "subject not found" fallback."""
+    state = _make_state(tmp_path)
+    assert not state.workspace_path.exists()
+    rels = _write_patches(state.meta_layer,
+                          [("0001.patch", _PREREQ_PATCH), ("0002.patch", _FIX_PATCH)])
+    flags = _compute_cve_tag_flags(state, rels)
+    assert flags == [True, True]
+
+
 def test_compute_flags_no_subject_match_falls_back_to_all(tmp_path):
     """If the fix subject matches no patch, fall back to tagging all so the
     fix never silently loses its CVE tag."""

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -1094,3 +1094,59 @@ class TestProtocolFallback:
         ok = _fetch_remote(tmp_path, "upstream-fix",
                            "https://sourceware.org/git/bzip2")
         assert ok is False
+
+
+class TestPremirrorFallback:
+    """Tests for premirror fallback in setup_upstream_remote."""
+
+    @patch("cve_corrector.workspace.run_cmd")
+    @patch("cve_corrector.workspace.run_cmd_capture")
+    @patch("cve_corrector.workspace.get_recipe_src_uri_git",
+           return_value="https://github.com/libexpat/libexpat")
+    @patch("cve_corrector.workspace.get_upstream_check_uri", return_value=None)
+    def test_premirror_fallback_on_fetch_failure(
+        self, mock_check_uri, mock_src_uri, mock_capture, mock_cmd, tmp_path
+    ):
+        """When premirror fetch fails, falls back to original upstream URL."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+
+        # Mock responses for run_cmd_capture:
+        # 1. git remote -> no upstream
+        mock_capture.return_value = MagicMock(
+            returncode=0, stdout="origin\n", stderr=""
+        )
+
+        # run_cmd calls: premirror fetches fail, original URL fetch succeeds
+        fetch_attempt = [0]
+
+        def run_cmd_effect(cmd, **kwargs):
+            cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+            if 'fetch' in cmd_str:
+                fetch_attempt[0] += 1
+                # First two fetch attempts fail (premirror + alt protocol)
+                # Third fetch attempt succeeds (original URL)
+                if fetch_attempt[0] <= 2:
+                    return 128
+                return 0
+            return 0
+
+        mock_cmd.side_effect = run_cmd_effect
+
+        result = setup_upstream_remote(
+            ws, None, None, "libexpat", [],
+            premirror="https://git.example.com/mirror"
+        )
+
+        # Should succeed via fallback
+        assert result is not None
+
+        # Verify premirror URL was tried first (git remote add with premirror URL)
+        add_calls = [c for c in mock_cmd.call_args_list
+                     if 'remote' in str(c) and 'add' in str(c)]
+        assert any('git.example.com' in str(c) for c in add_calls)
+
+        # Verify fallback to original URL (git remote set-url)
+        set_url_calls = [c for c in mock_cmd.call_args_list
+                         if 'set-url' in str(c)]
+        assert any('github.com/libexpat/libexpat' in str(c) for c in set_url_calls)

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -28,7 +28,11 @@ from cve_corrector.state import (
     PtestError,
     WorkflowState,
 )
-from cve_corrector.ui import print_conflict_instructions, print_edit_instructions
+from cve_corrector.ui import (
+    print_build_failure_instructions,
+    print_conflict_instructions,
+    print_edit_instructions,
+)
 from cve_corrector.workflow import (
     _handle_failed_series,
     _handle_no_clean_apply,
@@ -100,6 +104,18 @@ class TestPrintEditInstructions:
         out = capsys.readouterr().out
         assert "EDIT MODE" in out
         assert "abc123de" in out
+
+
+class TestPrintBuildFailureInstructions:
+    def test_basic(self, capsys, tmp_path):
+        print_build_failure_instructions(tmp_path, "libxml2")
+        out = capsys.readouterr().out
+        assert "BUILD FAILED" in out
+        assert "libxml2" in out
+        assert str(tmp_path) in out
+        assert "devtool build libxml2" in out
+        assert "git commit --amend" in out
+        assert "cve-corrector --continue" in out
 
 
 class TestComparePtestResults:

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -208,7 +208,7 @@ class TestMakeShouldRun:
 
 
 class TestCopyMissingFilesFromDevtool:
-    @patch("cve_corrector.git_ops.run_cmd_capture")
+    @patch("shared.git_runner.run_capture")
     def test_copies_missing(self, mock_run):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="a.c\nb.c\nconfigure\n"),
@@ -222,7 +222,7 @@ class TestCopyMissingFilesFromDevtool:
         ]
         copy_missing_files_from_devtool(Path("/ws"))
 
-    @patch("cve_corrector.git_ops.run_cmd_capture")
+    @patch("shared.git_runner.run_capture")
     def test_nothing_missing(self, mock_run):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="a.c\n"),
@@ -232,7 +232,7 @@ class TestCopyMissingFilesFromDevtool:
         ]
         copy_missing_files_from_devtool(Path("/ws"))
 
-    @patch("cve_corrector.git_ops.run_cmd_capture")
+    @patch("shared.git_runner.run_capture")
     def test_git_error(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1)
         copy_missing_files_from_devtool(Path("/ws"))  # should not crash

--- a/tests/integration/test-cve-metadata-agent.json.bak
+++ b/tests/integration/test-cve-metadata-agent.json.bak
@@ -1,0 +1,9577 @@
+{
+  "CVE-2024-32487": {
+    "name": "less",
+    "version": "643",
+    "cvss3_score": null,
+    "hashes": [
+      "007521ac3c95bc76e3d59c6dbfe75d06c8075c33"
+    ],
+    "hash_details": [
+      {
+        "hash": "007521ac3c95bc76e3d59c6dbfe75d06c8075c33",
+        "url": "https://github.com/gwsw/less/commit/007521ac3c95bc76e3d59c6dbfe75d06c8075c33",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/gwsw/less/commit/007521ac3c95bc76e3d59c6dbfe75d06c8075c33",
+      "https://www.openwall.com/lists/oss-security/2024/04/13/2"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/gwsw/less/commit/007521ac3c95bc76e3d59c6dbfe75d06c8075c33",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/04/13/2",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/04/12/5",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/gwsw/less/commit/007521ac3c95bc76e3d59c6dbfe75d06c8075c33",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/04/13/2",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/04/15/1",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20240605-0009/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2024/05/msg00018.html",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-32487",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-6756-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-3596": {
+    "name": "wpa-supplicant",
+    "version": "2.10",
+    "cvss3_score": null,
+    "hashes": [
+      "f317c5b2668a4de7065df46b31267cd6ff32ddf1",
+      "3a00a6ecc188629b0441fd45ad61ca8986de156e",
+      "4da715d93bf7c9d9b653318ca695bbfa6ceefc1e",
+      "69765bb5cc854f07b5e598d97998b9b06a11e7fa",
+      "5e1a3939e774ee33b8b6a85661ab689c6212c751",
+      "bc4f0a7d9666fa7f834de7a031814f8b24542891",
+      "33ae351097e0f9606b666bbfd05df8eef755e8ef",
+      "828341a7bd69ed4ebfe4e36d8fbfede6c5c50399",
+      "ea6bf44ba891a4d5b7c921c78e6cc697d349515a",
+      "0c101d631253baab62a9ad108138942856312991",
+      "836aeb93d762671703d1482eda236be91fe9fc05",
+      "099c41632dbd6137eb6874a8ecf9eb7dc31232fa",
+      "94553419c36cd76e89bc63927313399f99a91643",
+      "43587a6b378204ef82c8b3578c31d4ef70c00083",
+      "6451425175e988f2d048c26fd5683e4620ed2c0d",
+      "2817b853ddc6b0e12217fc8d3433dc8105d40bc0",
+      "accb06ac915db351c17e02711eaeebb05fda9371",
+      "3f8da1322f1ec0d27e9ed543ba798d12b9bafec7",
+      "bf190f9a0e2d79677edbeb76e5b4ae0a959f5f7f",
+      "0aada8c9b784ae6ee995565ffff4233c4eee1671",
+      "a26afcf05785c3bf699b303dfa30f426ad19a396",
+      "9518f2d25b4eadbc153f03554da21bb2233c8c6b",
+      "55342c7b33772a4fae152b32c4ce01f60a105042",
+      "da643f1edc267ce95260dc36069e6f1a7a4d66f8",
+      "470f56b9d32d0769ff824f6cfa3b058021864b90",
+      "17a8a42ce1dc859ed929de4c6431cb94962f0aab",
+      "7d41c6eabdbe456e33b0b1f08d797abcc845de6e",
+      "7af62285489d346e97390b062f5ce3fb3b14b8a5"
+    ],
+    "hash_details": [
+      {
+        "hash": "f317c5b2668a4de7065df46b31267cd6ff32ddf1",
+        "url": "https://github.com/freeradius/freeradius-server/commit/f317c5b2668a4de7065df46b31267cd6ff32ddf1",
+        "source": "osv"
+      },
+      {
+        "hash": "3a00a6ecc188629b0441fd45ad61ca8986de156e",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/3a00a6ecc188629b0441fd45ad61ca8986de156e",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "4da715d93bf7c9d9b653318ca695bbfa6ceefc1e",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/4da715d93bf7c9d9b653318ca695bbfa6ceefc1e",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "69765bb5cc854f07b5e598d97998b9b06a11e7fa",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/69765bb5cc854f07b5e598d97998b9b06a11e7fa",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "5e1a3939e774ee33b8b6a85661ab689c6212c751",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/5e1a3939e774ee33b8b6a85661ab689c6212c751",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "bc4f0a7d9666fa7f834de7a031814f8b24542891",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/bc4f0a7d9666fa7f834de7a031814f8b24542891",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "33ae351097e0f9606b666bbfd05df8eef755e8ef",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/33ae351097e0f9606b666bbfd05df8eef755e8ef",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "828341a7bd69ed4ebfe4e36d8fbfede6c5c50399",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/828341a7bd69ed4ebfe4e36d8fbfede6c5c50399",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "ea6bf44ba891a4d5b7c921c78e6cc697d349515a",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/ea6bf44ba891a4d5b7c921c78e6cc697d349515a",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "0c101d631253baab62a9ad108138942856312991",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/0c101d631253baab62a9ad108138942856312991",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "836aeb93d762671703d1482eda236be91fe9fc05",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/836aeb93d762671703d1482eda236be91fe9fc05",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "099c41632dbd6137eb6874a8ecf9eb7dc31232fa",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/099c41632dbd6137eb6874a8ecf9eb7dc31232fa",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "94553419c36cd76e89bc63927313399f99a91643",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/94553419c36cd76e89bc63927313399f99a91643",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "43587a6b378204ef82c8b3578c31d4ef70c00083",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/43587a6b378204ef82c8b3578c31d4ef70c00083",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "6451425175e988f2d048c26fd5683e4620ed2c0d",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/6451425175e988f2d048c26fd5683e4620ed2c0d",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "2817b853ddc6b0e12217fc8d3433dc8105d40bc0",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/2817b853ddc6b0e12217fc8d3433dc8105d40bc0",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "accb06ac915db351c17e02711eaeebb05fda9371",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/accb06ac915db351c17e02711eaeebb05fda9371",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "3f8da1322f1ec0d27e9ed543ba798d12b9bafec7",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/3f8da1322f1ec0d27e9ed543ba798d12b9bafec7",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "bf190f9a0e2d79677edbeb76e5b4ae0a959f5f7f",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/bf190f9a0e2d79677edbeb76e5b4ae0a959f5f7f",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "0aada8c9b784ae6ee995565ffff4233c4eee1671",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/0aada8c9b784ae6ee995565ffff4233c4eee1671",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "a26afcf05785c3bf699b303dfa30f426ad19a396",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/a26afcf05785c3bf699b303dfa30f426ad19a396",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "9518f2d25b4eadbc153f03554da21bb2233c8c6b",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/9518f2d25b4eadbc153f03554da21bb2233c8c6b",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "55342c7b33772a4fae152b32c4ce01f60a105042",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/55342c7b33772a4fae152b32c4ce01f60a105042",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "da643f1edc267ce95260dc36069e6f1a7a4d66f8",
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/da643f1edc267ce95260dc36069e6f1a7a4d66f8",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "470f56b9d32d0769ff824f6cfa3b058021864b90",
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/470f56b9d32d0769ff824f6cfa3b058021864b90",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "17a8a42ce1dc859ed929de4c6431cb94962f0aab",
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/17a8a42ce1dc859ed929de4c6431cb94962f0aab",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "7d41c6eabdbe456e33b0b1f08d797abcc845de6e",
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/7d41c6eabdbe456e33b0b1f08d797abcc845de6e",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "7af62285489d346e97390b062f5ce3fb3b14b8a5",
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/7af62285489d346e97390b062f5ce3fb3b14b8a5",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/freeradius/freeradius-server/commit/f317c5b2668a4de7065df46b31267cd6ff32ddf1",
+      "https://github.com/FreeRADIUS/freeradius-server/commits/v3.0.x/?since=2024-07-09&until=2024-07-09",
+      "https://github.com/FreeRADIUS/freeradius-server/commits/v3.2.x/?since=2024-07-09&until=2024-07-09",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/3a00a6ecc188629b0441fd45ad61ca8986de156e",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/4da715d93bf7c9d9b653318ca695bbfa6ceefc1e",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/69765bb5cc854f07b5e598d97998b9b06a11e7fa",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/5e1a3939e774ee33b8b6a85661ab689c6212c751",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/bc4f0a7d9666fa7f834de7a031814f8b24542891",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/33ae351097e0f9606b666bbfd05df8eef755e8ef",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/828341a7bd69ed4ebfe4e36d8fbfede6c5c50399",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/ea6bf44ba891a4d5b7c921c78e6cc697d349515a",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/0c101d631253baab62a9ad108138942856312991",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/836aeb93d762671703d1482eda236be91fe9fc05",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/099c41632dbd6137eb6874a8ecf9eb7dc31232fa",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/94553419c36cd76e89bc63927313399f99a91643",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/43587a6b378204ef82c8b3578c31d4ef70c00083",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/6451425175e988f2d048c26fd5683e4620ed2c0d",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/2817b853ddc6b0e12217fc8d3433dc8105d40bc0",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/accb06ac915db351c17e02711eaeebb05fda9371",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/3f8da1322f1ec0d27e9ed543ba798d12b9bafec7",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/bf190f9a0e2d79677edbeb76e5b4ae0a959f5f7f",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/0aada8c9b784ae6ee995565ffff4233c4eee1671",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/a26afcf05785c3bf699b303dfa30f426ad19a396",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/9518f2d25b4eadbc153f03554da21bb2233c8c6b",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/55342c7b33772a4fae152b32c4ce01f60a105042",
+      "https://github.com/FreeRADIUS/freeradius-server/commit/da643f1edc267ce95260dc36069e6f1a7a4d66f8",
+      "https://github.com/FreeRADIUS/pam_radius/commit/470f56b9d32d0769ff824f6cfa3b058021864b90",
+      "https://github.com/FreeRADIUS/pam_radius/commit/17a8a42ce1dc859ed929de4c6431cb94962f0aab",
+      "https://github.com/FreeRADIUS/pam_radius/commit/7d41c6eabdbe456e33b0b1f08d797abcc845de6e",
+      "https://github.com/FreeRADIUS/pam_radius/commit/7af62285489d346e97390b062f5ce3fb3b14b8a5"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/freeradius/freeradius-server/commit/f317c5b2668a4de7065df46b31267cd6ff32ddf1",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commits/v3.0.x/?since=2024-07-09&until=2024-07-09",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commits/v3.2.x/?since=2024-07-09&until=2024-07-09",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/3a00a6ecc188629b0441fd45ad61ca8986de156e",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/4da715d93bf7c9d9b653318ca695bbfa6ceefc1e",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/69765bb5cc854f07b5e598d97998b9b06a11e7fa",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/5e1a3939e774ee33b8b6a85661ab689c6212c751",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/bc4f0a7d9666fa7f834de7a031814f8b24542891",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/33ae351097e0f9606b666bbfd05df8eef755e8ef",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/828341a7bd69ed4ebfe4e36d8fbfede6c5c50399",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/ea6bf44ba891a4d5b7c921c78e6cc697d349515a",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/0c101d631253baab62a9ad108138942856312991",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/836aeb93d762671703d1482eda236be91fe9fc05",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/099c41632dbd6137eb6874a8ecf9eb7dc31232fa",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/94553419c36cd76e89bc63927313399f99a91643",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/43587a6b378204ef82c8b3578c31d4ef70c00083",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/6451425175e988f2d048c26fd5683e4620ed2c0d",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/2817b853ddc6b0e12217fc8d3433dc8105d40bc0",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/accb06ac915db351c17e02711eaeebb05fda9371",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/3f8da1322f1ec0d27e9ed543ba798d12b9bafec7",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/bf190f9a0e2d79677edbeb76e5b4ae0a959f5f7f",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/0aada8c9b784ae6ee995565ffff4233c4eee1671",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/a26afcf05785c3bf699b303dfa30f426ad19a396",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/9518f2d25b4eadbc153f03554da21bb2233c8c6b",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/55342c7b33772a4fae152b32c4ce01f60a105042",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/freeradius-server/commit/da643f1edc267ce95260dc36069e6f1a7a4d66f8",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/470f56b9d32d0769ff824f6cfa3b058021864b90",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/17a8a42ce1dc859ed929de4c6431cb94962f0aab",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/7d41c6eabdbe456e33b0b1f08d797abcc845de6e",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/FreeRADIUS/pam_radius/commit/7af62285489d346e97390b062f5ce3fb3b14b8a5",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.blastradius.fail/",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://kb.cert.org/vuls/id/456537",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/07/09/4",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://blog.cloudflare.com/radius-udp-vulnerable-md5-attack/",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/proftpd/proftpd/issues/1840",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://datatracker.ietf.org/doc/html/rfc2865",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://datatracker.ietf.org/doc/draft-ietf-radext-deprecating-radius/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://networkradius.com/assets/pdf/radius_and_md5_collisions.pdf",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/09/4",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2024-0014",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-794185.html",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-723487.html",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20240822-0001/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://today.ucsd.edu/story/computer-scientists-discover-vulnerabilities-in-a-popular-security-protocol",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.kb.cert.org/vuls/id/456537",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-364175.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-770770.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-3596",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://kb.cert.org/vince/comm/case/1515/",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7055-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7257-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-39689": {
+    "name": "python3-certifi",
+    "version": "2024.2.2",
+    "cvss3_score": null,
+    "hashes": [
+      "bd8153872e9c6fc98f4023df9c2deaffea2fa463"
+    ],
+    "hash_details": [
+      {
+        "hash": "bd8153872e9c6fc98f4023df9c2deaffea2fa463",
+        "url": "https://github.com/certifi/python-certifi/commit/bd8153872e9c6fc98f4023df9c2deaffea2fa463",
+        "source": "cvelistv5, nvd, osv, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/certifi/python-certifi/commit/bd8153872e9c6fc98f4023df9c2deaffea2fa463"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/certifi/python-certifi/commit/bd8153872e9c6fc98f4023df9c2deaffea2fa463",
+        "source": "osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/certifi/python-certifi/commit/bd8153872e9c6fc98f4023df9c2deaffea2fa463",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20241206-0001/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2024/39xxx/CVE-2024-39689.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-39689",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-39689",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-39894": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "146c420d29d055cc75c8606327a1cf8439fe3a08"
+    ],
+    "hash_details": [
+      {
+        "hash": "146c420d29d055cc75c8606327a1cf8439fe3a08",
+        "url": "https://github.com/openssh/openssh-portable/commit/146c420d29d055cc75c8606327a1cf8439fe3a08",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/146c420d29d055cc75c8606327a1cf8439fe3a08"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/146c420d29d055cc75c8606327a1cf8439fe3a08",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-announce/2024-July/000158.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/07/02/1",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/txt/release-9.8",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/6",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20240712-0004/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/23/4",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/23/6",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/28/3",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://crzphil.github.io/posts/ssh-obfuscation-bypass/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://news.ycombinator.com/item?id=41508530",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2024/Sep/33",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.freebsd.org/security/advisories/FreeBSD-SA-25:01.openssh.asc",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-39894",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-6887-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-46901": {
+    "name": "subversion",
+    "version": "1.14.3",
+    "cvss3_score": null,
+    "hashes": [
+      "c828a37af875249916a452481cae96df83dc67ea"
+    ],
+    "hash_details": [
+      {
+        "hash": "c828a37af875249916a452481cae96df83dc67ea",
+        "url": "https://github.com/apache/subversion/commit/c828a37af875249916a452481cae96df83dc67ea",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/apache/subversion/commit/c828a37af875249916a452481cae96df83dc67ea"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/apache/subversion/commit/c828a37af875249916a452481cae96df83dc67ea",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://subversion.apache.org/security/CVE-2024-46901-advisory.txt",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00023.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-46901",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7818-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7818-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-52532": {
+    "name": "libsoup-2.4",
+    "version": "2.74.3",
+    "cvss3_score": null,
+    "hashes": [
+      "6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+      "29b96fab2512666d7241e46c98cc45b60b795c0c",
+      "4c9e75c6676a37b6485620c332e568e1a3f530ff",
+      "8b46a93bc1cbadb22dcdbb6844d9616723376535"
+    ],
+    "hash_details": [
+      {
+        "hash": "6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "29b96fab2512666d7241e46c98cc45b60b795c0c",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/29b96fab2512666d7241e46c98cc45b60b795c0c",
+        "source": "debian",
+        "type": "test"
+      },
+      {
+        "hash": "4c9e75c6676a37b6485620c332e568e1a3f530ff",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4c9e75c6676a37b6485620c332e568e1a3f530ff",
+        "source": "debian",
+        "type": "test"
+      },
+      {
+        "hash": "8b46a93bc1cbadb22dcdbb6844d9616723376535",
+        "url": "https://github.com/gnome/libsoup/commit/8b46a93bc1cbadb22dcdbb6844d9616723376535",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/29b96fab2512666d7241e46c98cc45b60b795c0c",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4c9e75c6676a37b6485620c332e568e1a3f530ff",
+      "https://github.com/gnome/libsoup/commit/8b46a93bc1cbadb22dcdbb6844d9616723376535"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/29b96fab2512666d7241e46c98cc45b60b795c0c",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4c9e75c6676a37b6485620c332e568e1a3f530ff",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/gnome/libsoup/commit/8b46a93bc1cbadb22dcdbb6844d9616723376535",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/391",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/410",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/29b96fab2512666d7241e46c98cc45b60b795c0c",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4c9e75c6676a37b6485620c332e568e1a3f530ff",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/Teams/Releng/security/-/wikis/home",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2024/12/msg00014.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-52532",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7127-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7126-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7565-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/391",
+        "commits": [
+          "29b96fab2512666d7241e46c98cc45b60b795c0c",
+          "6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be"
+        ]
+      },
+      {
+        "pull_url": "debian:master",
+        "commits": [
+          "6adc0e3eb74c257ed4e2a23eb4b2774fdb0d67be",
+          "29b96fab2512666d7241e46c98cc45b60b795c0c",
+          "4c9e75c6676a37b6485620c332e568e1a3f530ff"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-56738": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "0739d24cd"
+    ],
+    "hash_details": [
+      {
+        "hash": "0739d24cd",
+        "url": "0739d24cd",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://savannah.gnu.org/bugs/?66603",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-56738",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-6345": {
+    "name": "python3-setuptools",
+    "version": "69.1.1",
+    "cvss3_score": null,
+    "hashes": [
+      "88807c7062788254f654ea8c03427adc859321f0"
+    ],
+    "hash_details": [
+      {
+        "hash": "88807c7062788254f654ea8c03427adc859321f0",
+        "url": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0",
+        "source": "debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://huntr.com/bounties/d6362117-ad57-4e83-951f-b8141c6e7ca5",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2024/09/msg00018.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-6345",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7002-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-6387": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "752250caabda3dd24635503c4cd689b32a650794",
+      "81c1099d22b81ebfd20a334ce986c4f753b0db29",
+      "e1f438970e5a337a17070a637c1b9e19697cad09",
+      "6518797401f2f6951e7b3f76d8d9e75876be4361"
+    ],
+    "hash_details": [
+      {
+        "hash": "752250caabda3dd24635503c4cd689b32a650794",
+        "url": "https://github.com/openssh/openssh-portable/commit/752250caabda3dd24635503c4cd689b32a650794",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "81c1099d22b81ebfd20a334ce986c4f753b0db29",
+        "url": "https://github.com/openssh/openssh-portable/commit/81c1099d22b81ebfd20a334ce986c4f753b0db29",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "e1f438970e5a337a17070a637c1b9e19697cad09",
+        "url": "https://github.com/openela-main/openssh/commit/e1f438970e5a337a17070a637c1b9e19697cad09",
+        "source": "nvd, osv"
+      },
+      {
+        "hash": "6518797401f2f6951e7b3f76d8d9e75876be4361",
+        "url": "https://github.com/rapier1/hpn-ssh/commit/6518797401f2f6951e7b3f76d8d9e75876be4361",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/752250caabda3dd24635503c4cd689b32a650794",
+      "https://github.com/openssh/openssh-portable/commit/81c1099d22b81ebfd20a334ce986c4f753b0db29",
+      "https://github.com/openela-main/openssh/commit/e1f438970e5a337a17070a637c1b9e19697cad09",
+      "https://github.com/rapier1/hpn-ssh/commit/6518797401f2f6951e7b3f76d8d9e75876be4361",
+      "http://www.openwall.com/lists/oss-security/2024/07/03/3",
+      "https://news.ycombinator.com/item?id=40843778",
+      "https://lists.mindrot.org/pipermail/openssh-unix-dev/2024-July/041431.html"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/752250caabda3dd24635503c4cd689b32a650794",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/81c1099d22b81ebfd20a334ce986c4f753b0db29",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/openela-main/openssh/commit/e1f438970e5a337a17070a637c1b9e19697cad09",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/rapier1/hpn-ssh/commit/6518797401f2f6951e7b3f76d8d9e75876be4361",
+        "source": "osv"
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/3",
+        "source": "osv"
+      },
+      {
+        "url": "https://news.ycombinator.com/item?id=40843778",
+        "source": "osv"
+      },
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-dev/2024-July/041431.html",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/752250caabda3dd24635503c4cd689b32a650794",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/81c1099d22b81ebfd20a334ce986c4f753b0db29",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-announce/2024-July/000158.html",
+        "sources": [
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2024/07/01/1",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4312",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4340",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4389",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4469",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4474",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4479",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2024:4484",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2024-6387",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2294604",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://santandersecurityresearch.github.io/blog/sshing_the_masses.html",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/txt/release-9.8",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2024/Jul/18",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2024/Jul/19",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2024/Jul/20",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/01/12",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/01/13",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/02/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/11",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/03/5",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/04/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/04/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/08/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/08/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/09/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/09/5",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/10/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/10/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/10/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/10/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/10/6",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/11/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/11/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/23/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/23/6",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/28/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2024/07/28/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://archlinux.org/news/the-sshd-service-needs-to-be-restarted-after-upgrading-to-openssh-98p1/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://arstechnica.com/security/2024/07/regresshion-vulnerability-in-openssh-gives-attackers-root-on-linux/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://blog.qualys.com/vulnerabilities-threat-research/2024/07/01/regresshion-remote-unauthenticated-code-execution-vulnerability-in-openssh-server",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://explore.alas.aws.amazon.com/CVE-2024-6387.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://forum.vmssoftware.com/viewtopic.php?f=8&t=9132",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ftp.netbsd.org/pub/NetBSD/security/advisories/NetBSD-SA2024-002.txt.asc",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/AlmaLinux/updates/issues/629",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/Azure/AKS/issues/4379",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/PowerShell/Win32-OpenSSH/discussions/2248",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/PowerShell/Win32-OpenSSH/issues/2249",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/microsoft/azurelinux/issues/9555",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/openela-main/openssh/commit/e1f438970e5a337a17070a637c1b9e19697cad09",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/oracle/oracle-linux/issues/149",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/rapier1/hpn-ssh/issues/87",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/zgzhang/cve-2024-6387-poc",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.almalinux.org/archives/list/announce@lists.almalinux.org/thread/23BF5BMGFVEVUI2WNVAGMLKT557EU7VY/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-dev/2024-July/041431.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://news.ycombinator.com/item?id=40843778",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://packetstorm.news/files/id/190587/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2024-0010",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security-tracker.debian.org/tracker/CVE-2024-6387",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20240701-0001/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://sig-security.rocky.page/issues/CVE-2024-6387/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://stackdiary.com/openssh-race-condition-in-sshd-allows-remote-code-execution/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://support.apple.com/kb/HT214118",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://support.apple.com/kb/HT214119",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://support.apple.com/kb/HT214120",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/CVE-2024-6387",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-6859-1",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.akamai.com/blog/security-research/2024-openssh-vulnerability-regression-what-to-know-and-do",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.arista.com/en/support/advisories-notices/security-advisory/19904-security-advisory-0100",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.exploit-db.com/exploits/52269",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.freebsd.org/security/advisories/FreeBSD-SA-24:04.openssh.asc",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.splunk.com/en_us/blog/security/cve-2024-6387-regresshion-vulnerability.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.suse.com/security/cve/CVE-2024-6387.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.theregister.com/2024/07/01/regresshion_openssh/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/regresshion-an-openssh-regression-error-cve-2024-6387",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-082556.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-446545.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-6387",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/blog/ubuntu-regresshion-security-fix",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2024-7537": {
+    "name": "ofono",
+    "version": "2.4",
+    "cvss3_score": null,
+    "hashes": [
+      "e6d8d526d5077c0b6ab459efeb6b882c28e0fdeb"
+    ],
+    "hash_details": [
+      {
+        "hash": "e6d8d526d5077c0b6ab459efeb6b882c28e0fdeb",
+        "url": "https://web.git.kernel.org/pub/scm/network/ofono/ofono.git/commit/?id=e6d8d526d5077c0b6ab459efeb6b882c28e0fdeb",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://www.zerodayinitiative.com/advisories/ZDI-24-1077/",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lore.kernel.org/ofono/BYAPR01MB3830B08E8DB1D76A9A85B07680D62@BYAPR01MB3830.prod.exchangelabs.com/T/#u",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2024-7537",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-0677": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10"
+    ],
+    "hash_details": [
+      {
+        "hash": "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "url": "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00024.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/3",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:16154",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:6990",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-0677",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346116",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-0677",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-0684": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10"
+    ],
+    "hash_details": [
+      {
+        "hash": "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "url": "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00024.html",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/3",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-0684",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346119",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-0684",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-0685": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10"
+    ],
+    "hash_details": [
+      {
+        "hash": "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "url": "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00024.html",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/3",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-0685",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346120",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-0685",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-0686": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10"
+    ],
+    "hash_details": [
+      {
+        "hash": "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "url": "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00024.html",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/3",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-0686",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346121",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-0686",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-0689": {
+    "name": "grub",
+    "version": "2.12",
+    "cvss3_score": null,
+    "hashes": [
+      "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10"
+    ],
+    "hash_details": [
+      {
+        "hash": "47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "url": "https://git.savannah.gnu.org/cgit/grub.git/commit/?id=47b2dfc7953f70f98ddf35dfdd6e7f4f20283b10",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/grub-devel/2025-02/msg00024.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/3",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-0689",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346122",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-0689",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-1153": {
+    "name": "binutils",
+    "version": "2.42",
+    "cvss3_score": null,
+    "hashes": [
+      "8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150"
+    ],
+    "hash_details": [
+      {
+        "hash": "8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+      "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150"
+    ],
+    "patch_details": [
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+        "source": "cvelistv5, osv"
+      },
+      {
+        "url": "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32603",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=8d97c1a53f3dc9fd8e1ccdb039b8a33d50133150",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?id.295057",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?ctiid.295057",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?submit.489991",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.gnu.org/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250404-0005/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-1153",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7423-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7423-2",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7899-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-1176": {
+    "name": "binutils",
+    "version": "2.42",
+    "cvss3_score": null,
+    "hashes": [
+      "f9978defb6fab0bd8583942d97c112b0932ac814"
+    ],
+    "hash_details": [
+      {
+        "hash": "f9978defb6fab0bd8583942d97c112b0932ac814",
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=f9978defb6fab0bd8583942d97c112b0932ac814",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=f9978defb6fab0bd8583942d97c112b0932ac814",
+      "https://sourceware.org/bugzilla/show_bug.cgi?id=32636",
+      "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=f9978defb6fab0bd8583942d97c112b0932ac814"
+    ],
+    "patch_details": [
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=f9978defb6fab0bd8583942d97c112b0932ac814",
+        "source": "cvelistv5, osv"
+      },
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32636",
+        "source": "osv"
+      },
+      {
+        "url": "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=f9978defb6fab0bd8583942d97c112b0932ac814",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32636",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=f9978defb6fab0bd8583942d97c112b0932ac814",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?id.295079",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?ctiid.295079",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?submit.495329",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/bugzilla/attachment.cgi?id=15913",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.gnu.org/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250411-0007/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-1176",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7423-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7423-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-1179": {
+    "name": "binutils",
+    "version": "2.42",
+    "cvss3_score": null,
+    "hashes": [
+      "76eab8f47a743bde86be410bce8fd8382eaea6c2"
+    ],
+    "hash_details": [
+      {
+        "hash": "76eab8f47a743bde86be410bce8fd8382eaea6c2",
+        "url": "https://github.com/bminor/binutils-gdb/commit/76eab8f47a743bde86be410bce8fd8382eaea6c2",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://sourceware.org/bugzilla/show_bug.cgi?id=32640#c1",
+      "https://github.com/bminor/binutils-gdb/commit/76eab8f47a743bde86be410bce8fd8382eaea6c2"
+    ],
+    "patch_details": [
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32640#c1",
+        "source": "cvelistv5"
+      },
+      {
+        "url": "https://github.com/bminor/binutils-gdb/commit/76eab8f47a743bde86be410bce8fd8382eaea6c2",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32640",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?id.295082",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?ctiid.295082",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?submit.495376",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/bugzilla/attachment.cgi?id=15915",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32640#c1",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.gnu.org/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-1179",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-1181": {
+    "name": "binutils",
+    "version": "2.42",
+    "cvss3_score": null,
+    "hashes": [
+      "931494c9a89558acb36a03a340c01726545eef24"
+    ],
+    "hash_details": [
+      {
+        "hash": "931494c9a89558acb36a03a340c01726545eef24",
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=931494c9a89558acb36a03a340c01726545eef24",
+        "source": "cvelistv5, debian, nvd, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=931494c9a89558acb36a03a340c01726545eef24"
+    ],
+    "patch_details": [
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=931494c9a89558acb36a03a340c01726545eef24",
+        "source": "cvelistv5, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=32643",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=931494c9a89558acb36a03a340c01726545eef24",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?id.295084",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?ctiid.295084",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://vuldb.com/?submit.495402",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://sourceware.org/bugzilla/attachment.cgi?id=15918",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.gnu.org/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250425-0007/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-1181",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7423-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7899-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-11961": {
+    "name": "libpcap",
+    "version": "1.10.4",
+    "cvss3_score": null,
+    "hashes": [
+      "b2d2f9a9a0581c40780bde509f7cc715920f1c02"
+    ],
+    "hash_details": [
+      {
+        "hash": "b2d2f9a9a0581c40780bde509f7cc715920f1c02",
+        "url": "https://github.com/the-tcpdump-group/libpcap/commit/b2d2f9a9a0581c40780bde509f7cc715920f1c02",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/the-tcpdump-group/libpcap/commit/b2d2f9a9a0581c40780bde509f7cc715920f1c02"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/the-tcpdump-group/libpcap/commit/b2d2f9a9a0581c40780bde509f7cc715920f1c02",
+        "source": "cvelistv5, debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/the-tcpdump-group/libpcap/commit/b2d2f9a9a0581c40780bde509f7cc715920f1c02",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-11961",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-14523": {
+    "name": "libsoup",
+    "version": "3.4.4",
+    "cvss3_score": null,
+    "hashes": [
+      "aecd8daadc110f8561fb2d6b2806a4cacf2e4c85"
+    ],
+    "hash_details": [
+      {
+        "hash": "aecd8daadc110f8561fb2d6b2806a4cacf2e4c85",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/aecd8daadc110f8561fb2d6b2806a4cacf2e4c85",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/aecd8daadc110f8561fb2d6b2806a4cacf2e4c85"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/aecd8daadc110f8561fb2d6b2806a4cacf2e4c85",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/472",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0421",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0422",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0423",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0836",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0867",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0868",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0905",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0906",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0907",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0908",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0909",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0911",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:0925",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:1509",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:1569",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:1570",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:1571",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:1572",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-14523",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2421349",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-14523",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/472",
+        "commits": [
+          "aecd8daadc110f8561fb2d6b2806a4cacf2e4c85",
+          "2d54bf7faa812cdbbe7e323205416c7dc9ad52a1"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-22871": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+      "15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931"
+    ],
+    "hash_details": [
+      {
+        "hash": "ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+        "url": "https://github.com/golang/go/commit/ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931",
+        "url": "https://github.com/golang/go/commit/15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931",
+        "source": "debian",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+      "https://github.com/golang/go/commit/15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931",
+        "source": "debian"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk/m/cs_6qIK5BAAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/71988",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/ac1f5aa3d62efe21e65ce4dc30e6996d59acfbd0",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/15e01a2e43ecb8c7e15ff7e9d62fe3f10dcac931",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/652998",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/71988",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-3563",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/04/04/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-783943.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-22871",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-24857": {
+    "name": "u-boot-tools",
+    "version": "1_2024.01",
+    "cvss3_score": null,
+    "hashes": [
+      "c253573f3e269fd9a24ee6684d87dd91106018a5"
+    ],
+    "hash_details": [
+      {
+        "hash": "c253573f3e269fd9a24ee6684d87dd91106018a5",
+        "url": "https://github.com/u-boot/u-boot/commit/c253573f3e269fd9a24ee6684d87dd91106018a5",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/u-boot/u-boot/commit/c253573f3e269fd9a24ee6684d87dd91106018a5"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/u-boot/u-boot/commit/c253573f3e269fd9a24ee6684d87dd91106018a5",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.cisa.gov/news-events/ics-advisories/icsa-25-343-01",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-24857",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-26465": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "5e39a49930d885aac9c76af3129332b6e772cd75",
+      "0832aac79517611dd4de93ad0a83577994d9c907"
+    ],
+    "hash_details": [
+      {
+        "hash": "5e39a49930d885aac9c76af3129332b6e772cd75",
+        "url": "https://github.com/openssh/openssh-portable/commit/5e39a49930d885aac9c76af3129332b6e772cd75",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "0832aac79517611dd4de93ad0a83577994d9c907",
+        "url": "https://github.com/openssh/openssh-portable/commit/0832aac79517611dd4de93ad0a83577994d9c907",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/5e39a49930d885aac9c76af3129332b6e772cd75",
+      "https://github.com/openssh/openssh-portable/commit/0832aac79517611dd4de93ad0a83577994d9c907",
+      "https://ftp.openbsd.org/pub/OpenBSD/patches/7.6/common/008_ssh.patch.sig"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/5e39a49930d885aac9c76af3129332b6e772cd75",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/0832aac79517611dd4de93ad0a83577994d9c907",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://ftp.openbsd.org/pub/OpenBSD/patches/7.6/common/008_ssh.patch.sig",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openssh.com/releasenotes.html#9.9p2",
+        "sources": [
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.qualys.com/2025/02/18/openssh-mitm-dos.txt",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/5e39a49930d885aac9c76af3129332b6e772cd75",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/0832aac79517611dd4de93ad0a83577994d9c907",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:16823",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:3837",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:6993",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8385",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-26465",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/solutions/7109879",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2344780",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://seclists.org/oss-sec/2025/q1/144",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/Feb/18",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/May/7",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/May/8",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://blog.qualys.com/vulnerabilities-threat-research/2025/02/18/qualys-tru-discovers-two-vulnerabilities-in-openssh-cve-2025-26465-cve-2025-26466",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.suse.com/show_bug.cgi?id=1237040",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ftp.openbsd.org/pub/OpenBSD/patches/7.6/common/008_ssh.patch.sig",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/02/msg00020.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-announce/2025-February/000161.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security-tracker.debian.org/tracker/CVE-2025-26465",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250228-0003/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/CVE-2025-26465",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.theregister.com/2025/02/18/openssh_vulnerabilities_mitm_dos/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-26465-detect-vulnerable-openssh",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-26465-mitigate-vulnerable-openssh",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-082556.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-26465",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7270-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7270-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-26466": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+      "6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2"
+    ],
+    "hash_details": [
+      {
+        "hash": "dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+        "url": "https://github.com/openssh/openssh-portable/commit/dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2",
+        "url": "https://github.com/openssh/openssh-portable/commit/6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+      "https://github.com/openssh/openssh-portable/commit/6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2",
+        "source": "debian, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openssh.com/releasenotes.html#9.9p2",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.qualys.com/2025/02/18/openssh-mitm-dos.txt",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/dce6d80d2ed3cad2c516082682d5f6ca877ef714",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/6ce00f0c2ecbb9f75023dbe627ee6460bcec78c2",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-26466",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2345043",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://seclists.org/oss-sec/2025/q1/144",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/Feb/18",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/May/7",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://seclists.org/fulldisclosure/2025/May/8",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://bugzilla.suse.com/show_bug.cgi?id=1237041",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security-tracker.debian.org/tracker/CVE-2025-26466",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250228-0002/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/CVE-2025-26466",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/02/18/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-26466-detection-script-memory-consumption-vulnerability-in-openssh",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-26466-mitigation-script-memory-consumption-vulnerability-in-openssh",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-26466",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7270-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-32049": {
+    "name": "libsoup",
+    "version": "3.4.4",
+    "cvss3_score": null,
+    "hashes": [
+      "db87805ab565d67533dfed2cb409dbfd63c7fdce",
+      "4904a46a2d9a014efa6be01a186ac353dbf5047b",
+      "2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+      "4d00b45b7eebdcfa0706b58e34c40b8a0a16015b"
+    ],
+    "hash_details": [
+      {
+        "hash": "db87805ab565d67533dfed2cb409dbfd63c7fdce",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/db87805ab565d67533dfed2cb409dbfd63c7fdce",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "4904a46a2d9a014efa6be01a186ac353dbf5047b",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4904a46a2d9a014efa6be01a186ac353dbf5047b",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "4d00b45b7eebdcfa0706b58e34c40b8a0a16015b",
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4d00b45b7eebdcfa0706b58e34c40b8a0a16015b",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/408",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/db87805ab565d67533dfed2cb409dbfd63c7fdce",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4904a46a2d9a014efa6be01a186ac353dbf5047b",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+      "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4d00b45b7eebdcfa0706b58e34c40b8a0a16015b"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/408",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/db87805ab565d67533dfed2cb409dbfd63c7fdce",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4904a46a2d9a014efa6be01a186ac353dbf5047b",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/commit/4d00b45b7eebdcfa0706b58e34c40b8a0a16015b",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/390",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/408",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/408#note_2394070",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:21657",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8126",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8128",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8132",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8139",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8140",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8252",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8480",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8481",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8482",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:8663",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:9179",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-32049",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357066",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-32049",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/390",
+        "commits": [
+          "4d00b45b7eebdcfa0706b58e34c40b8a0a16015b",
+          "2df34d9544cabdbfdedd3b36f098cf69233b1df7",
+          "4904a46a2d9a014efa6be01a186ac353dbf5047b",
+          "db87805ab565d67533dfed2cb409dbfd63c7fdce"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-32728": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "fc86875e6acb36401dfc1dfb6b628a9d1460f367"
+    ],
+    "hash_details": [
+      {
+        "hash": "fc86875e6acb36401dfc1dfb6b628a9d1460f367",
+        "url": "https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367",
+        "source": "debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://lists.mindrot.org/pipermail/openssh-unix-dev/2025-April/041879.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/txt/release-10.0",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ftp.openbsd.org/pub/OpenBSD/patches/7.6/common/013_ssh.patch.sig",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/txt/release-7.4",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/05/msg00008.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20250425-0002/",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-32728",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7457-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-4373": {
+    "name": "glib-2.0",
+    "version": "1_2.78.6",
+    "cvss3_score": null,
+    "hashes": [
+      "cc647f9e46d55509a93498af19659baf9c80f2e3",
+      "089070bf53807ad2a81bc0b014ad19016fada2a5"
+    ],
+    "hash_details": [
+      {
+        "hash": "cc647f9e46d55509a93498af19659baf9c80f2e3",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588/diffs?commit_id=cc647f9e46d55509a93498af19659baf9c80f2e3",
+        "source": "ubuntu"
+      },
+      {
+        "hash": "089070bf53807ad2a81bc0b014ad19016fada2a5",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4592/diffs?commit_id=089070bf53807ad2a81bc0b014ad19016fada2a5",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588/diffs?commit_id=cc647f9e46d55509a93498af19659baf9c80f2e3",
+      "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4592/diffs?commit_id=089070bf53807ad2a81bc0b014ad19016fada2a5"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588/diffs?commit_id=cc647f9e46d55509a93498af19659baf9c80f2e3",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4592/diffs?commit_id=089070bf53807ad2a81bc0b014ad19016fada2a5",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/issues/3677",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4588",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4592",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:10855",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11140",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11327",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11373",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11374",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11662",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12275",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13335",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14988",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14989",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14990",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14991",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-4373",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2364265",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-082556.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-089022.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-4373",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7532-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-4674": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+      "e9d2c032b14c17083be0f8f0c822565199d2994f",
+      "0a75dd7c2dcf7057ef200290d8f5c4c1514dba80",
+      "9d828e80fa1f3cc52de60428cae446b35b576de8"
+    ],
+    "hash_details": [
+      {
+        "hash": "825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+        "url": "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "e9d2c032b14c17083be0f8f0c822565199d2994f",
+        "url": "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "0a75dd7c2dcf7057ef200290d8f5c4c1514dba80",
+        "url": "https://github.com/golang/go/commit/0a75dd7c2dcf7057ef200290d8f5c4c1514dba80",
+        "source": "osv"
+      },
+      {
+        "hash": "9d828e80fa1f3cc52de60428cae446b35b576de8",
+        "url": "https://github.com/golang/go/commit/9d828e80fa1f3cc52de60428cae446b35b576de8",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+      "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f",
+      "https://github.com/golang/go/commit/0a75dd7c2dcf7057ef200290d8f5c4c1514dba80",
+      "https://github.com/golang/go/commit/9d828e80fa1f3cc52de60428cae446b35b576de8",
+      "https://go.dev/cl/686515",
+      "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a (go1.24.5)",
+      "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f (go1.23.11)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/0a75dd7c2dcf7057ef200290d8f5c4c1514dba80",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/9d828e80fa1f3cc52de60428cae446b35b576de8",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/686515",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a (go1.24.5)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f (go1.23.11)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/gTNJnDXmn34",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/74380",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/686515",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/74380",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-3828",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/07/08/5",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-4674",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/825eeee3f789a11231ce23a4836c74ec5e34bf2a (go1.24.5)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e9d2c032b14c17083be0f8f0c822565199d2994f (go1.23.11)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-47183": {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+      "d76cae74dad89994bfcdad83da6ef1ad69074332",
+      "100c21e1faf68efe7f3830b6e9f856760697ab48"
+    ],
+    "hash_details": [
+      {
+        "hash": "48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "d76cae74dad89994bfcdad83da6ef1ad69074332",
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/d76cae74dad89994bfcdad83da6ef1ad69074332",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "100c21e1faf68efe7f3830b6e9f856760697ab48",
+        "url": "https://github.com/gstreamer/gstreamer/commit/100c21e1faf68efe7f3830b6e9f856760697ab48",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+      "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/d76cae74dad89994bfcdad83da6ef1ad69074332",
+      "https://github.com/gstreamer/gstreamer/commit/100c21e1faf68efe7f3830b6e9f856760697ab48"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/d76cae74dad89994bfcdad83da6ef1ad69074332",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://github.com/gstreamer/gstreamer/commit/100c21e1faf68efe7f3830b6e9f856760697ab48",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/atredispartners/advisories/blob/master/2025/ATREDIS-2025-0003.md",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gstreamer.freedesktop.org/security/sa-2025-0005.html",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/48bf6a92d75051be7e5ffb66fcd1a49de74fe865",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/d76cae74dad89994bfcdad83da6ef1ad69074332",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gstreamer.freedesktop.org/security/",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-47183",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7717-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-47203": {
+    "name": "dropbear",
+    "version": "2022.83",
+    "cvss3_score": null,
+    "hashes": [
+      "e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+      "887241694277b3816da5d174932c10546ea9d2c5"
+    ],
+    "hash_details": [
+      {
+        "hash": "e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+        "url": "https://github.com/mkj/dropbear/commit/e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "887241694277b3816da5d174932c10546ea9d2c5",
+        "url": "https://github.com/mkj/dropbear/commit/887241694277b3816da5d174932c10546ea9d2c5",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/mkj/dropbear/commit/e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+      "https://github.com/mkj/dropbear/commit/887241694277b3816da5d174932c10546ea9d2c5"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/mkj/dropbear/commit/e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/mkj/dropbear/commit/887241694277b3816da5d174932c10546ea9d2c5",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/mkj/dropbear/commit/e5a0ef27c227f7ae69d9a9fec98a056494409b9b",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/mkj/dropbear/blob/master/src/cli-main.c",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/mkj/dropbear/blob/master/CHANGES",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/09/4",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/12/6",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/13/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/13/10",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/13/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/05/msg00020.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-47203",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-47273": {
+    "name": "python3-setuptools",
+    "version": "69.1.1",
+    "cvss3_score": null,
+    "hashes": [
+      "250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+      "8e4868a036b7fae3208d16cb4e5fe6d63c3752df"
+    ],
+    "hash_details": [
+      {
+        "hash": "250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+        "url": "https://github.com/pypa/setuptools/commit/250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "8e4868a036b7fae3208d16cb4e5fe6d63c3752df",
+        "url": "https://github.com/pypa/setuptools/commit/8e4868a036b7fae3208d16cb4e5fe6d63c3752df",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pypa/setuptools/commit/250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+      "https://github.com/pypa/setuptools/commit/8e4868a036b7fae3208d16cb4e5fe6d63c3752df"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pypa/setuptools/commit/250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pypa/setuptools/commit/8e4868a036b7fae3208d16cb4e5fe6d63c3752df",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pypa/setuptools/security/advisories/GHSA-5rjg-fvgr-3xxf",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/setuptools/issues/4946",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/setuptools/commit/250a6d17978f9f6ac3ac887091f2d32886fbbb0b",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/setuptools/blob/6ead555c5fb29bc57fe6105b1bffc163f56fd558/setuptools/package_index.py#L810C1-L825C88",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/05/msg00035.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/47xxx/CVE-2025-47273.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-47273",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-47273",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7544-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8010-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-47907": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "83b4a5db240960720e51b7d5a6da1f399bd868ee",
+      "8a924caaf348fdc366bab906424616b2974ad4e9",
+      "dd8b7ad9268c2fbde675132a41b4e4da02eef94d",
+      "7f36edc26d4e3becb6d9c9008ff00f260bb19055"
+    ],
+    "hash_details": [
+      {
+        "hash": "83b4a5db240960720e51b7d5a6da1f399bd868ee",
+        "url": "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "8a924caaf348fdc366bab906424616b2974ad4e9",
+        "url": "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "dd8b7ad9268c2fbde675132a41b4e4da02eef94d",
+        "url": "https://github.com/golang/go/commit/dd8b7ad9268c2fbde675132a41b4e4da02eef94d",
+        "source": "osv"
+      },
+      {
+        "hash": "7f36edc26d4e3becb6d9c9008ff00f260bb19055",
+        "url": "https://github.com/golang/go/commit/7f36edc26d4e3becb6d9c9008ff00f260bb19055",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee",
+      "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9",
+      "https://github.com/golang/go/commit/dd8b7ad9268c2fbde675132a41b4e4da02eef94d",
+      "https://github.com/golang/go/commit/7f36edc26d4e3becb6d9c9008ff00f260bb19055",
+      "https://go.dev/cl/693735",
+      "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee (go1.24.6)",
+      "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9 (go1.23.12)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/dd8b7ad9268c2fbde675132a41b4e4da02eef94d",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/7f36edc26d4e3becb6d9c9008ff00f260bb19055",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/693735",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee (go1.24.6)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9 (go1.23.12)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/x5MKroML2yM/m/5_v-oMjUAgAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/74831",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/693735",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/74831",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/x5MKroML2yM",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-3849",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/08/06/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-47907",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/83b4a5db240960720e51b7d5a6da1f399bd868ee (go1.24.6)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/8a924caaf348fdc366bab906424616b2974ad4e9 (go1.23.12)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-47912": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "9fd3ac8a10272afd90312fef5d379de7d688a58e",
+      "d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+      "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd"
+    ],
+    "hash_details": [
+      {
+        "hash": "9fd3ac8a10272afd90312fef5d379de7d688a58e",
+        "url": "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+        "url": "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "hash": "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e",
+      "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+      "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+      "https://go.dev/cl/709857",
+      "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e (go1.25.2)",
+      "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea (go1.24.8)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/709857",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e (go1.25.2)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea (go1.24.8)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/75678",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/75678",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/709857",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-4010",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/08/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-47912",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/9fd3ac8a10272afd90312fef5d379de7d688a58e (go1.25.2)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/d6d2f7bf76718f1db05461cd912ae5e30d7b77ea (go1.24.8)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-50181": {
+    "name": "python3-urllib3",
+    "version": "2.2.2",
+    "cvss3_score": null,
+    "hashes": [
+      "f05b1329126d5be6de501f9d1e3e36738bc08857",
+      "aaab4eccc10c965897540b21e15f11859d0b62e7"
+    ],
+    "hash_details": [
+      {
+        "hash": "f05b1329126d5be6de501f9d1e3e36738bc08857",
+        "url": "https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857",
+        "source": "cvelistv5, debian, nvd, osv",
+        "type": null
+      },
+      {
+        "hash": "aaab4eccc10c965897540b21e15f11859d0b62e7",
+        "url": "https://github.com/urllib3/urllib3/commit/aaab4eccc10c965897540b21e15f11859d0b62e7",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857",
+      "https://github.com/urllib3/urllib3/commit/aaab4eccc10c965897540b21e15f11859d0b62e7"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/aaab4eccc10c965897540b21e15f11859d0b62e7",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/urllib3/urllib3/security/advisories/GHSA-pq67-6m6q-mj2v",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/releases/tag/2.5.0",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/50xxx/CVE-2025-50181.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-50181",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-50181",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7599-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7599-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-5278": {
+    "name": "coreutils",
+    "version": "9.4",
+    "cvss3_score": null,
+    "hashes": [
+      "8c9602e3a145e9596dc1a63c6ed67865814b6633"
+    ],
+    "hash_details": [
+      {
+        "hash": "8c9602e3a145e9596dc1a63c6ed67865814b6633",
+        "url": "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=8c9602e3a145e9596dc1a63c6ed67865814b6633",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=8c9602e3a145e9596dc1a63c6ed67865814b6633",
+      "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/8c9602e3a145e9596dc1a63c6ed67865814b6633"
+    ],
+    "patch_details": [
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=8c9602e3a145e9596dc1a63c6ed67865814b6633",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/8c9602e3a145e9596dc1a63c6ed67865814b6633",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368764",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.gnu.org/archive/html/bug-coreutils/2025-05/msg00036.html",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.gnu.org/archive/html/bug-coreutils/2025-05/msg00040.html",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=8c9602e3a145e9596dc1a63c6ed67865814b6633",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/05/27/2",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=78507",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-5278",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/27/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/29/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/05/29/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?id=8c9602e3a145e9596dc1a63c6ed67865814b6633#n14",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://security-tracker.debian.org/tracker/CVE-2025-5278",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-5278",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-58185": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "e0f655bf3f96410f90756f49532bc6a1851855ca",
+      "5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+      "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd"
+    ],
+    "hash_details": [
+      {
+        "hash": "e0f655bf3f96410f90756f49532bc6a1851855ca",
+        "url": "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+        "url": "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "hash": "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca",
+      "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+      "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+      "https://go.dev/cl/709856",
+      "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca (go1.25.2)",
+      "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1 (go1.24.8)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/709856",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca (go1.25.2)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1 (go1.24.8)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/75671",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/75671",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/709856",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-4011",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/08/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-58185",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/e0f655bf3f96410f90756f49532bc6a1851855ca (go1.25.2)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/5c3d61c886f7ecfce9a6d6d3c97e6d5a8afb17d1 (go1.24.8)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-58187": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+      "f334417e71f8b078ad64035bddb6df7f8910da6c",
+      "8e10ef451a1b6a1e8861ced1154e1c3265bfa01b",
+      "28622c19591d95c9a83f706f2ed1b303d58da85f"
+    ],
+    "hash_details": [
+      {
+        "hash": "f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+        "url": "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "f334417e71f8b078ad64035bddb6df7f8910da6c",
+        "url": "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "8e10ef451a1b6a1e8861ced1154e1c3265bfa01b",
+        "url": "https://github.com/golang/go/commit/8e10ef451a1b6a1e8861ced1154e1c3265bfa01b",
+        "source": "osv"
+      },
+      {
+        "hash": "28622c19591d95c9a83f706f2ed1b303d58da85f",
+        "url": "https://github.com/golang/go/commit/28622c19591d95c9a83f706f2ed1b303d58da85f",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+      "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c",
+      "https://github.com/golang/go/commit/8e10ef451a1b6a1e8861ced1154e1c3265bfa01b",
+      "https://github.com/golang/go/commit/28622c19591d95c9a83f706f2ed1b303d58da85f",
+      "https://go.dev/cl/709854",
+      "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5 (go1.25.2)",
+      "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c (go1.24.8)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/8e10ef451a1b6a1e8861ced1154e1c3265bfa01b",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/28622c19591d95c9a83f706f2ed1b303d58da85f",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/709854",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5 (go1.25.2)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c (go1.24.8)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/75681",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/75681",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/709854",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-4007",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/08/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-58187",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f0c69db15aae2eb10bddd8b6745dff5c2932e8f5 (go1.25.2)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f334417e71f8b078ad64035bddb6df7f8910da6c (go1.24.8)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-58188": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "930ce220d052d632f0d84df5850c812a77b70175",
+      "f9f198ab05e3282cbf6b13251d47d9141981e401",
+      "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd"
+    ],
+    "hash_details": [
+      {
+        "hash": "930ce220d052d632f0d84df5850c812a77b70175",
+        "url": "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "f9f198ab05e3282cbf6b13251d47d9141981e401",
+        "url": "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "hash": "bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175",
+      "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401",
+      "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+      "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+      "https://go.dev/cl/709853",
+      "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175 (go1.25.2)",
+      "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401 (go1.24.8)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/3a666bca00d7fb30d55e252131ea2cf2006dc3a3",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/bed6c81c2dceeb19c7f9e46fc173671abcda7cfd",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/709853",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175 (go1.25.2)",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401 (go1.24.8)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/75675",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/709853",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/75675",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-4013",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/08/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-58188",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/930ce220d052d632f0d84df5850c812a77b70175 (go1.25.2)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f9f198ab05e3282cbf6b13251d47d9141981e401 (go1.24.8)",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-58364": {
+    "name": "cups",
+    "version": "2.4.11",
+    "cvss3_score": null,
+    "hashes": [
+      "e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+      "eee59dd0b55a0b11b80bda6ca437d60fee5faa09"
+    ],
+    "hash_details": [
+      {
+        "hash": "e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+        "url": "https://github.com/OpenPrinting/cups/commit/e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+        "source": "cvelistv5, debian, nvd, osv",
+        "type": "fix"
+      },
+      {
+        "hash": "eee59dd0b55a0b11b80bda6ca437d60fee5faa09",
+        "url": "https://github.com/openprinting/cups/commit/eee59dd0b55a0b11b80bda6ca437d60fee5faa09",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/OpenPrinting/cups/commit/e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+      "https://github.com/openprinting/cups/commit/eee59dd0b55a0b11b80bda6ca437d60fee5faa09"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/openprinting/cups/commit/eee59dd0b55a0b11b80bda6ca437d60fee5faa09",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/09/11/2",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/e58cba9d6fceed4242980e51dbd1302cf638ab1d",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/security/advisories/GHSA-7qx3-r744-6qv4",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/09/11/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/09/msg00013.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/58xxx/CVE-2025-58364.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-58364",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-58364",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7745-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-6021": {
+    "name": "libxml2",
+    "version": "2.12.10",
+    "cvss3_score": null,
+    "hashes": [
+      "ad346c9a249c4b380bf73c460ad3e81135c5d781",
+      "acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+      "4c6b2c3096b1da0d0780fe0b4f147e837140468d"
+    ],
+    "hash_details": [
+      {
+        "hash": "ad346c9a249c4b380bf73c460ad3e81135c5d781",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "4c6b2c3096b1da0d0780fe0b4f147e837140468d",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/commit/4c6b2c3096b1da0d0780fe0b4f147e837140468d",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781",
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+      "https://gitlab.gnome.org/GNOME/libxml2/commit/4c6b2c3096b1da0d0780fe0b4f147e837140468d"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/commit/4c6b2c3096b1da0d0780fe0b4f147e837140468d",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/926",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:10630",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:10698",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:10699",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11580",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:11673",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12098",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12099",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12199",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12237",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12239",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12240",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:12241",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13267",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13289",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13325",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13335",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:13336",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14059",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:14396",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:15308",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:15672",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2025:19020",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:7519",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-6021",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2372406",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2025/07/msg00014.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-032379.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-6021",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7694-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/926",
+        "commits": [
+          "fce62e18175c57fce887cca70f05867ef8fded66"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-6052": {
+    "name": "glib-2.0",
+    "version": "1_2.78.6",
+    "cvss3_score": null,
+    "hashes": [
+      "34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+      "33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+      "987309f23ada52592bffdb5db0d8a5d58bd8097b"
+    ],
+    "hash_details": [
+      {
+        "hash": "34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "987309f23ada52592bffdb5db0d8a5d58bd8097b",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/987309f23ada52592bffdb5db0d8a5d58bd8097b",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/glib/-/commit/34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+      "https://gitlab.gnome.org/GNOME/glib/-/commit/33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+      "https://gitlab.gnome.org/GNOME/glib/-/commit/987309f23ada52592bffdb5db0d8a5d58bd8097b"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/987309f23ada52592bffdb5db0d8a5d58bd8097b",
+        "source": "debian, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2372666",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4655",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/34b7992fd6e3894bf6d2229b8aa59cac34bcb1b5",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/33d9ba2fcc907b4f9a6c0540f9976b64b6f59db2",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4656",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/987309f23ada52592bffdb5db0d8a5d58bd8097b",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2025-6052",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-032379.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://cert-portal.siemens.com/productcert/html/ssa-253495.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-6052",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7942-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61726": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "afa9b66ac081d3b239d8c1a226b5e884c8435185",
+      "85c794ddce26a092b0ea68d0fca79028b5069d5a",
+      "63a1b82d1e68ddd87652467303901593efe0ff11",
+      "69801b25b9624c3a678ef87d30771861e7bba51f"
+    ],
+    "hash_details": [
+      {
+        "hash": "afa9b66ac081d3b239d8c1a226b5e884c8435185",
+        "url": "https://github.com/golang/go/commit/afa9b66ac081d3b239d8c1a226b5e884c8435185",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "85c794ddce26a092b0ea68d0fca79028b5069d5a",
+        "url": "https://github.com/golang/go/commit/85c794ddce26a092b0ea68d0fca79028b5069d5a",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "63a1b82d1e68ddd87652467303901593efe0ff11",
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "hash": "69801b25b9624c3a678ef87d30771861e7bba51f",
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/afa9b66ac081d3b239d8c1a226b5e884c8435185",
+      "https://github.com/golang/go/commit/85c794ddce26a092b0ea68d0fca79028b5069d5a",
+      "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+      "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+      "https://go.dev/cl/736712",
+      "https://go.dev/issue/77101"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/afa9b66ac081d3b239d8c1a226b5e884c8435185",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/85c794ddce26a092b0ea68d0fca79028b5069d5a",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/736712",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/issue/77101",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/77101",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/afa9b66ac081d3b239d8c1a226b5e884c8435185",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/85c794ddce26a092b0ea68d0fca79028b5069d5a",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/736712",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/77101",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2026-4341",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61726",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61729": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+      "3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+      "1296453960bac0fb5675853c40e3747e5237e16e",
+      "fefb02adf45c4bcc879bd406a8d61f2a292c26a9"
+    ],
+    "hash_details": [
+      {
+        "hash": "f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+        "url": "https://github.com/golang/go/commit/f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+        "url": "https://github.com/golang/go/commit/3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "1296453960bac0fb5675853c40e3747e5237e16e",
+        "url": "https://github.com/golang/go/commit/1296453960bac0fb5675853c40e3747e5237e16e",
+        "source": "osv"
+      },
+      {
+        "hash": "fefb02adf45c4bcc879bd406a8d61f2a292c26a9",
+        "url": "https://github.com/golang/go/commit/fefb02adf45c4bcc879bd406a8d61f2a292c26a9",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+      "https://github.com/golang/go/commit/3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+      "https://github.com/golang/go/commit/1296453960bac0fb5675853c40e3747e5237e16e",
+      "https://github.com/golang/go/commit/fefb02adf45c4bcc879bd406a8d61f2a292c26a9",
+      "https://go.dev/issue/76445",
+      "https://go.dev/cl/725920"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/1296453960bac0fb5675853c40e3747e5237e16e",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/fefb02adf45c4bcc879bd406a8d61f2a292c26a9",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/issue/76445",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/725920",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/8FJoBkPddm4",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://go-review.googlesource.com/c/go/+/725920",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/76445",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/f7bce4bd6f7b13de8d9f06f7f262e3b60381e7e9",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/3a842bd5c6aa8eefa13c0174de3ab361e50bd672",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/725920",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/76445",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2025-4155",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61729",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61730": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "525dd853633f90d6038719d9a48cba3770ca71ea",
+      "ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+      "63a1b82d1e68ddd87652467303901593efe0ff11",
+      "69801b25b9624c3a678ef87d30771861e7bba51f"
+    ],
+    "hash_details": [
+      {
+        "hash": "525dd853633f90d6038719d9a48cba3770ca71ea",
+        "url": "https://github.com/golang/go/commit/525dd853633f90d6038719d9a48cba3770ca71ea",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+        "url": "https://github.com/golang/go/commit/ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "63a1b82d1e68ddd87652467303901593efe0ff11",
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "hash": "69801b25b9624c3a678ef87d30771861e7bba51f",
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/525dd853633f90d6038719d9a48cba3770ca71ea",
+      "https://github.com/golang/go/commit/ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+      "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+      "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+      "https://go.dev/cl/724120",
+      "https://go.dev/issue/76443"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/525dd853633f90d6038719d9a48cba3770ca71ea",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/724120",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/issue/76443",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/76443",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/525dd853633f90d6038719d9a48cba3770ca71ea",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/ad2cd043db66cd36e1f55359638729d2c8ff3d99",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/724120",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/76443",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2026-4340",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61730",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61915": {
+    "name": "cups",
+    "version": "2.4.11",
+    "cvss3_score": null,
+    "hashes": [
+      "524749b0449b49d8967d4f777854259bf22b278a",
+      "db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+      "433af45db06759081d4f3cd606e08ca634fc490a"
+    ],
+    "hash_details": [
+      {
+        "hash": "524749b0449b49d8967d4f777854259bf22b278a",
+        "url": "https://github.com/OpenPrinting/cups/commit/524749b0449b49d8967d4f777854259bf22b278a",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+        "url": "https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+        "source": "cvelistv5, debian, nvd, osv",
+        "type": "fix"
+      },
+      {
+        "hash": "433af45db06759081d4f3cd606e08ca634fc490a",
+        "url": "https://github.com/openprinting/cups/commit/433af45db06759081d4f3cd606e08ca634fc490a",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/OpenPrinting/cups/commit/524749b0449b49d8967d4f777854259bf22b278a",
+      "https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+      "https://github.com/openprinting/cups/commit/433af45db06759081d4f3cd606e08ca634fc490a"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/524749b0449b49d8967d4f777854259bf22b278a",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/openprinting/cups/commit/433af45db06759081d4f3cd606e08ca634fc490a",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/11/27/5",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/security/advisories/GHSA-hxm8-vfpq-jrfc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/524749b0449b49d8967d4f777854259bf22b278a",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/OpenPrinting/cups/releases/tag/v2.4.15",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/11/27/5",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/61xxx/CVE-2025-61915.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-61915",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61915",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7897-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61984": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "35d5917652106aede47621bb3f64044604164043"
+    ],
+    "hash_details": [
+      {
+        "hash": "35d5917652106aede47621bb3f64044604164043",
+        "url": "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043",
+        "source": "debian, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043",
+        "source": "debian, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/10/06/1",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://dgl.cx/2025/10/bash-a-newline-ssh-proxycommand-cve-2025-61984",
+        "sources": [
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://marc.info/?l=openssh-unix-dev&m=175974522032149&w=2",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/releasenotes.html#10.1p1",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/07/1",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2025/10/12/1",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-61984-detection-script-remote-code-execution-vulnerability-affecting-openssh",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.vicarius.io/vsociety/posts/cve-2025-61984-mitigation-script-remote-code-execution-vulnerability-affecting-openssh",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61984",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8090-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8090-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-61985": {
+    "name": "openssh",
+    "version": "9.6p1",
+    "cvss3_score": null,
+    "hashes": [
+      "43b3bff47bb029f2299bacb6a36057981b39fdb0"
+    ],
+    "hash_details": [
+      {
+        "hash": "43b3bff47bb029f2299bacb6a36057981b39fdb0",
+        "url": "https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0",
+        "source": "debian, ubuntu",
+        "type": null
+      }
+    ],
+    "patches": [
+      "https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0",
+        "source": "debian, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/10/06/1",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://marc.info/?l=openssh-unix-dev&m=175974522032149&w=2",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openssh.com/releasenotes.html#10.1p1",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-61985",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8090-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8090-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-64505": {
+    "name": "libpng",
+    "version": "1.6.42",
+    "cvss3_score": null,
+    "hashes": [
+      "6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+      "49363adcfaf098748d7a4c8c624ad8c45a8c3a86"
+    ],
+    "hash_details": [
+      {
+        "hash": "6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+        "url": "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+        "url": "https://github.com/glennrp/libpng/commit/49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+      "https://github.com/glennrp/libpng/commit/49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+      "https://github.com/pnggroup/libpng/commit/49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+      "https://github.com/pnggroup/libpng/pull/748",
+      "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37 (v1.6.51)"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/glennrp/libpng/commit/49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/49363adcfaf098748d7a4c8c624ad8c45a8c3a86",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/pull/748",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37 (v1.6.51)",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pnggroup/libpng/security/advisories/GHSA-4952-h5wq-4m42",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/pull/748",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/11/22/1",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/64xxx/CVE-2025-64505.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-64505",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-64505",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/6a528eb5fd0dd7f6de1c39d30de0e41473431c37 (v1.6.51)",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7924-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8081-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://github.com/pnggroup/libpng/pull/748",
+        "commits": [
+          "ea094764f3436e3c6524622724c2d342a3eff235",
+          "6a528eb5fd0dd7f6de1c39d30de0e41473431c37",
+          "83b23a888b4395c3ae0af3f6d484fce3e4a81155"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-66471": {
+    "name": "python3-urllib3",
+    "version": "2.2.2",
+    "cvss3_score": null,
+    "hashes": [
+      "c19571de34c47de3a766541b041637ba5f716ed7",
+      "720f484b605f18887a48eef448d0084e2b76902d"
+    ],
+    "hash_details": [
+      {
+        "hash": "c19571de34c47de3a766541b041637ba5f716ed7",
+        "url": "https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "720f484b605f18887a48eef448d0084e2b76902d",
+        "url": "https://github.com/urllib3/urllib3/commit/720f484b605f18887a48eef448d0084e2b76902d",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7",
+      "https://github.com/urllib3/urllib3/commit/720f484b605f18887a48eef448d0084e2b76902d"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/720f484b605f18887a48eef448d0084e2b76902d",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2025/12/05/4",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/security/advisories/GHSA-2xpw-w6gg-jr37",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2025/66xxx/CVE-2025-66471.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66471",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-66471",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7927-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7927-2",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7927-3",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-68119": {
+    "name": "go-runtime",
+    "version": "1.22.12",
+    "cvss3_score": null,
+    "hashes": [
+      "082365aa552a7e2186f79110d5311dce70749cc0",
+      "73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+      "63a1b82d1e68ddd87652467303901593efe0ff11",
+      "69801b25b9624c3a678ef87d30771861e7bba51f"
+    ],
+    "hash_details": [
+      {
+        "hash": "082365aa552a7e2186f79110d5311dce70749cc0",
+        "url": "https://github.com/golang/go/commit/082365aa552a7e2186f79110d5311dce70749cc0",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+        "url": "https://github.com/golang/go/commit/73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "63a1b82d1e68ddd87652467303901593efe0ff11",
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "hash": "69801b25b9624c3a678ef87d30771861e7bba51f",
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/golang/go/commit/082365aa552a7e2186f79110d5311dce70749cc0",
+      "https://github.com/golang/go/commit/73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+      "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+      "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+      "https://go.dev/cl/736710",
+      "https://go.dev/issue/77099"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/golang/go/commit/082365aa552a7e2186f79110d5311dce70749cc0",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/63a1b82d1e68ddd87652467303901593efe0ff11",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/golang/go/commit/69801b25b9624c3a678ef87d30771861e7bba51f",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/cl/736710",
+        "source": "osv"
+      },
+      {
+        "url": "https://go.dev/issue/77099",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/issues/77099",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/082365aa552a7e2186f79110d5311dce70749cc0",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/golang/go/commit/73fe85f0ea1bf2cec8e9a89bf5645de06ecaa0a6",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/736710",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/77099",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2026-4338",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-68119",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2025-9375": {
+    "name": "python3-xmltodict",
+    "version": "0.13.0",
+    "cvss3_score": null,
+    "hashes": [
+      "ecd456ab88d379514b116ef9293318b74e5ed3ee",
+      "f98c90f071228ed73df997807298e1df4f790c33",
+      "75a17701db20d5d3ec2ea1f6c901cf2211011eb5"
+    ],
+    "hash_details": [
+      {
+        "hash": "ecd456ab88d379514b116ef9293318b74e5ed3ee",
+        "url": "https://github.com/martinblech/xmltodict/commit/ecd456ab88d379514b116ef9293318b74e5ed3ee",
+        "source": "debian, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "f98c90f071228ed73df997807298e1df4f790c33",
+        "url": "https://github.com/martinblech/xmltodict/commit/f98c90f071228ed73df997807298e1df4f790c33",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "75a17701db20d5d3ec2ea1f6c901cf2211011eb5",
+        "url": "https://github.com/martinblech/xmltodict/commit/75a17701db20d5d3ec2ea1f6c901cf2211011eb5",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/martinblech/xmltodict/commit/ecd456ab88d379514b116ef9293318b74e5ed3ee",
+      "https://github.com/martinblech/xmltodict/commit/f98c90f071228ed73df997807298e1df4f790c33",
+      "https://github.com/martinblech/xmltodict/blob/v0.15.1/CHANGELOG.md",
+      "https://github.com/martinblech/xmltodict/commit/75a17701db20d5d3ec2ea1f6c901cf2211011eb5"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/martinblech/xmltodict/commit/ecd456ab88d379514b116ef9293318b74e5ed3ee",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/commit/f98c90f071228ed73df997807298e1df4f790c33",
+        "source": "cvelistv5, debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/blob/v0.15.1/CHANGELOG.md",
+        "source": "cvelistv5"
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/commit/75a17701db20d5d3ec2ea1f6c901cf2211011eb5",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/martinblech/xmltodict/issues/377",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://fluidattacks.com/advisories/mono",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/commit/ecd456ab88d379514b116ef9293318b74e5ed3ee",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/commit/f98c90f071228ed73df997807298e1df4f790c33",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/blob/v0.15.1/CHANGELOG.md",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.XMLGenerator",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.escape",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/martinblech/xmltodict/issues/377#issuecomment-3255691923",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2025-9375",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7753-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-0989": {
+    "name": "libxml2",
+    "version": "2.12.10",
+    "cvss3_score": null,
+    "hashes": [
+      "66c52b3ac6c32ab112ec2a3bf41e6c30948be113"
+    ],
+    "hash_details": [
+      {
+        "hash": "66c52b3ac6c32ab112ec2a3bf41e6c30948be113",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113",
+        "source": "debian",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113",
+        "source": "debian"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/998",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/374",
+        "sources": [
+          "debian",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/66c52b3ac6c32ab112ec2a3bf41e6c30948be113",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:7519",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2026-0989",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2429933",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-0989",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7974-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/998",
+        "commits": [
+          "fac4411aa65a2ebf936be50856ab14c148966e9d",
+          "19549c61590c1873468c53e0026a2fbffae428ef"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-0990": {
+    "name": "libxml2",
+    "version": "2.12.10",
+    "cvss3_score": null,
+    "hashes": [
+      "1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+      "ac6f0fde1476c41f59ad0c68ada3394599ebf2ae"
+    ],
+    "hash_details": [
+      {
+        "hash": "1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "ac6f0fde1476c41f59ad0c68ada3394599ebf2ae",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae",
+        "source": "debian",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae",
+        "source": "debian"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/1018",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/1961208e958ca22f80a0b4e4c9d71cfa050aa982",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/ac6f0fde1476c41f59ad0c68ada3394599ebf2ae",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:7519",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2026-0990",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2429959",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-0990",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7974-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/1018",
+        "commits": [
+          "fac4411aa65a2ebf936be50856ab14c148966e9d",
+          "f75abfcaa419a740a3191e56c60400f3ff18988d",
+          "1961208e958ca22f80a0b4e4c9d71cfa050aa982"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-0992": {
+    "name": "libxml2",
+    "version": "2.12.10",
+    "cvss3_score": null,
+    "hashes": [
+      "f75abfcaa419a740a3191e56c60400f3ff18988d",
+      "4af23b523de5b72f27faf3e8e8a99dde5f7b82a2"
+    ],
+    "hash_details": [
+      {
+        "hash": "f75abfcaa419a740a3191e56c60400f3ff18988d",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/f75abfcaa419a740a3191e56c60400f3ff18988d",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "4af23b523de5b72f27faf3e8e8a99dde5f7b82a2",
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2",
+        "source": "debian",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/f75abfcaa419a740a3191e56c60400f3ff18988d",
+      "https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/f75abfcaa419a740a3191e56c60400f3ff18988d",
+        "source": "debian"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2",
+        "source": "debian"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/1019",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/f75abfcaa419a740a3191e56c60400f3ff18988d",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/libxml2/-/commit/4af23b523de5b72f27faf3e8e8a99dde5f7b82a2",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/errata/RHSA-2026:7519",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2026-0992",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2429975",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-0992",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7974-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/1019",
+        "commits": [
+          "fac4411aa65a2ebf936be50856ab14c148966e9d",
+          "f75abfcaa419a740a3191e56c60400f3ff18988d",
+          "1961208e958ca22f80a0b4e4c9d71cfa050aa982"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-1485": {
+    "name": "glib-2.0",
+    "version": "1_2.78.6",
+    "cvss3_score": null,
+    "hashes": [
+      "ee5acb2cefc643450509374da2600cd3bf49a109"
+    ],
+    "hash_details": [
+      {
+        "hash": "ee5acb2cefc643450509374da2600cd3bf49a109",
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/ee5acb2cefc643450509374da2600cd3bf49a109",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4980",
+      "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4981",
+      "https://gitlab.gnome.org/GNOME/glib/-/commit/ee5acb2cefc643450509374da2600cd3bf49a109"
+    ],
+    "patch_details": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4980",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4981",
+        "source": "ubuntu"
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/commit/ee5acb2cefc643450509374da2600cd3bf49a109",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/issues/3871",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4980",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4981",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2026-1485",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2433325",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-1485",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8017-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://gitlab.gnome.org/GNOME/glib/-/issues/3871",
+        "commits": [
+          "aacda5b07141b944408c79e83bcbed3b2e1e6e45"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-1703": {
+    "name": "python3-pip",
+    "version": "24.0",
+    "cvss3_score": null,
+    "hashes": [
+      "4c651b70d60ed91b13663bcda9b3ed41748d0124",
+      "8e227a9be4faa9594e05d02ca05a413a2a4e7735"
+    ],
+    "hash_details": [
+      {
+        "hash": "4c651b70d60ed91b13663bcda9b3ed41748d0124",
+        "url": "https://github.com/pypa/pip/commit/4c651b70d60ed91b13663bcda9b3ed41748d0124",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "8e227a9be4faa9594e05d02ca05a413a2a4e7735",
+        "url": "https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735",
+        "source": "cvelistv5, nvd, osv, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/pypa/pip/commit/4c651b70d60ed91b13663bcda9b3ed41748d0124",
+      "https://github.com/pypa/pip/pull/13777",
+      "https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pypa/pip/commit/4c651b70d60ed91b13663bcda9b3ed41748d0124",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/pypa/pip/pull/13777",
+        "source": "cvelistv5, osv"
+      },
+      {
+        "url": "https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735",
+        "source": "cvelistv5, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pypa/pip/pull/13777",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/pip/commit/4c651b70d60ed91b13663bcda9b3ed41748d0124",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://mail.python.org/archives/list/security-announce@python.org/thread/WIEA34D4TABF2UNQJAOMXKCICSPBE2DJ/",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-1703",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://github.com/pypa/pip/pull/13777",
+        "commits": [
+          "4c651b70d60ed91b13663bcda9b3ed41748d0124"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-21441": {
+    "name": "python3-urllib3",
+    "version": "2.2.2",
+    "cvss3_score": null,
+    "hashes": [
+      "8864ac407bba8607950025e0979c4c69bc7abc7b",
+      "7960512291072d707961287fe050a6817d783f57",
+      "0248277dd7ac0239204889ca991353ad3e3a1ddc"
+    ],
+    "hash_details": [
+      {
+        "hash": "8864ac407bba8607950025e0979c4c69bc7abc7b",
+        "url": "https://github.com/urllib3/urllib3/commit/8864ac407bba8607950025e0979c4c69bc7abc7b",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "7960512291072d707961287fe050a6817d783f57",
+        "url": "https://github.com/urllib3/urllib3/commit/7960512291072d707961287fe050a6817d783f57",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "0248277dd7ac0239204889ca991353ad3e3a1ddc",
+        "url": "https://github.com/urllib3/urllib3/commit/0248277dd7ac0239204889ca991353ad3e3a1ddc",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/urllib3/urllib3/commit/8864ac407bba8607950025e0979c4c69bc7abc7b",
+      "https://github.com/urllib3/urllib3/commit/7960512291072d707961287fe050a6817d783f57",
+      "https://github.com/urllib3/urllib3/commit/0248277dd7ac0239204889ca991353ad3e3a1ddc"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/8864ac407bba8607950025e0979c4c69bc7abc7b",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/7960512291072d707961287fe050a6817d783f57",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/0248277dd7ac0239204889ca991353ad3e3a1ddc",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/urllib3/urllib3/security/advisories/GHSA-38jv-5279-wg99",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/8864ac407bba8607950025e0979c4c69bc7abc7b",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/urllib3/urllib3/commit/7960512291072d707961287fe050a6817d783f57",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2026/01/msg00017.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/21xxx/CVE-2026-21441.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-21441",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-21441",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7955-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7955-2",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8010-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-22801": {
+    "name": "libpng",
+    "version": "1.6.42",
+    "cvss3_score": null,
+    "hashes": [
+      "cf155de014fc6c5cb199dd681dd5c8fb70429072",
+      "02f2b4f4699f0ef9111a6534f093b53732df4452",
+      "cf155de014"
+    ],
+    "hash_details": [
+      {
+        "hash": "cf155de014fc6c5cb199dd681dd5c8fb70429072",
+        "url": "https://github.com/pnggroup/libpng/commit/cf155de014fc6c5cb199dd681dd5c8fb70429072",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "02f2b4f4699f0ef9111a6534f093b53732df4452",
+        "url": "https://github.com/glennrp/libpng/commit/02f2b4f4699f0ef9111a6534f093b53732df4452",
+        "source": "osv"
+      },
+      {
+        "hash": "cf155de014",
+        "url": "https://github.com/pnggroup/libpng/commit/cf155de014",
+        "source": "ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/pnggroup/libpng/commit/cf155de014fc6c5cb199dd681dd5c8fb70429072",
+      "https://github.com/glennrp/libpng/commit/02f2b4f4699f0ef9111a6534f093b53732df4452",
+      "https://github.com/pnggroup/libpng/commit/02f2b4f4699f0ef9111a6534f093b53732df4452",
+      "https://github.com/pnggroup/libpng/commit/cf155de014"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/cf155de014fc6c5cb199dd681dd5c8fb70429072",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/glennrp/libpng/commit/02f2b4f4699f0ef9111a6534f093b53732df4452",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/02f2b4f4699f0ef9111a6534f093b53732df4452",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/cf155de014",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pnggroup/libpng/security/advisories/GHSA-vgjq-8cw5-ggw8",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/cf155de014fc6c5cb199dd681dd5c8fb70429072",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/22xxx/CVE-2026-22801.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-22801",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-22801",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2026/01/12/7",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7963-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8035-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-23490": {
+    "name": "python3-pyasn1",
+    "version": "0.5.1",
+    "cvss3_score": null,
+    "hashes": [
+      "3908f144229eed4df24bd569d16e5991ace44970",
+      "e7356f89cf32c130d65b1a0e903fe7ecce426424"
+    ],
+    "hash_details": [
+      {
+        "hash": "3908f144229eed4df24bd569d16e5991ace44970",
+        "url": "https://github.com/pyasn1/pyasn1/commit/3908f144229eed4df24bd569d16e5991ace44970",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "e7356f89cf32c130d65b1a0e903fe7ecce426424",
+        "url": "https://github.com/pyasn1/pyasn1/commit/e7356f89cf32c130d65b1a0e903fe7ecce426424",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pyasn1/pyasn1/commit/3908f144229eed4df24bd569d16e5991ace44970",
+      "https://github.com/pyasn1/pyasn1/commit/e7356f89cf32c130d65b1a0e903fe7ecce426424"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pyasn1/pyasn1/commit/3908f144229eed4df24bd569d16e5991ace44970",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pyasn1/pyasn1/commit/e7356f89cf32c130d65b1a0e903fe7ecce426424",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pyasn1/pyasn1/security/advisories/GHSA-63vm-454h-vhhq",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pyasn1/pyasn1/commit/3908f144229eed4df24bd569d16e5991ace44970",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/pyasn1/pyasn1/releases/tag/v0.6.2",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2026/02/msg00002.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/23xxx/CVE-2026-23490.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23490",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-23490",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-7975-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8134-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-24049": {
+    "name": "python3-wheel",
+    "version": "0.42.0",
+    "cvss3_score": null,
+    "hashes": [
+      "934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+      "7a7d2de96b22a9adf9208afcc9547e1001569fef",
+      "eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b"
+    ],
+    "hash_details": [
+      {
+        "hash": "934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+        "url": "https://github.com/pypa/wheel/commit/934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "7a7d2de96b22a9adf9208afcc9547e1001569fef",
+        "url": "https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b",
+        "url": "https://github.com/pypa/wheel/commit/eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pypa/wheel/commit/934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+      "https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef",
+      "https://github.com/pypa/wheel/commit/eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pypa/wheel/commit/934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pypa/wheel/commit/eba4036ccaca4e2d0c5b5bf3e3be59b2b2877d6b",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pypa/wheel/security/advisories/GHSA-8rrh-rw8j-w5fx",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/wheel/commit/934fe177ff912c8e03d5ae951d3805e1fd90ba5e",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pypa/wheel/releases/tag/0.46.2",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/24xxx/CVE-2026-24049.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24049",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-24049",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8221-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-25068": {
+    "name": "alsa-lib",
+    "version": "1.2.11",
+    "cvss3_score": null,
+    "hashes": [
+      "b6c9afb4f59bb678dc834028680d579f47dc273b",
+      "5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40"
+    ],
+    "hash_details": [
+      {
+        "hash": "b6c9afb4f59bb678dc834028680d579f47dc273b",
+        "url": "https://github.com/alsa-project/alsa-lib/commit/b6c9afb4f59bb678dc834028680d579f47dc273b",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40",
+        "url": "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/alsa-project/alsa-lib/commit/b6c9afb4f59bb678dc834028680d579f47dc273b",
+      "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/alsa-project/alsa-lib/commit/b6c9afb4f59bb678dc834028680d579f47dc273b",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40",
+        "source": "cvelistv5, debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/alsa-project/alsa-lib/commit/b6c9afb4f59bb678dc834028680d579f47dc273b",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.vulncheck.com/advisories/alsa-lib-topology-decoder-heap-based-buffer-overflow",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2026/02/msg00008.html",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-25068",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8044-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-25646": {
+    "name": "libpng",
+    "version": "1.6.42",
+    "cvss3_score": null,
+    "hashes": [
+      "01d03b8453eb30ade759cd45c707e5a1c7277d88",
+      "c3e304954a9cfd154bc0dfbfea2b01cd61d6546d"
+    ],
+    "hash_details": [
+      {
+        "hash": "01d03b8453eb30ade759cd45c707e5a1c7277d88",
+        "url": "https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "c3e304954a9cfd154bc0dfbfea2b01cd61d6546d",
+        "url": "https://github.com/glennrp/libpng/commit/c3e304954a9cfd154bc0dfbfea2b01cd61d6546d",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88",
+      "https://github.com/glennrp/libpng/commit/c3e304954a9cfd154bc0dfbfea2b01cd61d6546d",
+      "https://github.com/pnggroup/libpng/commit/c3e304954a9cfd154bc0dfbfea2b01cd61d6546d"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/glennrp/libpng/commit/c3e304954a9cfd154bc0dfbfea2b01cd61d6546d",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/c3e304954a9cfd154bc0dfbfea2b01cd61d6546d",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pnggroup/libpng/security/advisories/GHSA-g8hp-mq4h-rqm3",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pnggroup/libpng/commit/01d03b8453eb30ade759cd45c707e5a1c7277d88",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/09/7",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/25xxx/CVE-2026-25646.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25646",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-25646",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8035-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8039-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8081-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-25749": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "0714b15940b245108e6e9d7aa2260dd849a26fa9"
+    ],
+    "hash_details": [
+      {
+        "hash": "0714b15940b245108e6e9d7aa2260dd849a26fa9",
+        "url": "https://github.com/vim/vim/commit/0714b15940b245108e6e9d7aa2260dd849a26fa9",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/0714b15940b245108e6e9d7aa2260dd849a26fa9"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/0714b15940b245108e6e9d7aa2260dd849a26fa9",
+        "source": "debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-5w93-4g67-mm43",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/0714b15940b245108e6e9d7aa2260dd849a26fa9",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.1.2132",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/25xxx/CVE-2026-25749.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25749",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-25749",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8101-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-26007": {
+    "name": "python3-cryptography",
+    "version": "42.0.5",
+    "cvss3_score": null,
+    "hashes": [
+      "f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+      "0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+      "06e120e682cb200e3f7050c02f0bcdac90c4c6ad"
+    ],
+    "hash_details": [
+      {
+        "hash": "f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+        "url": "https://github.com/pyca/cryptography/commit/f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+        "source": "debian",
+        "type": null
+      },
+      {
+        "hash": "0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+        "url": "https://github.com/pyca/cryptography/commit/0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "06e120e682cb200e3f7050c02f0bcdac90c4c6ad",
+        "url": "https://github.com/pyca/cryptography/commit/06e120e682cb200e3f7050c02f0bcdac90c4c6ad",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pyca/cryptography/commit/f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+      "https://github.com/pyca/cryptography/commit/0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+      "https://github.com/pyca/cryptography/commit/06e120e682cb200e3f7050c02f0bcdac90c4c6ad"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pyca/cryptography/commit/f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/pyca/cryptography/commit/0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pyca/cryptography/commit/06e120e682cb200e3f7050c02f0bcdac90c4c6ad",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pyca/cryptography/security/advisories/GHSA-r6ph-v2qm-q3c2",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/cryptography/commit/f38eb4a0e45645e6a43f8dd589f1d3ce1103e83c",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/cryptography/commit/0eebb9dbb6343d9bc1d91e5a2482ed4e054a6d8c",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/10/4",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/26xxx/CVE-2026-26007.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26007",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-26007",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8087-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8087-3",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-26269": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "c5f312aad8e4179e437f81ad39a860cd0ef11970"
+    ],
+    "hash_details": [
+      {
+        "hash": "c5f312aad8e4179e437f81ad39a860cd0ef11970",
+        "url": "https://github.com/vim/vim/commit/c5f312aad8e4179e437f81ad39a860cd0ef11970",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/c5f312aad8e4179e437f81ad39a860cd0ef11970"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/c5f312aad8e4179e437f81ad39a860cd0ef11970",
+        "source": "debian, osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-9w5c-hwr9-hc68",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/c5f312aad8e4179e437f81ad39a860cd0ef11970",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.1.2148",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/13/2",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/26xxx/CVE-2026-26269.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-26269",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-26269",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8101-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-27135": {
+    "name": "nghttp2",
+    "version": "1.61.0",
+    "cvss3_score": null,
+    "hashes": [
+      "5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+      "f769990597670f3ea8d2440d1e18a3f9a0df9bc0"
+    ],
+    "hash_details": [
+      {
+        "hash": "5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+        "url": "https://github.com/nghttp2/nghttp2/commit/5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "f769990597670f3ea8d2440d1e18a3f9a0df9bc0",
+        "url": "https://github.com/nghttp2/nghttp2/commit/f769990597670f3ea8d2440d1e18a3f9a0df9bc0",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/nghttp2/nghttp2/commit/5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+      "https://github.com/nghttp2/nghttp2/commit/f769990597670f3ea8d2440d1e18a3f9a0df9bc0"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/nghttp2/nghttp2/commit/5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/nghttp2/nghttp2/commit/f769990597670f3ea8d2440d1e18a3f9a0df9bc0",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/nghttp2/nghttp2/security/advisories/GHSA-6933-cjhr-5qg6",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/nghttp2/nghttp2/commit/5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/20/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://lists.debian.org/debian-lts-announce/2026/05/msg00025.html",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/27xxx/CVE-2026-27135.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27135",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-27135",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8233-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8233-2",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-27448": {
+    "name": "python3-pyopenssl",
+    "version": "24.0.0",
+    "cvss3_score": null,
+    "hashes": [
+      "d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+      "358cbf29c4e364c59930e53a270116249581eaa3"
+    ],
+    "hash_details": [
+      {
+        "hash": "d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+        "url": "https://github.com/pyca/pyopenssl/commit/d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "358cbf29c4e364c59930e53a270116249581eaa3",
+        "url": "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pyca/pyopenssl/commit/d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+      "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3",
+        "source": "osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pyca/pyopenssl/security/advisories/GHSA-vp96-hxj8-p424",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/d41a814759a9fb49584ca8ab3f7295de49a85aa0",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/blob/358cbf29c4e364c59930e53a270116249581eaa3/CHANGELOG.rst#L27",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/27xxx/CVE-2026-27448.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27448",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-27448",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8115-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-27459": {
+    "name": "python3-pyopenssl",
+    "version": "24.0.0",
+    "cvss3_score": null,
+    "hashes": [
+      "57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+      "358cbf29c4e364c59930e53a270116249581eaa3"
+    ],
+    "hash_details": [
+      {
+        "hash": "57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+        "url": "https://github.com/pyca/pyopenssl/commit/57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+        "source": "cvelistv5, debian, nvd, osv, ubuntu",
+        "type": null
+      },
+      {
+        "hash": "358cbf29c4e364c59930e53a270116249581eaa3",
+        "url": "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3",
+        "source": "osv"
+      }
+    ],
+    "patches": [
+      "https://github.com/pyca/pyopenssl/commit/57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+      "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3",
+      "https://github.com/pyca/pyopenssl/pull/1479"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+        "source": "debian, osv, ubuntu"
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/358cbf29c4e364c59930e53a270116249581eaa3",
+        "source": "osv"
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/pull/1479",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/pyca/pyopenssl/security/advisories/GHSA-5pwr-322w-8jr4",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/commit/57f09bb4bb051d3bc2a1abd36e9525313d5cd408",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/pyca/pyopenssl/blob/358cbf29c4e364c59930e53a270116249581eaa3/CHANGELOG.rst",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/27xxx/CVE-2026-27459.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-27459",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-27459",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8115-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://github.com/pyca/pyopenssl/pull/1479",
+        "commits": [
+          "3b288fb112ccf4b5a3dbafbb32e5f6b1039c4a9f"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-28372": {
+    "name": "inetutils",
+    "version": "2.5",
+    "cvss3_score": null,
+    "hashes": [
+      "4db2f19f4caac03c7f4da6363c140bd70df31386",
+      "3953943d8296310485f98963883a798545ab9a6c"
+    ],
+    "hash_details": [
+      {
+        "hash": "4db2f19f4caac03c7f4da6363c140bd70df31386",
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=4db2f19f4caac03c7f4da6363c140bd70df31386",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "3953943d8296310485f98963883a798545ab9a6c",
+        "url": "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/?id=3953943d8296310485f98963883a798545ab9a6c",
+        "source": "cvelistv5, nvd, osv, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=4db2f19f4caac03c7f4da6363c140bd70df31386",
+      "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/3953943d8296310485f98963883a798545ab9a6c",
+      "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/?id=3953943d8296310485f98963883a798545ab9a6c"
+    ],
+    "patch_details": [
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=4db2f19f4caac03c7f4da6363c140bd70df31386",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/3953943d8296310485f98963883a798545ab9a6c",
+        "source": "osv"
+      },
+      {
+        "url": "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/?id=3953943d8296310485f98963883a798545ab9a6c",
+        "source": "osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00000.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=4db2f19f4caac03c7f4da6363c140bd70df31386",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/commit/?id=3953943d8296310485f98963883a798545ab9a6c",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00012.html",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2026/02/24/1",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/27/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/06/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/06/3",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/07/1",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/07/2",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-28372",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-28418": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+      "f6a7f469a9c0d09e84cd6cb"
+    ],
+    "hash_details": [
+      {
+        "hash": "f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+        "source": "debian, osv",
+        "type": "fix"
+      },
+      {
+        "hash": "f6a7f469a9c0d09e84cd6cb",
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb",
+        "source": "cvelistv5, nvd, osv, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+      "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb",
+        "source": "osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-h4mf-vg97-hj8j",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.2.0074",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/27/7",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/28xxx/CVE-2026-28418.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28418",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-28418",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8101-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-28419": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+      "9b7dfa2948c9e1e5e32a5812"
+    ],
+    "hash_details": [
+      {
+        "hash": "9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+        "source": "debian, osv",
+        "type": "fix"
+      },
+      {
+        "hash": "9b7dfa2948c9e1e5e32a5812",
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812",
+        "source": "cvelistv5, nvd, osv, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+      "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+        "source": "debian, osv"
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812",
+        "source": "osv, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-xcc8-r6c5-hvwv",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812812d580c7879f4a0",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.2.0075",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/02/27/8",
+        "sources": [
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/28xxx/CVE-2026-28419.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-28419",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-28419",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8101-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-32746": {
+    "name": "inetutils",
+    "version": "2.5",
+    "cvss3_score": null,
+    "hashes": [
+      "6864598a29b652a6b69a958f5cd1318aa2b258af"
+    ],
+    "hash_details": [
+      {
+        "hash": "6864598a29b652a6b69a958f5cd1318aa2b258af",
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=6864598a29b652a6b69a958f5cd1318aa2b258af",
+        "source": "debian",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=6864598a29b652a6b69a958f5cd1318aa2b258af"
+    ],
+    "patch_details": [
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=6864598a29b652a6b69a958f5cd1318aa2b258af",
+        "source": "debian"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://lists.gnu.org/archive/html/bug-inetutils/2026-03/msg00031.html",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/commit/?id=6864598a29b652a6b69a958f5cd1318aa2b258af",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2026/03/12/4",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/14/1",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://github.com/watchtowrlabs/watchtowr-vs-telnetd-CVE-2026-32746",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-32746",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-32772": {
+    "name": "inetutils",
+    "version": "2.5",
+    "cvss3_score": null,
+    "hashes": [
+      "d6b8b83aa51616946fd314bc48087312d13c99f8"
+    ],
+    "hash_details": [
+      {
+        "hash": "d6b8b83aa51616946fd314bc48087312d13c99f8",
+        "url": "https://cgit.git.savannah.gnu.org/cgit/inetutils.git/patch/?id=d6b8b83aa51616946fd314bc48087312d13c99f8",
+        "source": "oe_patch"
+      }
+    ],
+    "patches": [],
+    "patch_details": [],
+    "references": [
+      {
+        "url": "https://www.openwall.com/lists/oss-security/2026/03/13/1",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-32772",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-33412": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "645ed6597d1ea896c712cd7ddbb6edee79577e9a"
+    ],
+    "hash_details": [
+      {
+        "hash": "645ed6597d1ea896c712cd7ddbb6edee79577e9a",
+        "url": "https://github.com/vim/vim/commit/645ed6597d1ea896c712cd7ddbb6edee79577e9a",
+        "source": "cvelistv5, debian, nvd, osv",
+        "type": "fix"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/645ed6597d1ea896c712cd7ddbb6edee79577e9a"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/645ed6597d1ea896c712cd7ddbb6edee79577e9a",
+        "source": "debian, osv"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-w5jw-f54h-x46c",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/pull/19746",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/645ed6597d1ea896c712cd7ddbb6edee79577e9a",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.2.0202",
+        "sources": [
+          "cvelistv5",
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/03/19/10",
+        "sources": [
+          "nvd",
+          "osv"
+        ]
+      },
+      {
+        "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/33xxx/CVE-2026-33412.json",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33412",
+        "sources": [
+          "osv"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-33412",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8171-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://github.com/vim/vim/pull/19746",
+        "commits": [
+          "25f1b0899025ed0b88223cd530d1433d7084de4b"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-34933": {
+    "name": "avahi",
+    "version": "0.8",
+    "cvss3_score": null,
+    "hashes": [
+      "0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+      "a93fdd980d2db5d453475c0aa2b39946bd6611bd",
+      "625ca0fac19229f6dfa3a6c6b698ae657187e50c"
+    ],
+    "hash_details": [
+      {
+        "hash": "0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+        "url": "https://github.com/avahi/avahi/commit/0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+        "source": "debian, ubuntu",
+        "type": "fix"
+      },
+      {
+        "hash": "a93fdd980d2db5d453475c0aa2b39946bd6611bd",
+        "url": "https://github.com/avahi/avahi/commit/a93fdd980d2db5d453475c0aa2b39946bd6611bd",
+        "source": "debian, ubuntu",
+        "type": "test"
+      },
+      {
+        "hash": "625ca0fac19229f6dfa3a6c6b698ae657187e50c",
+        "url": "https://github.com/avahi/avahi/commit/625ca0fac19229f6dfa3a6c6b698ae657187e50c",
+        "source": "cvelistv5, nvd"
+      }
+    ],
+    "patches": [
+      "https://github.com/avahi/avahi/commit/0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+      "https://github.com/avahi/avahi/commit/a93fdd980d2db5d453475c0aa2b39946bd6611bd"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/avahi/avahi/commit/0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+        "source": "debian, ubuntu"
+      },
+      {
+        "url": "https://github.com/avahi/avahi/commit/a93fdd980d2db5d453475c0aa2b39946bd6611bd",
+        "source": "debian, ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/avahi/avahi/security/advisories/GHSA-w65r-6gxh-vhvc",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/avahi/avahi/pull/891",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/avahi/avahi/commit/0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/avahi/avahi/commit/a93fdd980d2db5d453475c0aa2b39946bd6611bd",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/avahi/avahi/commit/625ca0fac19229f6dfa3a6c6b698ae657187e50c",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2026/04/11/9",
+        "sources": [
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-34933",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8269-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ],
+    "series": [
+      {
+        "pull_url": "https://github.com/avahi/avahi/pull/891",
+        "commits": [
+          "3a884bca577eff37773067797adad99babadac3c",
+          "0ccadca425af151ebb67f276e5cc88e50266a8e6",
+          "e3cb6de5fd2223262058acd56368611027068f2f"
+        ]
+      },
+      {
+        "pull_url": "debian:v0.9-rc4",
+        "commits": [
+          "0be89b6bb5c3983837b5e0febcbbbf452ecf7675",
+          "a93fdd980d2db5d453475c0aa2b39946bd6611bd"
+        ]
+      }
+    ]
+  },
+  "CVE-2026-39881": {
+    "name": "vim-tiny",
+    "version": "9.1.1683",
+    "cvss3_score": null,
+    "hashes": [
+      "7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+      "7ab76a86048ed492374ac6b19"
+    ],
+    "hash_details": [
+      {
+        "hash": "7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+        "source": "debian",
+        "type": "fix"
+      },
+      {
+        "hash": "7ab76a86048ed492374ac6b19",
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19",
+        "source": "cvelistv5, nvd, ubuntu"
+      }
+    ],
+    "patches": [
+      "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+      "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19"
+    ],
+    "patch_details": [
+      {
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+        "source": "debian"
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19",
+        "source": "ubuntu"
+      }
+    ],
+    "references": [
+      {
+        "url": "https://github.com/vim/vim/security/advisories/GHSA-mr87-rhgv-7pw6",
+        "sources": [
+          "cvelistv5",
+          "debian",
+          "nvd",
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19c6cb52f89a365b4",
+        "sources": [
+          "debian"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/commit/7ab76a86048ed492374ac6b19",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://github.com/vim/vim/releases/tag/v9.2.0316",
+        "sources": [
+          "cvelistv5",
+          "nvd"
+        ]
+      },
+      {
+        "url": "https://www.cve.org/CVERecord?id=CVE-2026-39881",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8213-1",
+        "sources": [
+          "ubuntu"
+        ]
+      },
+      {
+        "url": "https://ubuntu.com/security/notices/USN-8246-1",
+        "sources": [
+          "ubuntu"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Summary
  
  Thirteen commits hardening the CVE backport pipeline against real failures hit in live runs (binutils, libxml2, gstreamer), plus an
  over-engineering cleanup pass. Changes span all three tools (cve-corrector, cve-agent, cve-metadata-extractor) and the shared/ layer.
  
  Changes
  
  cve-agent — session & branch correctness
  
  - Land AI fixes on the CVE branch, not devtool. The corrector leaves the throwaway devtool branch checked out and the agent's allow-list forbids
  branch switching, so fixes were amended onto devtool, orphaned, and silently reverted on the next resume. Adds _ensure_cve_branch() (switch +
  restore devtool-tracked tarball files) and surfaces pre-session setup progress.
  - Skip approval for no-op build/ptest sessions. When a session changes nothing, the orchestrator no longer prompts for approval of a
  non-existent fix and instead retries (HEAD snapshot before/after). Conflict resolutions still show approval, since taking the existing version
  verbatim is a valid fix. Review is shown before finalizing (before --continue's devtool finish removes the workspace).
  - Allow scoped git status --porcelain -- <path> in both agent configs and document it; clarify that tarball-extracted untracked files are
  intentional; make build verification a hard requirement with bounded log reading.
  
  cve-corrector — robustness fixes
  
  - Fail soft when the devtool workspace is gone. _git_commit_subject() crashed with an uncaught FileNotFoundError in --bbappend mode after
  devtool reset (reproduced: binutils/CVE-2026-18220 on scarthgap). Now returns None and takes the tested tag-every-patch fallback.
  - Reset devtool to patched base before re-transfer. On a build/ptest resume after the agent amended the CVE commit, re-transfer was aborting
  with AlreadyAppliedError due to a stale patch-id match. Adds reset_devtool_to_base() (resets to devtool-patched, preserving recipe SRC_URI
  patches; falls back to devtool-base).
  - Add --premirror for bitbake-style git mirrors (host/path joined by dots, .git stripped), with transparent fallback to upstream.
  - Fix find_exact_tag for mixed-separator tags (binutils-2_46.1 ↔ 2.46.1).
  - Fix CVE_STATUS mapping and filter non-release tags — map version-based reasons to fixed-version; drop branchpoint/rc/snapshot tags from blame
  analysis.
  - Fix SRC_URI patch insertion into scoped overrides — check sibling .inc files, avoid SRC_URI:append:class-*, fall back to a new unscoped
  SRC_URI:append.
  - Print build-failure instructions on build/ptest error.
  
  url-parser
  
  - Fix gitweb deduction for sourceware URLs without ;a= — ?p=<repo>;h=<hash> now parses the repo name instead of yielding .../gitweb.cgi.
  
  shared
  
  - Move copy_missing_files_from_devtool (+ _get_submodule_paths) into shared/git_runner.py so the corrector and agent share one implementation;
  re-exported from cve_corrector.git_ops for existing callers.
  
  Cleanup (treewide)
  
  - Delete the unused mirror-creation cluster from cve_metadata_extractor; remove the dead AGENT_INSTRUCTIONS constant; collapse the
  run_cmd_capture passthrough into a direct re-export; drop a no-op else branch. No behavior change.
  
  Testing
  
  - New/expanded unit tests for every fix above (test_ensure_cve_branch, test_noop_session_skip_approval, test_cherry_pick_devtool_git,
  test_bitbake_ops, test_blame, test_meta_layer_export, test_patch, test_git_ops, test_workflow_full).
  - Full gate green: ruff check ., mypy (49 files), pytest (1210 passed / 7 skipped, coverage ~80%).
  
  Net diff: 34 files, +1646/−240.