### PR TITLE
cve-agent: reliability and context-efficiency improvements for CVE backporting

### DIFF
--- a/.kiro/agents/yocto-cve-backport-interactive.json
+++ b/.kiro/agents/yocto-cve-backport-interactive.json
@@ -46,6 +46,7 @@
         "^git merge-base .*$",
         "^git format-patch .*$",
         "^devtool build .*$",
+        "^bitbake -c cleansstate [^-;&|$`\\s][^;&|$`\\s]*$",
         "^tee [^;&|$`\\n]*/cve_agent/[^;&|$`\\n]*\\.log$",
         "^echo \"Exit code: \\$\\?\"$",
         "^echo \"Exit code: \\$\\{PIPESTATUS\\[0\\]\\}\"$",

--- a/.kiro/agents/yocto-cve-backport.json
+++ b/.kiro/agents/yocto-cve-backport.json
@@ -45,6 +45,7 @@
         "^git rev-parse .*$",
         "^git merge-base .*$",
         "^devtool build .*$",
+        "^bitbake -c cleansstate [^-;&|$`\\s][^;&|$`\\s]*$",
         "^tee [^;&|$`\\n]*/cve_agent/[^;&|$`\\n]*\\.log$",
         "^echo \"Exit code: \\$\\?\"$",
         "^echo \"Exit code: \\$\\{PIPESTATUS\\[0\\]\\}\"$",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,10 @@
 │   ├── backend.py               # AIBackend interface + backend registry
 │   ├── kiro_backend.py          # KiroBackend (drives `kiro-cli`, default)
 │   ├── claude_backend.py        # ClaudeBackend (drives the `claude` CLI)
-│   └── context.py / knowledge.py / review.py
+│   ├── context.py / knowledge.py / review.py
+│   ├── AGENT_INSTRUCTIONS.md    # Phase-independent core AI system prompt
+│   └── instructions/           # Per-phase workflow fragments embedded into
+│                               # context.md by exit code (conflict/build/ptest)
 ├── extra/                       # Plugin directory (.gitignore'd .py files)
 └── tests/{agent,corrector,extractor,shared}/
 ```

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -1,4 +1,3 @@
-<!-- SPDX-License-Identifier: MIT -->
 # CVE Backport Agent Instructions
 
 ## Available Tools
@@ -70,7 +69,8 @@ Bash commands you CAN run:
 - Commit: `git commit -m "<msg>"`, `git commit -F <file>`, `git commit --amend
   --no-edit`, `git commit --amend -m "<msg>"`, `git commit --amend -F <file>`.
 - Build: `devtool build *`.
-- Recover stale build state (see §3): `bitbake -c cleansstate <recipe>` — a
+- Recover stale build state (see the Build Error phase instructions in
+  `context.md`): `bitbake -c cleansstate <recipe>` — a
   single recipe name, no chaining. Forces the recipe's tasks to re-run from
   scratch (e.g. so `do_configure` regenerates files a stale sstate restore
   left missing). No other `bitbake` subcommand is permitted.
@@ -130,7 +130,8 @@ a different name, signature, or location?**
 If a function was renamed, a signature changed, a struct member renamed, or a
 function moved, the functionality is already present — this is *adaptation, not
 a prerequisite*. Adapt the fix in place to match the stable name/shape and do
-**NOT** cherry-pick anything. See **Common Conflict Patterns** below. This is
+**NOT** cherry-pick anything. See **Common Conflict Patterns** in the
+conflict-resolution instructions. This is
 the common case.
 
 **Step 2 — only if the referenced code genuinely does NOT exist in the stable
@@ -229,124 +230,10 @@ or feature and the version. Example:
 
 After writing the conclusion file, **stop — do not make any other changes.**
 
-### 2. Resolve Conflicts (exit code 1)
-```bash
-git status && git diff                      # examine conflicts
-git ls-files -u                             # unmerged stages (1=base, 2=ours, 3=theirs)
-git show <upstream_sha>                     # upstream fix intent
-git log --oneline -20 -- <file>             # file history for context
-```
-
-Resolve each conflicted file. Three shapes come up, in increasing order of
-effort — prefer the cheapest one that is correct:
-
-1. **Take one side wholesale.** If the resolution is "keep upstream verbatim"
-   or "drop the upstream hunk entirely", do it with git rather than an editor:
-   ```bash
-   git checkout --theirs <file>   # keep the upstream (cherry-picked) side
-   git checkout --ours <file>     # keep the stable-branch side
-   ```
-2. **Partial resolution.** Neither side is right on its own — edit the file
-   with your editing tool, removing all conflict markers.
-3. **Drop a path from the cherry-pick.** If upstream deletes a file, mark it
-   with `git rm <file>`. If a conflicted path exists only in the upstream
-   history and not in this workspace (a submodule/gitlink recorded upstream
-   against a tarball-sourced recipe is the common case — confirm with `git
-   submodule status`), unstage it instead of trying to materialise it:
-   ```bash
-   git restore --staged <path>    # index-only; the working tree is untouched
-   ```
-
-Then stage the resolutions:
-```bash
-git add <resolved_files>                    # ONLY allowed files
-```
-
-If the cherry-pick as a whole turns out not to apply to this version, `git
-cherry-pick --skip` drops it (`--abort` stops the sequence entirely).
-
-If you adapted the patch (not a verbatim cherry-pick), append your backport
-notes to `.git/MERGE_MSG` — **read the file first**, keep the original content,
-and append your notes after a blank line. Then:
-```bash
-git cherry-pick --no-edit --continue
-```
-
-### 3. Fix Build Errors (exit code 4)
-Run the build to reproduce the failure:
-```bash
-devtool build <recipe> 2>&1 | tee <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
-```
-Only read log output on failure (`Exit code:` is non-zero). On failure, read
-the **last 50 lines** of `<agent_dir>/build.log` to identify the error.
-
-**Stale build state — recover, do NOT escalate.** If the build fails because a
-task was restored from sstate/skipped and a file it should have generated is
-missing, the recipe's cached build state is stale — this is **not** a defect in
-your patch and **not** grounds for escalation. The classic signatures are:
-- `cp: cannot stat '.config.orig'` (busybox), or any "No such file or
-  directory" for a file a configure/prepare step produces; and/or
-- a task log showing only `do_compile` ran while `do_configure` was skipped.
-
-Recover by forcing this recipe to rebuild from scratch, then re-verify:
-```bash
-bitbake -c cleansstate <recipe>
-devtool build <recipe> 2>&1 | tee <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
-```
-`cleansstate` drops the recipe's stale sstate so `do_configure` actually
-re-executes and regenerates the missing files. Do this before concluding a
-build failure is environmental.
-
-If the failing task belongs to a **different recipe** than the one being
-patched, **abort immediately** — do not attempt to fix it. This indicates a
-pre-existing or environmental issue.
-Otherwise, fix the code, amend the commit, and re-run the build to verify.
-
-### 4. Fix Test Failures (exit code 3)
-
-The context file lists the **failing test cases** and the **before/after** pass
-counts. Understand *why* the backport made them fail before changing anything —
-a ptest regression is almost always one of two things:
-
-**(a) A defect in the backport.** Your adaptation changed behavior in a way the
-test correctly rejects (a mis-resolved conflict, a dropped hunk, a wrong
-signature or sign). Re-read the failing test to see what behavior it asserts,
-compare against the upstream fix intent (`git show <upstream_sha>`), and correct
-the C/source **in the allowed files only**. Amend and re-verify.
-
-**(b) An expected behavior change upstream shipped a companion commit for.**
-Some fixes deliberately change observable behavior, and upstream updates the
-test suite (or adds a follow-up fix) in a *separate* commit. The failing test
-then needs that companion commit — not a hand-edit. **Never hand-edit test
-files**; test cases must not be changed by you.
-
-To tell (a) from (b), look for a follow-up in upstream history. The workspace
-has the full upstream history fetched as the `upstream` remote, so search it
-directly:
-```bash
-git show <upstream_sha>                                                  # the fix you backported
-git log --oneline <upstream_sha>..upstream/master -- <failing_test_file> # later commits touching that test
-git log --oneline <upstream_sha>..upstream/master -- <code_area>         # or the code area under test
-git show <candidate_sha>                                                 # confirm it addresses the failing case
-```
-Derive `<failing_test_file>` from the failing-case names in the context (e.g. a
-`tar` case lives in `testsuite/tar.tests`). If `upstream/master` does not exist,
-try `upstream/main`.
-
-Then choose:
-- **Companion commit touches only Allowed Files** → cherry-pick it as a
-  separate follow-up commit (Strategy A) and re-verify.
-- **Companion commit touches files OUTSIDE the Allowed Files** (a test-suite
-  update almost always does) → do NOT edit those files. Escalate with a
-  `suggested_commits` entry naming the exact SHA you confirmed (see "Suggesting
-  a commit for a scope extension"), so a human or `--trust` can re-run with it
-  added to the fix chain and your scope widened.
-- **No companion commit exists and it is a real backport defect** → fix the code
-  in the allowed files.
-
-Document in the `Conflicts Resolved:` commit-message block: which ptest cases
-failed, the cause, and either the code change that fixed them or the companion
-commit you suggested.
+> The phase-specific steps for the current run — resolving conflicts (exit 1),
+> fixing build errors (exit 4), or fixing ptest regressions (exit 3) — are
+> provided in the `context.md` for this session, under its "Instructions"
+> section. Follow those together with the always-applicable rules here.
 
 ### 5. Build Verification (mandatory after every change)
 **You MUST verify the build passes before finishing.** Do not declare success
@@ -400,15 +287,6 @@ make/cmake/gcc directly.
 - **Check dependencies** — look for `Link:` in commit, prerequisite patches
 - **If uncertain, stop** — flag for human review rather than guess
 
-## Common Conflict Patterns
-
-| Pattern | Resolution | Commit Note |
-|---|---|---|
-| Function signature changed | Keep fix logic, adapt to stable signature | `Adapted foo_v2() to foo_v1() API` |
-| Struct member renamed | Use stable member name with upstream logic | `Member renamed netdev→ndev in original patch` |
-| Function moved to different file | Apply fix where function lives in stable | `Function in old_file.c in original patch` |
-| Missing helper function | Inline it or use stable equivalent | `Inlined helper_foo() (not in stable)` |
-
 ## Commit Message Format
 
 **IMPORTANT: Preserve the original upstream commit message.** The `.git/MERGE_MSG`
@@ -449,10 +327,12 @@ Rules:
   types, APIs, and why the stable branch differs
 - **No duplication**: each fact (what changed, in which function, why) must
   appear exactly once
-- **Be succinct**: use as few sentences and lines as possible while still
-  covering what/why/how. Cut restatements, filler, and any detail a reviewer
-  wouldn't need (e.g. exact test-run counts, step-by-step narration). One
-  short paragraph per conflicted file is usually enough.
+- **Be succinct — hard limit**: at most 2–3 lines (~40 words) per file. State
+  only the *adaptation*: what changed and the stable-vs-upstream reason. Do NOT
+  include the investigation that led you there — no "checked upstream history",
+  no "no companion commit exists", no describing how unrelated code paths handle
+  the case, no test-run counts or step-by-step narration. If you cherry-picked
+  or suggested a companion commit, name it in one clause.
 - Omitted files: `<file>: omitted (not in branch)`
 - Do NOT add a "Changes from upstream" section (the agent generates that)
 - If you adapted the patch (not a verbatim cherry-pick), add a trailer line

--- a/cve_agent/AGENT_INSTRUCTIONS.md
+++ b/cve_agent/AGENT_INSTRUCTIONS.md
@@ -28,6 +28,15 @@ of tool names:
   what the allow-list says. To capture output to a file, pipe into `tee`
   instead: `<cmd> 2>&1 | tee <agent_dir>/<name>.log`. Merging stderr with
   `2>&1` is fine; only the `>`/`>>` file-write form is refused.
+- **Creating or editing any file goes through your file-writing/editing
+  tool — never the shell.** The command runner's only file-writing power is
+  capturing build output to a `.log` file via `tee` (above). Everything else
+  you need to write or change — `conclusion.json`, source-file edits, and
+  appending your notes to `.git/MERGE_MSG` — must use your file-writing/editing
+  tool (its name is in the preamble that precedes these instructions). Do NOT
+  use `cat > file`, a heredoc (`<< 'EOF'`), or `tee` to write these: `>`/`>>`
+  are refused outright and `tee` is limited to `.log` capture, so those forms
+  will fail and leave the file unwritten.
 - **Never write files outside the agent dir or the Yocto build dir** — the
   only two locations you have any reason to write to are `<agent_dir>`
   (given in the context header, for logs like `build.log`) and paths under
@@ -61,6 +70,10 @@ Bash commands you CAN run:
 - Commit: `git commit -m "<msg>"`, `git commit -F <file>`, `git commit --amend
   --no-edit`, `git commit --amend -m "<msg>"`, `git commit --amend -F <file>`.
 - Build: `devtool build *`.
+- Recover stale build state (see §3): `bitbake -c cleansstate <recipe>` — a
+  single recipe name, no chaining. Forces the recipe's tasks to re-run from
+  scratch (e.g. so `do_configure` regenerates files a stale sstate restore
+  left missing). No other `bitbake` subcommand is permitted.
 - Capture build output: `tee <agent_dir>/<name>.log` (only paths under a
   `cve_agent/` directory ending in `.log`), and
   `echo "Exit code: ${PIPESTATUS[0]}"` / `echo "Exit code: $?"` verbatim.
@@ -151,13 +164,34 @@ branch in any form is it a real prerequisite.** Then choose one of:
   - it itself depends on further prerequisites (a dependency chain).
 
   Write an escalation conclusion and stop — do not mark the CVE not-applicable,
-  because it *is* applicable, just not safe to automate:
-  ```bash
-  cat > "<agent_dir>/conclusion.json" <<'EOF'
+  because it *is* applicable, just not safe to automate. Create
+  `<agent_dir>/conclusion.json` **with your file-writing tool** (not the shell —
+  see Available Tools) with these contents:
+  ```json
   {"needs_human": true, "reason": "<why this prerequisite can't be safely automated, naming the prerequisite SHA and what it changes>"}
-  EOF
   ```
   Replace `<agent_dir>` with the actual agent dir path from the context header.
+  After writing the file, **stop — make no other changes.**
+
+  **Suggesting a commit for a scope extension.** When the blocker is a specific
+  companion or prerequisite commit that touches files **outside** your Allowed
+  Files list — for example, a follow-up that updates a testsuite/ file to match
+  new behavior, or a prerequisite you may not cherry-pick because its files are
+  out of scope — name it in a `suggested_commits` array. A human (or `--trust`)
+  can then accept it, and the backport re-runs with that commit added to the
+  fix chain and your allowed-files scope widened to include its files. Create
+  `<agent_dir>/conclusion.json` **with your file-writing tool** with these
+  contents:
+  ```json
+  {"needs_human": true,
+   "reason": "ptest regresses because upstream <sha> updates testsuite/tar.tests to match the new hardlink-stripping behavior, but that file is outside my Allowed Files",
+   "suggested_commits": ["<sha>"]}
+  ```
+  Each entry is a **full commit SHA** (preferred) or a full commit **URL** in
+  the same repository as the fix. List them in application order (earliest
+  prerequisite first). Only suggest commits you have confirmed exist and are
+  relevant — verify with `git show <sha>` first. If you cannot name a concrete
+  commit, omit `suggested_commits` and escalate with the reason alone.
   After writing the file, **stop — make no other changes.**
 
 **Files not in the baseline**: If the upstream commit adds a NEW file that is
@@ -180,12 +214,12 @@ If the patch is incompatible with the stable base, adapt it.
 
 If the CVE fix is **not applicable** to this version (e.g. the vulnerable code
 path, function, struct, or feature does not exist in the stable branch), do NOT
-make any code changes. Instead, write a conclusion file:
+make any code changes. Instead, write a conclusion file **with your
+file-writing tool** (not the shell — see Available Tools) at
+`<agent_dir>/conclusion.json` with these contents:
 
-```bash
-cat > "<agent_dir>/conclusion.json" <<'EOF'
+```json
 {"not_applicable": true, "reason": "<one-line explanation of why the CVE does not apply>"}
-EOF
 ```
 
 Replace `<agent_dir>` with the actual agent dir path from the context header.
@@ -241,20 +275,78 @@ git cherry-pick --no-edit --continue
 ### 3. Fix Build Errors (exit code 4)
 Run the build to reproduce the failure:
 ```bash
-devtool build <recipe> 2>&1 > <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
+devtool build <recipe> 2>&1 | tee <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
 ```
 Only read log output on failure (`Exit code:` is non-zero). On failure, read
 the **last 50 lines** of `<agent_dir>/build.log` to identify the error.
+
+**Stale build state — recover, do NOT escalate.** If the build fails because a
+task was restored from sstate/skipped and a file it should have generated is
+missing, the recipe's cached build state is stale — this is **not** a defect in
+your patch and **not** grounds for escalation. The classic signatures are:
+- `cp: cannot stat '.config.orig'` (busybox), or any "No such file or
+  directory" for a file a configure/prepare step produces; and/or
+- a task log showing only `do_compile` ran while `do_configure` was skipped.
+
+Recover by forcing this recipe to rebuild from scratch, then re-verify:
+```bash
+bitbake -c cleansstate <recipe>
+devtool build <recipe> 2>&1 | tee <agent_dir>/build.log; echo "Exit code: ${PIPESTATUS[0]}"
+```
+`cleansstate` drops the recipe's stale sstate so `do_configure` actually
+re-executes and regenerates the missing files. Do this before concluding a
+build failure is environmental.
+
 If the failing task belongs to a **different recipe** than the one being
 patched, **abort immediately** — do not attempt to fix it. This indicates a
 pre-existing or environmental issue.
 Otherwise, fix the code, amend the commit, and re-run the build to verify.
 
 ### 4. Fix Test Failures (exit code 3)
-Fix the **backported code in the allowed files only**.
-If the fix requires changing a file not in the allowed list, stop and
-flag for human review. Document which tests failed and what code change
-fixed them in the commit message.
+
+The context file lists the **failing test cases** and the **before/after** pass
+counts. Understand *why* the backport made them fail before changing anything —
+a ptest regression is almost always one of two things:
+
+**(a) A defect in the backport.** Your adaptation changed behavior in a way the
+test correctly rejects (a mis-resolved conflict, a dropped hunk, a wrong
+signature or sign). Re-read the failing test to see what behavior it asserts,
+compare against the upstream fix intent (`git show <upstream_sha>`), and correct
+the C/source **in the allowed files only**. Amend and re-verify.
+
+**(b) An expected behavior change upstream shipped a companion commit for.**
+Some fixes deliberately change observable behavior, and upstream updates the
+test suite (or adds a follow-up fix) in a *separate* commit. The failing test
+then needs that companion commit — not a hand-edit. **Never hand-edit test
+files**; test cases must not be changed by you.
+
+To tell (a) from (b), look for a follow-up in upstream history. The workspace
+has the full upstream history fetched as the `upstream` remote, so search it
+directly:
+```bash
+git show <upstream_sha>                                                  # the fix you backported
+git log --oneline <upstream_sha>..upstream/master -- <failing_test_file> # later commits touching that test
+git log --oneline <upstream_sha>..upstream/master -- <code_area>         # or the code area under test
+git show <candidate_sha>                                                 # confirm it addresses the failing case
+```
+Derive `<failing_test_file>` from the failing-case names in the context (e.g. a
+`tar` case lives in `testsuite/tar.tests`). If `upstream/master` does not exist,
+try `upstream/main`.
+
+Then choose:
+- **Companion commit touches only Allowed Files** → cherry-pick it as a
+  separate follow-up commit (Strategy A) and re-verify.
+- **Companion commit touches files OUTSIDE the Allowed Files** (a test-suite
+  update almost always does) → do NOT edit those files. Escalate with a
+  `suggested_commits` entry naming the exact SHA you confirmed (see "Suggesting
+  a commit for a scope extension"), so a human or `--trust` can re-run with it
+  added to the fix chain and your scope widened.
+- **No companion commit exists and it is a real backport defect** → fix the code
+  in the allowed files.
+
+Document in the `Conflicts Resolved:` commit-message block: which ptest cases
+failed, the cause, and either the code change that fixed them or the companion
+commit you suggested.
 
 ### 5. Build Verification (mandatory after every change)
 **You MUST verify the build passes before finishing.** Do not declare success
@@ -357,6 +449,10 @@ Rules:
   types, APIs, and why the stable branch differs
 - **No duplication**: each fact (what changed, in which function, why) must
   appear exactly once
+- **Be succinct**: use as few sentences and lines as possible while still
+  covering what/why/how. Cut restatements, filler, and any detail a reviewer
+  wouldn't need (e.g. exact test-run counts, step-by-step narration). One
+  short paragraph per conflicted file is usually enough.
 - Omitted files: `<file>: omitted (not in branch)`
 - Do NOT add a "Changes from upstream" section (the agent generates that)
 - If you adapted the patch (not a verbatim cherry-pick), add a trailer line

--- a/cve_agent/agents/yocto-cve-backport-interactive.json
+++ b/cve_agent/agents/yocto-cve-backport-interactive.json
@@ -46,6 +46,7 @@
         "^git merge-base .*$",
         "^git format-patch .*$",
         "^devtool build .*$",
+        "^bitbake -c cleansstate [^-;&|$`\\s][^;&|$`\\s]*$",
         "^tee [^;&|$`\\n]*/cve_agent/[^;&|$`\\n]*\\.log$",
         "^echo \"Exit code: \\$\\?\"$",
         "^echo \"Exit code: \\$\\{PIPESTATUS\\[0\\]\\}\"$",

--- a/cve_agent/agents/yocto-cve-backport.json
+++ b/cve_agent/agents/yocto-cve-backport.json
@@ -45,6 +45,7 @@
         "^git rev-parse .*$",
         "^git merge-base .*$",
         "^devtool build .*$",
+        "^bitbake -c cleansstate [^-;&|$`\\s][^;&|$`\\s]*$",
         "^tee [^;&|$`\\n]*/cve_agent/[^;&|$`\\n]*\\.log$",
         "^echo \"Exit code: \\$\\?\"$",
         "^echo \"Exit code: \\$\\{PIPESTATUS\\[0\\]\\}\"$",

--- a/cve_agent/claude_backend.py
+++ b/cve_agent/claude_backend.py
@@ -81,6 +81,7 @@ _ALLOWED_TOOLS = (
     "Bash(git rev-parse:*)",
     "Bash(git merge-base:*)",
     "Bash(devtool build:*)",
+    "Bash(bitbake -c cleansstate:*)",
     "Bash(tee:*)",
     "Bash(echo:*)",
     "Bash(cat:*)",

--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -23,10 +23,18 @@ from . import (
     EXIT_PTEST_ERROR,
     get_agent_dir,
     get_build_dir,
-    resolve_agent_instructions,
 )
 from .git import get_all_upstream_shas, get_upstream_sha, run_capture, run_git_stdout
 from .interdiff import generate_interdiff
+
+# Per-phase workflow fragments embedded into context.md by exit code. The
+# phase-independent core is delivered separately via the system prompt; exit 0
+# (analysis) has no fragment — the core's Analyse step covers it.
+_PHASE_INSTRUCTION_FILES = {
+    EXIT_CONFLICT: "conflict.md",
+    EXIT_BUILD_ERROR: "build.md",
+    EXIT_PTEST_ERROR: "ptest.md",
+}
 
 
 def build_context(workspace_path: Path, exit_code: int, cve_id: str,
@@ -53,7 +61,7 @@ def build_context(workspace_path: Path, exit_code: int, cve_id: str,
     sections = [
         _build_header(cve_id, recipe, exit_code, workspace_path, cve_info,
                       model, backend),
-        _build_phase_instructions(),
+        _build_phase_instructions(exit_code),
         _gather_context_for_exit_code(workspace_path, exit_code, cve_info),
     ]
 
@@ -80,7 +88,8 @@ def build_context(workspace_path: Path, exit_code: int, cve_id: str,
             )
         feedback_file.unlink()
 
-    context_file.write_text('\n\n'.join(sections), encoding='utf-8')
+    context_file.write_text('\n\n'.join(s for s in sections if s),
+                            encoding='utf-8')
     return context_file
 
 
@@ -176,24 +185,29 @@ def _build_header(cve_id: str, recipe: str, exit_code: int,
     )
 
 
-def _build_phase_instructions() -> str:
-    """Reference agent instructions without re-embedding their full text.
+def _build_phase_instructions(exit_code: int) -> str:
+    """Return the phase-specific workflow instructions for this exit code.
 
-    The full AGENT_INSTRUCTIONS.md content already reaches the model via the
-    session's system prompt (the kiro-cli agent's ``prompt: file://...``
-    field, or the ``claude`` CLI's ``--append-system-prompt``; see
-    ``cve_agent.kiro_backend`` / ``cve_agent.claude_backend``). Embedding it
-    again here would just pay its token cost a second (or third) time on
-    every context.md this function contributes to, including retries, with
-    no new information. A short pointer is enough since the workflow steps
-    are already active in the model's system prompt.
+    The phase-independent core (tools, scope rules, analysis, build
+    verification, commit format) reaches the model via the session's system
+    prompt (kiro-cli's ``prompt: file://...`` / the ``claude`` CLI's
+    ``--append-system-prompt``; see ``cve_agent.kiro_backend`` /
+    ``cve_agent.claude_backend``). The per-phase steps live in small fragment
+    files under ``cve_agent/instructions/`` and are embedded here into
+    ``context.md`` for the matching exit code ONLY, so a session receives just
+    the workflow its phase needs instead of the whole manual.
+
+    Returns an empty string when there is no fragment for the exit code
+    (analysis / exit 0) or the file is missing, so ``build_context`` omits the
+    section entirely.
     """
-    instructions_path = resolve_agent_instructions()
-    if not instructions_path.exists():
-        return "## Instructions\n\nSee cve_agent/AGENT_INSTRUCTIONS.md for workflow details."
-    return ("## Instructions\n\nFollow the workflow, scope rules, and commit "
-            "message format from AGENT_INSTRUCTIONS.md (already provided as "
-            "your system prompt / agent instructions for this session).")
+    filename = _PHASE_INSTRUCTION_FILES.get(exit_code)
+    if not filename:
+        return ""
+    fragment = Path(__file__).parent / "instructions" / filename
+    if not fragment.is_file():
+        return ""
+    return f"## Instructions\n\n{fragment.read_text(encoding='utf-8').strip()}"
 
 
 def _gather_context_for_exit_code(workspace_path: Path, exit_code: int,
@@ -250,7 +264,11 @@ def _gather_conflict_context(workspace_path: Path, cve_info: dict) -> str:
 
 
 def _gather_build_error_context(workspace_path: Path) -> str:
-    """Gather context for build error resolution.
+    """Gather the dynamic build-error data (last commit; log pointers).
+
+    The static how-to-fix guidance (stale-sstate recovery, cross-recipe
+    aborts) lives in the ``build.md`` phase fragment embedded alongside this
+    section in ``context.md`` — it is not repeated here.
 
     Args:
         workspace_path: Path to workspace where build failed.
@@ -263,23 +281,21 @@ def _gather_build_error_context(workspace_path: Path) -> str:
     return (
         f"## Build Error Details\n\n"
         f"### Last Commit (stat)\n```\n{last_commit}\n```\n\n"
-        f"Run `git show HEAD` to see the full diff.\n\n"
-        f"Check build logs in the Yocto build directory for specific errors.\n"
-        f"Run `devtool build <recipe>` to reproduce.\n\n"
-        f"**Stale build state**: if the failure is a missing generated file "
-        f"from a skipped/sstate-restored task — e.g. "
-        f"`cp: cannot stat '.config.orig'`, or a log showing only `do_compile` "
-        f"ran while `do_configure` was skipped — the recipe's sstate is stale, "
-        f"not your patch. Recover with `bitbake -c cleansstate <recipe>` then "
-        f"rebuild; do NOT escalate for this (see §3 of the instructions)."
+        f"Run `git show HEAD` to see the full diff. Check the build logs in "
+        f"the Yocto build directory (paths in the context header) for the "
+        f"specific error, and `devtool build <recipe>` to reproduce."
     )
 
 
 def _gather_ptest_error_context(workspace_path: Path, cve_info: dict) -> str:
-    """Gather context for ptest failure resolution.
+    """Gather the dynamic ptest-failure data (results, last commit, SHAs).
 
     Reads the cve_corrector state file to extract before/after ptest results
-    and the ptest log files for detailed failure information.
+    and the ptest log files for detailed failure information. The static
+    how-to-fix guidance (defect-vs-companion-commit triage, upstream history
+    search, ``suggested_commits`` escalation, "never hand-edit tests") lives
+    in the ``ptest.md`` phase fragment embedded alongside this section in
+    ``context.md`` — it is not repeated here.
 
     Args:
         workspace_path: Path to workspace where ptest failed.
@@ -299,48 +315,7 @@ def _gather_ptest_error_context(workspace_path: Path, cve_info: dict) -> str:
         f"{ptest_section}\n\n"
         f"### Last Commit (stat)\n```\n{last_commit}\n```\n\n"
         f"Run `git show HEAD` for the current backport, and `git show {sha}` "
-        f"for the upstream fix you backported.\n\n"
-        f"### What to fix and what to look for\n\n"
-        f"Classify each failing case before changing anything — a ptest "
-        f"regression is almost always one of two things:\n\n"
-        f"1. **A defect in the backport.** Your adaptation changed behavior in "
-        f"a way the test correctly rejects (mis-resolved conflict, dropped "
-        f"hunk, wrong signature/sign). Re-read the failing test to see what it "
-        f"asserts, compare with the upstream intent (`git show {sha}`), and fix "
-        f"the C/source **in the allowed files only**.\n"
-        f"2. **An expected behavior change upstream shipped a companion commit "
-        f"for.** Some fixes deliberately change observable behavior and "
-        f"upstream updates the test suite (or adds a follow-up fix) in a "
-        f"*separate* commit. The failing test then needs that commit — not a "
-        f"hand-edit.\n\n"
-        f"To tell them apart, search upstream history for a follow-up. The full "
-        f"upstream history is fetched as the `upstream` remote:\n"
-        f"```\n"
-        f"git log --oneline {sha}..upstream/master -- <failing_test_file>   "
-        f"# later commits touching that test (try upstream/main if master is absent)\n"
-        f"git log --oneline {sha}..upstream/master -- <code_area_under_test>\n"
-        f"git show <candidate_sha>                                          "
-        f"# confirm it addresses the failing case\n"
-        f"```\n"
-        f"Derive `<failing_test_file>` from the failing-case names above "
-        f"(e.g. a `tar` case lives in `testsuite/tar.tests`).\n\n"
-        f"Then:\n"
-        f"- **Companion commit touches only Allowed Files** \u2192 cherry-pick it "
-        f"as a separate follow-up commit (Strategy A) and re-verify.\n"
-        f"- **Companion commit touches files OUTSIDE the Allowed Files** (a "
-        f"testsuite update almost always does) \u2192 do NOT hand-edit those "
-        f"files. Escalate naming that commit in `suggested_commits` (see "
-        f"\"Suggesting a commit for a scope extension\") so the run can be "
-        f"retried with it added to the fix chain and your scope widened. Give "
-        f"the exact SHA you confirmed with `git show`.\n"
-        f"- **No companion commit and it is a real backport defect** \u2192 fix "
-        f"the code in the allowed files.\n\n"
-        f"**Rule**: Never hand-edit test cases — only backported source files "
-        f"may be modified directly. A legitimate upstream test update must come "
-        f"in as its own commit via `suggested_commits`, not by editing tests.\n\n"
-        f"In the `Conflicts Resolved:` commit message section, document: which "
-        f"ptest cases failed, the cause, and either the code change that fixed "
-        f"them or the companion commit you suggested."
+        f"for the upstream fix you backported."
     )
 
 

--- a/cve_agent/context.py
+++ b/cve_agent/context.py
@@ -213,7 +213,7 @@ def _gather_context_for_exit_code(workspace_path: Path, exit_code: int,
     if exit_code == EXIT_BUILD_ERROR:
         return _gather_build_error_context(workspace_path)
     if exit_code == EXIT_PTEST_ERROR:
-        return _gather_ptest_error_context(workspace_path)
+        return _gather_ptest_error_context(workspace_path, cve_info)
     return _gather_analysis_context(workspace_path, cve_info)
 
 
@@ -265,11 +265,17 @@ def _gather_build_error_context(workspace_path: Path) -> str:
         f"### Last Commit (stat)\n```\n{last_commit}\n```\n\n"
         f"Run `git show HEAD` to see the full diff.\n\n"
         f"Check build logs in the Yocto build directory for specific errors.\n"
-        f"Run `devtool build <recipe>` to reproduce."
+        f"Run `devtool build <recipe>` to reproduce.\n\n"
+        f"**Stale build state**: if the failure is a missing generated file "
+        f"from a skipped/sstate-restored task — e.g. "
+        f"`cp: cannot stat '.config.orig'`, or a log showing only `do_compile` "
+        f"ran while `do_configure` was skipped — the recipe's sstate is stale, "
+        f"not your patch. Recover with `bitbake -c cleansstate <recipe>` then "
+        f"rebuild; do NOT escalate for this (see §3 of the instructions)."
     )
 
 
-def _gather_ptest_error_context(workspace_path: Path) -> str:
+def _gather_ptest_error_context(workspace_path: Path, cve_info: dict) -> str:
     """Gather context for ptest failure resolution.
 
     Reads the cve_corrector state file to extract before/after ptest results
@@ -277,25 +283,64 @@ def _gather_ptest_error_context(workspace_path: Path) -> str:
 
     Args:
         workspace_path: Path to workspace where ptest failed.
+        cve_info: CVE metadata dict (used to resolve the upstream SHA so the
+            agent can search upstream history for a companion fix).
 
     Returns:
         Formatted ptest error context string.
     """
     last_commit = run_git_stdout(['show', '--stat', 'HEAD'], cwd=workspace_path)
     ptest_section = _read_ptest_results(workspace_path)
+    upstream_sha = get_upstream_sha(cve_info, workspace_path)
+    sha = upstream_sha if upstream_sha and upstream_sha != "unknown" else "<upstream_sha>"
 
     return (
         f"## Test Failure Details\n\n"
         f"{ptest_section}\n\n"
         f"### Last Commit (stat)\n```\n{last_commit}\n```\n\n"
-        f"Run `git show HEAD` to see the full diff.\n\n"
-        f"**Rule**: Test cases must NEVER change. Only backported files may be "
-        f"modified.\nAnalyse the backport commit intent and adjust it to pass "
-        f"tests while preserving the fix.\n\n"
-        f"In the `### Conflicts Resolved` commit message section, document:\n"
-        f"- Which ptest cases failed\n"
-        f"- What code change caused the failure\n"
-        f"- How the backported code was corrected to fix it"
+        f"Run `git show HEAD` for the current backport, and `git show {sha}` "
+        f"for the upstream fix you backported.\n\n"
+        f"### What to fix and what to look for\n\n"
+        f"Classify each failing case before changing anything — a ptest "
+        f"regression is almost always one of two things:\n\n"
+        f"1. **A defect in the backport.** Your adaptation changed behavior in "
+        f"a way the test correctly rejects (mis-resolved conflict, dropped "
+        f"hunk, wrong signature/sign). Re-read the failing test to see what it "
+        f"asserts, compare with the upstream intent (`git show {sha}`), and fix "
+        f"the C/source **in the allowed files only**.\n"
+        f"2. **An expected behavior change upstream shipped a companion commit "
+        f"for.** Some fixes deliberately change observable behavior and "
+        f"upstream updates the test suite (or adds a follow-up fix) in a "
+        f"*separate* commit. The failing test then needs that commit — not a "
+        f"hand-edit.\n\n"
+        f"To tell them apart, search upstream history for a follow-up. The full "
+        f"upstream history is fetched as the `upstream` remote:\n"
+        f"```\n"
+        f"git log --oneline {sha}..upstream/master -- <failing_test_file>   "
+        f"# later commits touching that test (try upstream/main if master is absent)\n"
+        f"git log --oneline {sha}..upstream/master -- <code_area_under_test>\n"
+        f"git show <candidate_sha>                                          "
+        f"# confirm it addresses the failing case\n"
+        f"```\n"
+        f"Derive `<failing_test_file>` from the failing-case names above "
+        f"(e.g. a `tar` case lives in `testsuite/tar.tests`).\n\n"
+        f"Then:\n"
+        f"- **Companion commit touches only Allowed Files** \u2192 cherry-pick it "
+        f"as a separate follow-up commit (Strategy A) and re-verify.\n"
+        f"- **Companion commit touches files OUTSIDE the Allowed Files** (a "
+        f"testsuite update almost always does) \u2192 do NOT hand-edit those "
+        f"files. Escalate naming that commit in `suggested_commits` (see "
+        f"\"Suggesting a commit for a scope extension\") so the run can be "
+        f"retried with it added to the fix chain and your scope widened. Give "
+        f"the exact SHA you confirmed with `git show`.\n"
+        f"- **No companion commit and it is a real backport defect** \u2192 fix "
+        f"the code in the allowed files.\n\n"
+        f"**Rule**: Never hand-edit test cases — only backported source files "
+        f"may be modified directly. A legitimate upstream test update must come "
+        f"in as its own commit via `suggested_commits`, not by editing tests.\n\n"
+        f"In the `Conflicts Resolved:` commit message section, document: which "
+        f"ptest cases failed, the cause, and either the code change that fixed "
+        f"them or the companion commit you suggested."
     )
 
 
@@ -316,6 +361,13 @@ def _read_ptest_results(workspace_path: Path) -> str:
         ptest_before = data.get('ptest_before')
         if ptest_before:
             lines.append(f"**Before patch**:\n```\n{ptest_before}\n```\n")
+        ptest_after = data.get('ptest_after')
+        if ptest_after:
+            lines.append(
+                "**After patch** — the `Failing cases:` listed here are the "
+                "regressions you must investigate and resolve (each name is a "
+                "ptest case; reproduce and analyse it):\n"
+                f"```\n{ptest_after}\n```\n")
 
     # Read ptest log for detailed failure output
     recipe = workspace_path.name
@@ -437,8 +489,15 @@ def _find_state_file(workspace_path: Path) -> Path | None:
         Path to state JSON file, or None if not found.
     """
     recipe_name = workspace_path.name
-    build_dir = get_build_dir(workspace_path)
-    state_dir = build_dir / 'cve_corrector'
+    # The corrector saves state under the devtool workspace, at
+    # get_build_path()/workspace/cve_corrector/<recipe>.json (see
+    # cve_corrector.bitbake_ops.get_state_dir). That is two levels up from the
+    # recipe source dir — the same base get_agent_dir() uses. A previous
+    # version looked at get_build_dir()/cve_corrector (three levels up, one
+    # directory too high) and silently never found the state file, so ptest
+    # before/after results — and their `Failing cases:` list — never reached
+    # the agent's context.
+    state_dir = workspace_path.parent.parent / 'cve_corrector'
     state_file = state_dir / f'{recipe_name}.json'
     if state_file.exists():
         return state_file

--- a/cve_agent/instructions/build.md
+++ b/cve_agent/instructions/build.md
@@ -1,0 +1,19 @@
+### Fix Build Errors (exit code 4)
+
+Reproduce and read the failure with the Build Verification command and log
+handling from the core instructions. Two build-specific cases:
+
+**Stale build state — recover, do NOT escalate.** If the build fails because an
+sstate-restored/skipped task left a file it should have generated missing, the
+recipe's cached state is stale — not a defect in your patch. Signatures: `cp:
+cannot stat '.config.orig'` (or any "No such file or directory" for a
+configure-generated file); or a log showing only `do_compile` ran while
+`do_configure` was skipped. Recover before concluding it is environmental:
+```bash
+bitbake -c cleansstate <recipe>
+```
+
+**Different recipe.** If the failing task belongs to a recipe other than the one
+being patched, **abort immediately** — it is pre-existing/environmental.
+
+Otherwise fix the code, amend the commit, and re-run the build.

--- a/cve_agent/instructions/conflict.md
+++ b/cve_agent/instructions/conflict.md
@@ -1,0 +1,44 @@
+### Resolve Conflicts (exit code 1)
+```bash
+git status && git diff                      # examine conflicts
+git ls-files -u                             # unmerged stages (1=base, 2=ours, 3=theirs)
+git show <upstream_sha>                     # upstream fix intent
+git log --oneline -20 -- <file>             # file history for context
+```
+
+Resolve each conflicted file. Three shapes come up, cheapest-correct first:
+
+1. **Take one side wholesale** — "keep upstream verbatim" or "drop the upstream
+   hunk": use git, not an editor:
+   ```bash
+   git checkout --theirs <file>   # keep the upstream (cherry-picked) side
+   git checkout --ours <file>     # keep the stable-branch side
+   ```
+2. **Partial resolution** — neither side is right alone: edit the file with your
+   editing tool, removing all conflict markers.
+3. **Drop a path** — if upstream deletes a file, `git rm <file>`. If a conflicted
+   path exists only in upstream history, not this workspace (a submodule/gitlink
+   recorded upstream against a tarball-sourced recipe — confirm with `git
+   submodule status`), unstage it rather than materialise it:
+   ```bash
+   git restore --staged <path>    # index-only; working tree untouched
+   ```
+
+Then stage ONLY allowed files (`git add <resolved_files>`). If the cherry-pick
+as a whole does not apply, `git cherry-pick --skip` drops it (`--abort` stops
+the sequence).
+
+If you adapted the patch, append backport notes to `.git/MERGE_MSG` (preserve
+the original message — see Commit Message Format), then:
+```bash
+git cherry-pick --no-edit --continue
+```
+
+### Common Conflict Patterns
+
+| Pattern | Resolution | Commit Note |
+|---|---|---|
+| Function signature changed | Keep fix logic, adapt to stable signature | `Adapted foo_v2() to foo_v1() API` |
+| Struct member renamed | Use stable member name with upstream logic | `Member renamed netdev→ndev in original patch` |
+| Function moved to different file | Apply fix where function lives in stable | `Function in old_file.c in original patch` |
+| Missing helper function | Inline it or use stable equivalent | `Inlined helper_foo() (not in stable)` |

--- a/cve_agent/instructions/ptest.md
+++ b/cve_agent/instructions/ptest.md
@@ -1,0 +1,34 @@
+### Fix Test Failures (exit code 3)
+
+The context lists the failing cases and before/after pass counts. Understand
+*why* the backport made them fail before changing anything — a ptest regression
+is almost always one of two things:
+
+**(a) A backport defect.** Your adaptation changed behavior the test correctly
+rejects (mis-resolved conflict, dropped hunk, wrong signature/sign). Re-read the
+failing test, compare with the upstream intent (`git show <upstream_sha>`), and
+fix the source **in allowed files only**. Amend and re-verify.
+
+**(b) A behavior change with a companion commit.** Some fixes deliberately
+change observable behavior and upstream updates the tests (or adds a follow-up)
+in a *separate* commit. The failing test then needs that commit.
+**Never hand-edit test files.**
+
+Tell (a) from (b) by searching the `upstream` remote (full history is fetched):
+```bash
+git log --oneline <upstream_sha>..upstream/master -- <failing_test_file> # later commits on that test
+git log --oneline <upstream_sha>..upstream/master -- <code_area>         # or the code under test
+git show <candidate_sha>                                                 # confirm it fixes the case
+```
+Derive `<failing_test_file>` from the failing-case names (e.g. a `tar` case
+lives in `testsuite/tar.tests`). Try `upstream/main` if `upstream/master` is
+absent. Then:
+- **Companion commit, only Allowed Files** → cherry-pick it as a follow-up
+  commit (Strategy A) and re-verify.
+- **Companion commit, files OUTSIDE Allowed Files** (a testsuite update almost
+  always is) → escalate with a `suggested_commits` entry naming the confirmed
+  SHA (see "Suggesting a commit for a scope extension"); do not edit those files.
+- **No companion commit, real defect** → fix the code in the allowed files.
+
+Document in the `Conflicts Resolved:` block: which cases failed, the cause, and
+either the code fix or the companion commit you suggested.

--- a/cve_agent/kiro_backend.py
+++ b/cve_agent/kiro_backend.py
@@ -36,7 +36,11 @@ class KiroBackend(AIBackend):
         """
         return (
             "Your file/directory inspection tool is `fs_read`; your "
-            "bash-equivalent command runner is `execute_bash`.\n\n"
+            "file-writing/editing tool is `fs_write`; your "
+            "bash-equivalent command runner is `execute_bash`. Use `fs_write` "
+            "to create or edit files — source-file edits, `conclusion.json`, "
+            "and appending to `.git/MERGE_MSG` — never shell redirection "
+            "(`>`/`>>`) or heredocs, which the command guard rejects.\n\n"
         )
 
     def run_session(self, prompt: str, workspace_path: Path,

--- a/cve_agent/kiro_backend.py
+++ b/cve_agent/kiro_backend.py
@@ -106,36 +106,8 @@ class KiroBackend(AIBackend):
         cmd = ['kiro-cli', 'chat', '--agent', agent_name, '--model', model]
         if not interactive:
             cmd.append('--no-interactive')
-            prompt = KiroBackend._with_agent_instructions(prompt)
         cmd.append(prompt)
         return cmd
-
-    @staticmethod
-    def _with_agent_instructions(prompt: str) -> str:
-        """Prepend AGENT_INSTRUCTIONS.md content (with the kiro tool preamble)
-        to the prompt.
-
-        ``kiro-cli chat`` has no ``--append-system-prompt`` equivalent (unlike
-        the ``claude`` CLI backend, see :meth:`ClaudeBackend._build_command`),
-        so the agent's ``prompt: file://...`` field is normally the only way
-        instructions reach the model — and that static file is synced via
-        :func:`cve_agent.setup.sync_agent_instructions`, which also prepends
-        the same tool preamble. In ``--no-interactive`` (CI) runs there is no
-        human to notice if that file:// prompt failed to resolve, so inline
-        the instructions directly into the query text as a second, explicit
-        path — redundant with the agent config, but that redundancy is the
-        point for unattended runs.
-        """
-        from . import resolve_agent_instructions
-        instructions_path = resolve_agent_instructions()
-        if not instructions_path.is_file():
-            logging.warning(
-                "Agent instructions not found (%s); running with only the "
-                "agent config's file:// prompt.", instructions_path)
-            return prompt
-        instructions = instructions_path.read_text(encoding="utf-8")
-        preamble = KiroBackend().tool_preamble()
-        return f"{preamble}{instructions}\n\n---\n\n{prompt}"
 
     @staticmethod
     def _transcript_path(workspace_path: Path) -> Optional[Path]:

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -8,6 +8,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from shared.url_parser import HASH_RE, extract_commit_hash
+
 from . import (
     EXIT_ALREADY_APPLIED,
     EXIT_BUILD_ERROR,
@@ -31,12 +33,47 @@ from .knowledge import KnowledgeBase, gather_pattern_details, save_knowledge_pat
 from .review import build_change_summary, request_approval
 from .session import guarded_session
 
+# Safety cap on how many times a single CVE run may be re-launched with an
+# agent-suggested, human/trust-accepted commit appended to the chain. Prevents
+# a misbehaving session from suggesting an endless stream of commits.
+_MAX_CHAIN_EXTENSIONS = 3
+
 
 @dataclasses.dataclass
 class _AttemptOutcome:
     """Result of a single resolution attempt."""
     result: Optional[CveResult] = None
     next_step: Optional[int] = None
+
+
+@dataclasses.dataclass
+class _Escalation:
+    """A parsed ``needs_human`` conclusion.
+
+    ``suggested_commits`` holds any upstream commits the agent named as needed
+    to complete the backport but which reach files outside its current
+    allowed-files scope (a companion/prerequisite commit). Each entry is a
+    commit URL or a full SHA; empty when the agent asked for review without
+    proposing a concrete commit.
+    """
+    reason: str
+    suggested_commits: list[str] = dataclasses.field(default_factory=list)
+
+
+class _AcceptedSuggestion(Exception):
+    """Signals that a human (or ``--trust``) accepted agent-suggested commits.
+
+    Carries the full, ordered ``--fix-url`` chain (original fix first, then the
+    accepted commits) to re-run the corrector with. The corrector records the
+    whole chain in its ``series_state``, and ``get_all_upstream_shas`` feeds
+    that back into the next session's allowed files — so the guard extends to
+    the suggested commits' files automatically, no guard code changes needed.
+    """
+
+    def __init__(self, fix_urls: list[str], new_hashes: list[str]) -> None:
+        super().__init__()
+        self.fix_urls = fix_urls
+        self.new_hashes = new_hashes
 
 
 def _make_result(cve_id: str, status: ResultStatus, retries: int,
@@ -65,7 +102,7 @@ def _read_conclusion(workspace_path: Path) -> Optional[str]:
     return None
 
 
-def _read_escalation(workspace_path: Path) -> Optional[str]:
+def _read_escalation(workspace_path: Path) -> Optional[_Escalation]:
     """Read the agent conclusion file if it asked for human review.
 
     Distinct from :func:`_read_conclusion`: a ``needs_human`` conclusion means
@@ -73,6 +110,13 @@ def _read_escalation(workspace_path: Path) -> Optional[str]:
     prerequisite that reaches outside the allowed files, or a structural
     dependency). It must escalate to a human — NOT be marked not-applicable,
     which would wrongly report the vulnerability as a non-issue.
+
+    When the agent also names ``suggested_commits`` (a companion/prerequisite
+    commit whose files fall outside the current allowed scope), those are
+    returned so the caller can offer to re-run with an extended commit chain.
+
+    Returns:
+        An :class:`_Escalation` if the agent requested review, else ``None``.
     """
     try:
         conclusion_file = get_agent_dir(workspace_path) / 'conclusion.json'
@@ -80,10 +124,147 @@ def _read_escalation(workspace_path: Path) -> Optional[str]:
             return None
         data = json.loads(conclusion_file.read_text(encoding='utf-8'))
         if data.get('needs_human'):
-            return data.get('reason', 'Agent requested human review (no details)')
+            reason = data.get('reason', 'Agent requested human review (no details)')
+            raw = data.get('suggested_commits')
+            suggested: list[str] = []
+            if isinstance(raw, list):
+                suggested = [str(c).strip() for c in raw if str(c).strip()]
+            return _Escalation(reason=reason, suggested_commits=suggested)
     except (json.JSONDecodeError, OSError):
         pass
     return None
+
+
+def _original_fix_url(cve_info: dict) -> Optional[str]:
+    """Return the first fix-commit URL from the CVE metadata, if any.
+
+    Prefers ``patches`` (the human-facing fix URLs), falling back to
+    ``hash_details`` URLs. Only returns a URL that :func:`extract_commit_hash`
+    can resolve to a commit — otherwise it is useless as the head of a
+    ``--fix-url`` chain.
+    """
+    for url in cve_info.get('patches') or []:
+        if isinstance(url, str) and extract_commit_hash(url):
+            return url
+    for detail in cve_info.get('hash_details') or []:
+        url = detail.get('url')
+        if isinstance(url, str) and extract_commit_hash(url):
+            return url
+    return None
+
+
+def _normalize_suggestion(suggestion: str, ref_url: Optional[str],
+                          ref_hash: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Resolve one agent suggestion to a ``(fix_url, hash)`` pair.
+
+    A suggestion is either a full commit URL or a bare commit SHA. A URL is
+    accepted as-is once :func:`extract_commit_hash` confirms it names a commit.
+    A bare SHA is turned into a fetchable URL by substituting it into the
+    original fix URL's template (``ref_url``) — the sibling commit lives in the
+    same repository and forge, so the proven URL shape carries over verbatim,
+    which keeps this forge-agnostic. Returns ``(None, None)`` when the
+    suggestion cannot be resolved.
+    """
+    if '://' in suggestion:
+        commit_hash = extract_commit_hash(suggestion)
+        return (suggestion, commit_hash) if commit_hash else (None, None)
+    if HASH_RE.fullmatch(suggestion) and ref_url and ref_hash and ref_hash in ref_url:
+        candidate = ref_url.replace(ref_hash, suggestion)
+        if extract_commit_hash(candidate) == suggestion:
+            return candidate, suggestion
+    return None, None
+
+
+def _build_extended_chain(cve_info: dict,
+                          suggested: list[str]) -> tuple[list[str], list[str]]:
+    """Build the ordered ``--fix-url`` chain for a re-run.
+
+    The chain is ``[original_fix_url, *accepted_suggestions]``. Suggestions
+    that cannot be resolved to a fetchable URL, or that duplicate a commit
+    already in the chain, are skipped.
+
+    Returns:
+        ``(fix_urls, new_hashes)``. Both are empty if there is no resolvable
+        original fix URL or no genuinely new commit to add.
+    """
+    original_url = _original_fix_url(cve_info)
+    if not original_url:
+        print("  \u26a0 No resolvable fix URL in metadata — cannot build an "
+              "extended chain; escalating")
+        return [], []
+
+    hashes = cve_info.get('hashes') or []
+    original_hash = hashes[0] if hashes else None
+    existing = set(hashes)
+
+    chain = [original_url]
+    new_hashes: list[str] = []
+    for suggestion in suggested:
+        url, commit_hash = _normalize_suggestion(
+            suggestion, original_url, original_hash)
+        if not url or not commit_hash:
+            print(f"  \u26a0 Could not resolve suggested commit '{suggestion}' "
+                  f"to a fetchable URL — skipping")
+            continue
+        if commit_hash in existing or commit_hash in new_hashes:
+            print(f"  Suggested commit {commit_hash[:12]} already in chain — "
+                  f"skipping")
+            continue
+        chain.append(url)
+        new_hashes.append(commit_hash)
+
+    if not new_hashes:
+        return [], []
+    return chain, new_hashes
+
+
+def _accept_suggestion(config: AgentConfig, new_hashes: list[str]) -> bool:
+    """Decide whether to accept agent-suggested commits.
+
+    ``--trust`` auto-accepts (the operator has already opted into unattended
+    operation). Interactive runs prompt the human. A non-interactive run
+    without ``--trust`` cannot safely widen scope on its own, so it declines
+    and the caller escalates.
+    """
+    joined = ', '.join(h[:12] for h in new_hashes)
+    if config.trust_mode:
+        print(f"  --trust: auto-accepting suggested commit(s) {joined}; "
+              f"re-running with extended scope")
+        return True
+    if config.interactive:
+        response = input(
+            f"  Accept suggested commit(s) {joined} and re-run with extended "
+            f"scope? [y/N]: "
+        ).strip().lower()
+        return response in ('y', 'yes')
+    print("  Non-interactive without --trust: cannot auto-accept a scope "
+          "extension — escalating")
+    return False
+
+
+def _handle_escalation(config: AgentConfig, cve_info: dict,
+                       escalation: _Escalation, attempt: int,
+                       start_time: float) -> CveResult:
+    """Report an escalation and, if commits were suggested and accepted,
+    signal a re-run with an extended chain.
+
+    Raises:
+        _AcceptedSuggestion: when suggested commits are accepted (interactive
+            approval or ``--trust``), carrying the new ``--fix-url`` chain.
+    """
+    print("\n\u26a0 Agent escalated to human review:")
+    print(f"  {escalation.reason}")
+    if escalation.suggested_commits:
+        print(f"  Agent suggested commit(s): "
+              f"{', '.join(escalation.suggested_commits)}")
+        chain, new_hashes = _build_extended_chain(
+            cve_info, escalation.suggested_commits)
+        if new_hashes and _accept_suggestion(config, new_hashes):
+            raise _AcceptedSuggestion(chain, new_hashes)
+    return _make_result(
+        config.cve_id, ResultStatus.ESCALATED, attempt, start_time,
+        escalation.reason
+    )
 
 
 def _is_empty_cherry_pick(workspace_path: Path, cve_info: dict) -> bool:
@@ -192,14 +373,10 @@ def _run_single_resolution_attempt(
             attempt, start_time, conclusion_reason
         ))
 
-    escalation_reason = _read_escalation(workspace_path)
-    if escalation_reason:
-        print("\n\u26a0 Agent escalated to human review:")
-        print(f"  {escalation_reason}")
-        return _AttemptOutcome(result=_make_result(
-            config.cve_id, ResultStatus.ESCALATED,
-            attempt, start_time, escalation_reason
-        ))
+    escalation = _read_escalation(workspace_path)
+    if escalation:
+        return _AttemptOutcome(result=_handle_escalation(
+            config, cve_info, escalation, attempt, start_time))
 
     if not workspace_path.exists():
         return _AttemptOutcome(result=_make_result(
@@ -344,6 +521,10 @@ def _handle_clean_apply(config: AgentConfig, workspace_path: Path,
         return _make_result(config.cve_id, ResultStatus.SKIPPED, 0,
                             start_time, conclusion_reason)
 
+    escalation = _read_escalation(workspace_path)
+    if escalation:
+        return _handle_escalation(config, cve_info, escalation, 0, start_time)
+
     approval, _ = request_approval(workspace_path, upstream_sha, config)
 
     if approval == "rejected":
@@ -382,12 +563,55 @@ def _handle_clean_apply(config: AgentConfig, workspace_path: Path,
 
 def process_single_cve(config: AgentConfig,
                        knowledge_base: KnowledgeBase) -> CveResult:
-    """Process a single CVE through the full agent workflow."""
+    """Process a single CVE through the full agent workflow.
+
+    Wraps :func:`_run_cve_pipeline` in a re-run loop: when the agent suggests a
+    companion/prerequisite commit and it is accepted (interactive approval or
+    ``--trust``), the pipeline raises :class:`_AcceptedSuggestion` and we
+    re-launch with the accepted commit appended to the ``--fix-url`` chain. The
+    corrector then cherry-picks the whole chain, which widens the session's
+    allowed-files guard to the suggested commit's files automatically.
+    """
     start_time = time.monotonic()
     print(f"\n{'=' * 60}")
     print(f"Processing {config.cve_id}")
     print(f"{'=' * 60}")
 
+    accepted_hashes: set[str] = set()
+    extensions = 0
+    while True:
+        try:
+            return _run_cve_pipeline(config, knowledge_base, start_time)
+        except _AcceptedSuggestion as accepted:
+            genuinely_new = [h for h in accepted.new_hashes
+                             if h not in accepted_hashes]
+            if not genuinely_new or extensions >= _MAX_CHAIN_EXTENSIONS:
+                return _make_result(
+                    config.cve_id, ResultStatus.ESCALATED, 0, start_time,
+                    "Suggested commits already tried or chain-extension cap "
+                    f"({_MAX_CHAIN_EXTENSIONS}) reached — escalating"
+                )
+            accepted_hashes.update(genuinely_new)
+            extensions += 1
+            # Keep --cve-info (version + recipe metadata); the fix-url chain is
+            # authoritative for which commits are applied, and clean=True forces
+            # a fresh cherry-pick of the whole chain.
+            config = dataclasses.replace(
+                config, fix_urls=accepted.fix_urls, clean=True)
+            print(f"\n{'=' * 60}")
+            print(f"Re-running {config.cve_id} with extended commit chain "
+                  f"({len(accepted.fix_urls)} commits, "
+                  f"+{len(genuinely_new)} accepted)")
+            print(f"{'=' * 60}")
+
+
+def _run_cve_pipeline(config: AgentConfig, knowledge_base: KnowledgeBase,
+                      start_time: float) -> CveResult:
+    """Run the CVE pipeline once (corrector -> resolution loop).
+
+    May raise :class:`_AcceptedSuggestion`, which :func:`process_single_cve`
+    catches to re-run with an extended commit chain.
+    """
     try:
         if config.cve_info_path:
             cve_data = load_cve_metadata(config.cve_info_path)

--- a/cve_corrector/workflow.py
+++ b/cve_corrector/workflow.py
@@ -232,16 +232,34 @@ def _ensure_layer_branch(meta_layer: Path) -> None:
         )
 
 
+def _clean_and_reset_sstate(workspace_path: Path, recipe: str) -> None:
+    """Remove stale workspace artifacts, then invalidate the recipe's sstate.
+
+    Whenever we remove files from the workspace before a build, we must reset
+    the recipe's sstate — the two go together. ``git clean -fdx`` drops every
+    ignored/untracked build artifact from the workspace and
+    remove_git_only_build_triggers drops git-only files; if the recipe's sstate
+    is left valid after that, the next build setscene-restores ``do_configure``
+    WITHOUT re-creating the run-time files it produces (e.g. busybox's
+    ``${B}/.config.orig``, consumed by ``do_compile``), and the build dies with
+    ``cp: cannot stat '.config.orig'``. ``bitbake -c cleansstate`` drops the
+    sstate too, forcing ``do_configure`` to actually execute again and
+    regenerate those files. The recipe recompiles from source either way, so
+    the only added cost is one ``do_configure`` execution.
+    """
+    git_clean_workspace(workspace_path, remove_ignored=True)
+    copy_missing_files_from_devtool(workspace_path)
+    remove_git_only_build_triggers(workspace_path)
+    run_cmd(['bitbake', '-c', 'cleansstate', recipe])
+
+
 def _run_build_step(state: WorkflowState) -> None:
     """Build recipe after patch, saving progress on failure."""
     if state.skip_build:
         logger.info("Skipping build")
         return
     logger.info("Building %s", state.recipe)
-    git_clean_workspace(state.workspace_path, remove_ignored=True)
-    copy_missing_files_from_devtool(state.workspace_path)
-    remove_git_only_build_triggers(state.workspace_path)
-    run_cmd(['bitbake', '-c', 'clean', state.recipe])
+    _clean_and_reset_sstate(state.workspace_path, state.recipe)
     if run_cmd(['devtool', 'build', state.recipe]) != 0:
         save_progress(state, 'build_after_patch')
         print_build_failure_instructions(state.workspace_path, state.recipe)
@@ -273,6 +291,12 @@ def _run_ptest_step(state: WorkflowState) -> Optional[str]:
         save_progress(state, 'build_after_patch')
         print_build_failure_instructions(state.workspace_path, state.recipe)
         raise BuildError(f"Test image build failed for {state.recipe}") from None
+    # Persist the post-patch summary — which includes the `Failing cases:` list
+    # — to state *before* any save_progress/raise below, so a regression
+    # surfaces the exact failing cases in the agent's context (save_progress
+    # serializes state.ptest_after). Setting it only on the success path left
+    # the saved state's ptest_after as None precisely when the agent needs it.
+    state.ptest_after = ptest_after
     if ptest_after:
         logger.info("✓ Ptest completed: %s", ptest_after)
         if state.ptest_before:
@@ -290,7 +314,6 @@ def _run_ptest_step(state: WorkflowState) -> Optional[str]:
         _log_ptest_debug_conf()
         save_progress(state, 'ptest_after_patch')
         raise PtestError("Post-patch ptest failed to run")
-    state.ptest_after = ptest_after
     return ptest_after
 
 
@@ -748,6 +771,11 @@ def initialize_cve_workflow(
 
     if not config.skip_build and not ptest_before:
         logger.info("Pre-patch build verification for %s", recipe)
+        # prepare_cve_branch removed files from the workspace (git-only build
+        # triggers, and generated files dropped by the branch checkout); reset
+        # the recipe's sstate so do_configure re-runs and regenerates run-time
+        # artifacts rather than being setscene-restored without them.
+        _clean_and_reset_sstate(workspace_path, recipe)
         if run_cmd(['devtool', 'build', recipe]) != 0:
             logger.error("Pre-patch build failed")
             raise BuildPreexistingError("Pre-patch build failed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,4 @@ include = ["cve_agent*", "cve_corrector*", "cve_metadata_extractor*", "shared*"]
 
 [tool.setuptools.package-data]
 cve_metadata_extractor = ["config.json"]
-cve_agent = ["AGENT_INSTRUCTIONS.md", "agents/*.json"]
+cve_agent = ["AGENT_INSTRUCTIONS.md", "instructions/*.md", "agents/*.json"]

--- a/tests/agent/test_agent_permissions.py
+++ b/tests/agent/test_agent_permissions.py
@@ -64,7 +64,8 @@ MUST_ALLOW = [
     # Commit by hand (pre-commit hook still enforces file scope).
     'git commit -m "jq: fix CVE-2024-1234"',
     "git commit -F /ws/cve_agent/jq/msg.txt",
-    # Documented in AGENT_INSTRUCTIONS.md §3/§5 for build-failure iterations.
+    # Documented in the build.md fragment / AGENT_INSTRUCTIONS.md §5 for
+    # build-failure iterations.
     "git commit --amend --no-edit",
     'git commit --amend -m "reworded"',
     "git commit --amend -F /ws/msg.txt",

--- a/tests/agent/test_agent_permissions.py
+++ b/tests/agent/test_agent_permissions.py
@@ -76,6 +76,10 @@ MUST_ALLOW = [
     "git ls-files -s tests/jq.test",
     "git submodule status",
     "git submodule status modules/oniguruma",
+    # Recover stale build state (busybox .config.orig etc.) — a single recipe,
+    # forces do_configure to re-run. Recipe names may contain '.', '-', digits.
+    "bitbake -c cleansstate busybox",
+    "bitbake -c cleansstate gstreamer1.0-plugins-good",
 ]
 
 # Forms that must stay rejected: destructive variants of the newly allowed
@@ -113,6 +117,15 @@ MUST_DENY = [
     "git stash pop",
     "git submodule update --init",
     "git submodule foreach rm -rf .",
+    # bitbake is allowed ONLY as `-c cleansstate <recipe>`; nothing else.
+    "bitbake core-image-minimal",
+    "bitbake busybox",
+    "bitbake -c clean busybox",
+    "bitbake -c cleanall busybox",
+    "bitbake -c cleansstate -rf",
+    "bitbake -c cleansstate busybox; rm -rf /",
+    "bitbake -c cleansstate busybox && rm -rf /",
+    "bitbake -c cleansstate $(echo busybox)",
     # Chaining and command substitution.
     "git rm x; rm -rf /",
     "git rm $(echo x)",

--- a/tests/agent/test_context.py
+++ b/tests/agent/test_context.py
@@ -4,27 +4,45 @@
 from pathlib import Path
 from unittest.mock import patch as mock_patch
 
-from cve_agent import EXIT_CONFLICT, EXIT_SUCCESS
+from cve_agent import EXIT_BUILD_ERROR, EXIT_CONFLICT, EXIT_PTEST_ERROR, EXIT_SUCCESS
 from cve_agent.context import _build_phase_instructions, _gather_interdiff, build_context
 
 
-def test_build_phase_instructions_file_exists(tmp_path):
-    """When the instructions file exists, a short pointer is returned —
-    not the full file content, which already reaches the model via the
-    system prompt (see cve_agent.kiro_backend / cve_agent.claude_backend)."""
-    instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
-    instructions.write_text("# Instructions\nDo the thing.")
-    with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
-        result = _build_phase_instructions()
-    assert "Do the thing" not in result
-    assert "AGENT_INSTRUCTIONS.md" in result
+def test_build_phase_instructions_conflict():
+    """Conflict phase embeds ONLY the conflict fragment (§2 + patterns)."""
+    result = _build_phase_instructions(EXIT_CONFLICT)
+    assert "## Instructions" in result
+    assert "Resolve Conflicts" in result
+    assert "Common Conflict Patterns" in result
+    # Other phases' workflow must not leak into a conflict session.
+    assert "Fix Build Errors" not in result
+    assert "Fix Test Failures" not in result
+    # Fragments carry no SPDX/license header (prompt files are streamed to
+    # the model — a header would just pollute the context).
+    assert "SPDX-License-Identifier" not in result
 
 
-def test_build_phase_instructions_missing(tmp_path):
-    missing = tmp_path / "nonexistent.md"
-    with mock_patch("cve_agent.context.resolve_agent_instructions", return_value=missing):
-        result = _build_phase_instructions()
-    assert "AGENT_INSTRUCTIONS.md" in result
+def test_build_phase_instructions_build():
+    """Build phase embeds ONLY the build fragment (§3)."""
+    result = _build_phase_instructions(EXIT_BUILD_ERROR)
+    assert "Fix Build Errors" in result
+    assert "cleansstate" in result
+    assert "Resolve Conflicts" not in result
+    assert "Fix Test Failures" not in result
+
+
+def test_build_phase_instructions_ptest():
+    """Ptest phase embeds ONLY the ptest fragment (§4)."""
+    result = _build_phase_instructions(EXIT_PTEST_ERROR)
+    assert "Fix Test Failures" in result
+    assert "Never hand-edit" in result
+    assert "Resolve Conflicts" not in result
+    assert "Fix Build Errors" not in result
+
+
+def test_build_phase_instructions_analysis_has_no_fragment():
+    """Exit 0 (analysis) needs no fragment — the core Analyse step covers it."""
+    assert _build_phase_instructions(EXIT_SUCCESS) == ""
 
 
 class TestGatherInterdiff:

--- a/tests/agent/test_context_full.py
+++ b/tests/agent/test_context_full.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from cve_agent import EXIT_BUILD_ERROR, EXIT_CONFLICT, EXIT_PTEST_ERROR
 from cve_agent.context import (
     _build_header,
-    _build_phase_instructions,
     _find_ptest_log,
     _find_state_file,
     _gather_analysis_context,
@@ -85,24 +84,6 @@ class TestBuildHeader:
         assert "bare" in result.lower()
 
 
-class TestBuildPhaseInstructions:
-    def test_file_exists(self, tmp_path):
-        """Returns a short pointer, not the full file content (already
-        delivered via the session's system prompt)."""
-        instructions = tmp_path / "AGENT_INSTRUCTIONS.md"
-        instructions.write_text("# Do stuff")
-        with patch("cve_agent.context.resolve_agent_instructions", return_value=instructions):
-            result = _build_phase_instructions()
-            assert "Do stuff" not in result
-            assert "AGENT_INSTRUCTIONS.md" in result
-
-    def test_file_missing(self, tmp_path):
-        with patch("cve_agent.context.resolve_agent_instructions",
-                  return_value=tmp_path / "nope"):
-            result = _build_phase_instructions()
-            assert "AGENT_INSTRUCTIONS.md" in result
-
-
 class TestGatherContextForExitCode:
     @patch("cve_agent.context._gather_conflict_context", return_value="conflict")
     def test_conflict(self, mock):
@@ -138,10 +119,10 @@ class TestGatherBuildErrorContext:
         result = _gather_build_error_context(Path("/ws"))
         assert "Build Error" in result
         assert "commit stat" in result
-        # Stale-sstate recovery must be surfaced so the agent recovers the
-        # .config.orig-class failure instead of escalating.
-        assert ".config.orig" in result
-        assert "cleansstate" in result
+        # The stale-sstate recovery guidance now lives in the build.md phase
+        # fragment (embedded alongside this section), not duplicated here.
+        assert ".config.orig" not in result
+        assert "cleansstate" not in result
 
 
 class TestGatherPtestErrorContext:
@@ -152,11 +133,12 @@ class TestGatherPtestErrorContext:
         result = _gather_ptest_error_context(Path("/ws"), {})
         assert "Test Failure" in result
         assert "ptest data" in result
-        # Guidance now steers toward upstream companion commits + suggested_commits.
-        assert "Never hand-edit test cases" in result
-        assert "suggested_commits" in result
-        assert "upstream/master" in result
+        # The concrete upstream SHA stays in the data section for `git show`.
         assert "3fb6b31c7166" in result
+        # The defect-vs-companion-commit triage prose now lives in the ptest.md
+        # phase fragment (embedded alongside this section), not duplicated here.
+        assert "Never hand-edit" not in result
+        assert "suggested_commits" not in result
 
 
 class TestGatherAnalysisContext:

--- a/tests/agent/test_context_full.py
+++ b/tests/agent/test_context_full.py
@@ -138,16 +138,25 @@ class TestGatherBuildErrorContext:
         result = _gather_build_error_context(Path("/ws"))
         assert "Build Error" in result
         assert "commit stat" in result
+        # Stale-sstate recovery must be surfaced so the agent recovers the
+        # .config.orig-class failure instead of escalating.
+        assert ".config.orig" in result
+        assert "cleansstate" in result
 
 
 class TestGatherPtestErrorContext:
+    @patch("cve_agent.context.get_upstream_sha", return_value="3fb6b31c7166")
     @patch("cve_agent.context._read_ptest_results", return_value="ptest data")
     @patch("cve_agent.context.run_git_stdout", return_value="commit stat")
     def test_basic(self, *_):
-        result = _gather_ptest_error_context(Path("/ws"))
+        result = _gather_ptest_error_context(Path("/ws"), {})
         assert "Test Failure" in result
         assert "ptest data" in result
-        assert "Test cases must NEVER change" in result
+        # Guidance now steers toward upstream companion commits + suggested_commits.
+        assert "Never hand-edit test cases" in result
+        assert "suggested_commits" in result
+        assert "upstream/master" in result
+        assert "3fb6b31c7166" in result
 
 
 class TestGatherAnalysisContext:
@@ -179,6 +188,29 @@ class TestReadPtestResults:
         assert "Before patch" in result
 
     @patch("cve_agent.context._find_ptest_log", return_value=None)
+    @patch("cve_agent.context._find_state_file")
+    def test_surfaces_ptest_after_failing_cases(self, mock_state, mock_log, tmp_path):
+        """The post-patch summary — including the Failing cases: list — must
+        reach the context so the agent knows which cases to investigate."""
+        summary = ("PASSED: 620, FAILED: 2, SKIPPED: 90, ABORTED: 0\n"
+                   "Failing cases:\n"
+                   "  tar Pax-encoded UTF8 names and symlinks\n"
+                   "  tar Symlinks and hardlinks coexist")
+        state = tmp_path / "state.json"
+        state.write_text(json.dumps({
+            "ptest_before": "PASSED: 622, FAILED: 0, SKIPPED: 90, ABORTED: 0",
+            "ptest_after": summary,
+        }))
+        mock_state.return_value = state
+        ws = tmp_path / "build" / "workspace" / "sources" / "busybox"
+        ws.mkdir(parents=True)
+        result = _read_ptest_results(ws)
+        assert "After patch" in result
+        assert "tar Pax-encoded UTF8 names and symlinks" in result
+        assert "tar Symlinks and hardlinks coexist" in result
+        assert "investigate" in result.lower()
+
+    @patch("cve_agent.context._find_ptest_log", return_value=None)
     @patch("cve_agent.context._find_state_file", return_value=None)
     def test_no_data(self, *_):
         result = _read_ptest_results(Path("/build/workspace/sources/r"))
@@ -208,12 +240,25 @@ class TestFindPtestLog:
 
 class TestFindStateFile:
     def test_found(self, tmp_path):
+        """Must look where the corrector saves state:
+        <build>/workspace/cve_corrector/<recipe>.json (two levels up from the
+        recipe source dir), not <build>/cve_corrector."""
         ws = tmp_path / "build" / "workspace" / "sources" / "busybox"
         ws.mkdir(parents=True)
-        state_dir = tmp_path / "build" / "cve_corrector"
+        state_dir = tmp_path / "build" / "workspace" / "cve_corrector"
         state_dir.mkdir(parents=True)
-        (state_dir / "busybox.json").write_text("{}")
-        assert _find_state_file(ws) is not None
+        state_file = state_dir / "busybox.json"
+        state_file.write_text("{}")
+        assert _find_state_file(ws) == state_file
+
+    def test_not_at_build_root(self, tmp_path):
+        """A state file one level too high (the old buggy location) is ignored."""
+        ws = tmp_path / "build" / "workspace" / "sources" / "busybox"
+        ws.mkdir(parents=True)
+        wrong = tmp_path / "build" / "cve_corrector"
+        wrong.mkdir(parents=True)
+        (wrong / "busybox.json").write_text("{}")
+        assert _find_state_file(ws) is None
 
     def test_not_found(self, tmp_path):
         ws = tmp_path / "build" / "workspace" / "sources" / "busybox"

--- a/tests/agent/test_interactive.py
+++ b/tests/agent/test_interactive.py
@@ -101,49 +101,25 @@ class TestInteractiveAgentSelection:
         assert '--trust-all-tools' not in cmd
 
 
-class TestNonInteractivePromptIncludesInstructions:
-    """CI (--no-interactive) runs inline AGENT_INSTRUCTIONS.md into the query
-    text itself, since kiro-cli has no --append-system-prompt equivalent and
-    there's no human to notice a silently-unresolved file:// agent prompt."""
+class TestPromptCarriesNoInlinedInstructions:
+    """The instructions reach the model via the agent's file:// system prompt
+    plus the per-phase context.md — the query itself is just a pointer to the
+    context file, in both interactive and non-interactive mode. Regression
+    guard against re-introducing the AGENT_INSTRUCTIONS.md double-send that
+    inlined the full manual into the query on every CI run."""
 
     @patch('subprocess.run')
-    def test_non_interactive_prompt_prepends_instructions(self, mock_run, tmp_path):
-        instructions_file = tmp_path / 'AGENT_INSTRUCTIONS.md'
-        instructions_file.write_text('# CVE Backport Agent Instructions\n'
-                                     'Use fs_read for everything.',
-                                     encoding='utf-8')
-        with patch('cve_agent.resolve_agent_instructions',
-                   return_value=instructions_file):
-            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
-                            interactive=False)
+    def test_non_interactive_prompt_is_just_context_pointer(self, mock_run):
+        _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
+                        interactive=False)
         cmd = mock_run.call_args_list[0][0][0]
-        query = cmd[-1]
-        assert 'Use fs_read for everything.' in query
-        assert 'Read /ctx.md' in query
+        assert cmd[-1] == 'Read /ctx.md'
+        assert '--no-interactive' in cmd
 
     @patch('subprocess.run')
-    def test_interactive_prompt_does_not_duplicate_instructions(
-            self, mock_run, tmp_path):
-        """Interactive already gets instructions via the agent config's
-        file:// prompt; inlining them again would be redundant noise."""
-        instructions_file = tmp_path / 'AGENT_INSTRUCTIONS.md'
-        instructions_file.write_text('# CVE Backport Agent Instructions',
-                                     encoding='utf-8')
-        with patch('cve_agent.resolve_agent_instructions',
-                   return_value=instructions_file):
-            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
-                            interactive=True)
-        cmd = mock_run.call_args_list[0][0][0]
-        query = cmd[-1]
-        assert query == 'Read /ctx.md'
-
-    @patch('subprocess.run')
-    def test_missing_instructions_file_falls_back_to_plain_prompt(
-            self, mock_run, tmp_path):
-        missing = tmp_path / 'does-not-exist.md'
-        with patch('cve_agent.resolve_agent_instructions', return_value=missing):
-            _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
-                            interactive=False)
+    def test_interactive_prompt_is_just_context_pointer(self, mock_run):
+        _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
+                        interactive=True)
         cmd = mock_run.call_args_list[0][0][0]
         assert cmd[-1] == 'Read /ctx.md'
 

--- a/tests/agent/test_main_process.py
+++ b/tests/agent/test_main_process.py
@@ -37,13 +37,18 @@ class TestReadEscalation:
         agent_dir = self._write(
             tmp_path, {"needs_human": True, "reason": "prereq touches out-of-scope files"})
         with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
-            assert _read_escalation(tmp_path) == "prereq touches out-of-scope files"
+            esc = _read_escalation(tmp_path)
+        assert esc is not None
+        assert esc.reason == "prereq touches out-of-scope files"
+        assert esc.suggested_commits == []
 
     def test_needs_human_without_reason_has_default(self, tmp_path):
         from cve_agent.orchestrator import _read_escalation
         agent_dir = self._write(tmp_path, {"needs_human": True})
         with patch("cve_agent.orchestrator.get_agent_dir", return_value=agent_dir):
-            assert "human review" in _read_escalation(tmp_path)
+            esc = _read_escalation(tmp_path)
+        assert esc is not None
+        assert "human review" in esc.reason
 
     def test_not_applicable_is_not_escalation(self, tmp_path):
         """A not_applicable conclusion must NOT read as an escalation."""

--- a/tests/agent/test_suggested_commits.py
+++ b/tests/agent/test_suggested_commits.py
@@ -1,0 +1,277 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for the agent 'suggest commit -> accept -> re-run with extended guard'
+workflow (orchestrator escalation with ``suggested_commits``)."""
+import json
+
+import pytest
+
+from cve_agent import AgentConfig, ResultStatus, get_agent_dir
+from cve_agent import orchestrator as orch
+
+# A realistic busybox cgit fix URL + its 40-char commit SHA.
+FIX_URL = "https://git.busybox.net/busybox/commit/archival?id=3fb6b31c716669e12f75a2accd31bb7685b1a1cb"
+FIX_HASH = "3fb6b31c716669e12f75a2accd31bb7685b1a1cb"
+# A plausible sibling commit (different 40-char hex hash, same repo).
+SUGGESTED_HASH = "8c24af9dcabcdef0123456789abcdef012345678"
+SUGGESTED_URL = "https://git.busybox.net/busybox/commit/testsuite?id=" + SUGGESTED_HASH
+
+
+def _cve_info():
+    return {
+        "name": "busybox",
+        "version": "1.36.1",
+        "hashes": [FIX_HASH],
+        "patches": [FIX_URL],
+        "hash_details": [{"hash": FIX_HASH, "url": FIX_URL, "source": "debian"}],
+    }
+
+
+def _make_workspace(tmp_path):
+    """Build a devtool-style workspace path so get_agent_dir resolves."""
+    ws = tmp_path / "build" / "workspace" / "sources" / "busybox"
+    ws.mkdir(parents=True)
+    return ws
+
+
+def _write_conclusion(ws, payload):
+    agent_dir = get_agent_dir(ws)
+    (agent_dir / "conclusion.json").write_text(json.dumps(payload),
+                                               encoding="utf-8")
+
+
+# --- _read_escalation --------------------------------------------------------
+
+def test_read_escalation_with_suggested_commits(tmp_path):
+    ws = _make_workspace(tmp_path)
+    _write_conclusion(ws, {
+        "needs_human": True,
+        "reason": "needs testsuite fixup",
+        "suggested_commits": [SUGGESTED_HASH, "  "],  # blank entry is dropped
+    })
+    esc = orch._read_escalation(ws)
+    assert esc is not None
+    assert esc.reason == "needs testsuite fixup"
+    assert esc.suggested_commits == [SUGGESTED_HASH]
+
+
+def test_read_escalation_without_suggested_commits(tmp_path):
+    ws = _make_workspace(tmp_path)
+    _write_conclusion(ws, {"needs_human": True, "reason": "structural change"})
+    esc = orch._read_escalation(ws)
+    assert esc is not None
+    assert esc.suggested_commits == []
+
+
+def test_read_escalation_ignores_non_list_suggested(tmp_path):
+    ws = _make_workspace(tmp_path)
+    _write_conclusion(ws, {
+        "needs_human": True, "reason": "x", "suggested_commits": "not-a-list"})
+    esc = orch._read_escalation(ws)
+    assert esc is not None and esc.suggested_commits == []
+
+
+def test_read_escalation_absent_when_not_needs_human(tmp_path):
+    ws = _make_workspace(tmp_path)
+    _write_conclusion(ws, {"not_applicable": True, "reason": "n/a"})
+    assert orch._read_escalation(ws) is None
+
+
+def test_read_escalation_missing_file(tmp_path):
+    ws = _make_workspace(tmp_path)
+    assert orch._read_escalation(ws) is None
+
+
+# --- _original_fix_url -------------------------------------------------------
+
+def test_original_fix_url_prefers_patches():
+    assert orch._original_fix_url(_cve_info()) == FIX_URL
+
+
+def test_original_fix_url_falls_back_to_hash_details():
+    info = {"hash_details": [{"hash": FIX_HASH, "url": FIX_URL}]}
+    assert orch._original_fix_url(info) == FIX_URL
+
+
+def test_original_fix_url_none_when_unresolvable():
+    info = {"patches": ["https://example.com/advisory/GHSA-xxxx"]}
+    assert orch._original_fix_url(info) is None
+
+
+# --- _normalize_suggestion ---------------------------------------------------
+
+def test_normalize_suggestion_url():
+    url, h = orch._normalize_suggestion(SUGGESTED_URL, FIX_URL, FIX_HASH)
+    assert url == SUGGESTED_URL
+    assert h == SUGGESTED_HASH
+
+
+def test_normalize_suggestion_bare_sha_builds_sibling_url():
+    url, h = orch._normalize_suggestion(SUGGESTED_HASH, FIX_URL, FIX_HASH)
+    assert h == SUGGESTED_HASH
+    # Sibling URL reuses the fix URL template with the hash substituted.
+    assert url == FIX_URL.replace(FIX_HASH, SUGGESTED_HASH)
+
+
+def test_normalize_suggestion_bare_sha_without_template_fails():
+    # ref_hash not present in ref_url -> cannot build a sibling URL.
+    url, h = orch._normalize_suggestion(SUGGESTED_HASH, "https://x/commit/abc", "deadbeef")
+    assert (url, h) == (None, None)
+
+
+def test_normalize_suggestion_garbage():
+    assert orch._normalize_suggestion("not a commit", FIX_URL, FIX_HASH) == (None, None)
+
+
+def test_normalize_suggestion_non_commit_url():
+    assert orch._normalize_suggestion(
+        "https://example.com/blob/main/x.c", FIX_URL, FIX_HASH) == (None, None)
+
+
+# --- _build_extended_chain ---------------------------------------------------
+
+def test_build_extended_chain_with_sha():
+    chain, new_hashes = orch._build_extended_chain(_cve_info(), [SUGGESTED_HASH])
+    assert chain == [FIX_URL, FIX_URL.replace(FIX_HASH, SUGGESTED_HASH)]
+    assert new_hashes == [SUGGESTED_HASH]
+
+
+def test_build_extended_chain_with_url():
+    chain, new_hashes = orch._build_extended_chain(_cve_info(), [SUGGESTED_URL])
+    assert chain == [FIX_URL, SUGGESTED_URL]
+    assert new_hashes == [SUGGESTED_HASH]
+
+
+def test_build_extended_chain_dedupes_existing():
+    # Suggesting the fix commit itself yields no genuinely new commit.
+    chain, new_hashes = orch._build_extended_chain(_cve_info(), [FIX_HASH])
+    assert chain == [] and new_hashes == []
+
+
+def test_build_extended_chain_no_original_url():
+    info = {"hashes": [FIX_HASH], "patches": ["https://example.com/advisory"]}
+    chain, new_hashes = orch._build_extended_chain(info, [SUGGESTED_HASH])
+    assert chain == [] and new_hashes == []
+
+
+def test_build_extended_chain_skips_unresolvable():
+    chain, new_hashes = orch._build_extended_chain(
+        _cve_info(), ["garbage", SUGGESTED_HASH])
+    assert new_hashes == [SUGGESTED_HASH]
+    assert chain == [FIX_URL, FIX_URL.replace(FIX_HASH, SUGGESTED_HASH)]
+
+
+# --- _accept_suggestion ------------------------------------------------------
+
+def _cfg(**kw):
+    return AgentConfig(cve_id="CVE-2026-26157", **kw)
+
+
+def test_accept_suggestion_trust_auto_accepts():
+    assert orch._accept_suggestion(_cfg(trust_mode=True), [SUGGESTED_HASH]) is True
+
+
+def test_accept_suggestion_interactive_yes(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "y")
+    assert orch._accept_suggestion(
+        _cfg(interactive=True), [SUGGESTED_HASH]) is True
+
+
+def test_accept_suggestion_interactive_no(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "n")
+    assert orch._accept_suggestion(
+        _cfg(interactive=True), [SUGGESTED_HASH]) is False
+
+
+def test_accept_suggestion_non_interactive_declines():
+    # No trust, not interactive -> cannot safely widen scope.
+    assert orch._accept_suggestion(_cfg(), [SUGGESTED_HASH]) is False
+
+
+# --- _handle_escalation ------------------------------------------------------
+
+def test_handle_escalation_no_suggestion_returns_escalated():
+    esc = orch._Escalation(reason="structural change", suggested_commits=[])
+    result = orch._handle_escalation(_cfg(trust_mode=True), _cve_info(), esc, 1, 0.0)
+    assert result.status is ResultStatus.ESCALATED
+    assert result.resolution_summary == "structural change"
+
+
+def test_handle_escalation_trust_raises_accepted_suggestion():
+    esc = orch._Escalation(reason="needs fixup", suggested_commits=[SUGGESTED_HASH])
+    with pytest.raises(orch._AcceptedSuggestion) as excinfo:
+        orch._handle_escalation(_cfg(trust_mode=True), _cve_info(), esc, 1, 0.0)
+    assert excinfo.value.new_hashes == [SUGGESTED_HASH]
+    assert excinfo.value.fix_urls == [FIX_URL, FIX_URL.replace(FIX_HASH, SUGGESTED_HASH)]
+
+
+def test_handle_escalation_declined_returns_escalated():
+    esc = orch._Escalation(reason="needs fixup", suggested_commits=[SUGGESTED_HASH])
+    # Not trust, not interactive -> declined -> ESCALATED (no raise).
+    result = orch._handle_escalation(_cfg(), _cve_info(), esc, 1, 0.0)
+    assert result.status is ResultStatus.ESCALATED
+
+
+def test_handle_escalation_unresolvable_suggestion_escalates():
+    esc = orch._Escalation(reason="needs fixup", suggested_commits=["garbage"])
+    result = orch._handle_escalation(_cfg(trust_mode=True), _cve_info(), esc, 1, 0.0)
+    assert result.status is ResultStatus.ESCALATED
+
+
+# --- process_single_cve re-run loop -----------------------------------------
+
+def test_rerun_loop_extends_chain_then_succeeds(monkeypatch):
+    """First pipeline run accepts a suggestion; second run succeeds with the
+    extended fix-url chain threaded into the config."""
+    seen_configs = []
+
+    def fake_pipeline(config, kb, start_time):
+        seen_configs.append(config)
+        if len(seen_configs) == 1:
+            raise orch._AcceptedSuggestion(
+                [FIX_URL, SUGGESTED_URL], [SUGGESTED_HASH])
+        return orch._make_result(
+            config.cve_id, ResultStatus.CONFLICT_RESOLVED, 0, start_time, "ok")
+
+    monkeypatch.setattr(orch, "_run_cve_pipeline", fake_pipeline)
+    result = orch.process_single_cve(_cfg(trust_mode=True), None)
+
+    assert result.status is ResultStatus.CONFLICT_RESOLVED
+    assert len(seen_configs) == 2
+    # Re-run config carries the extended chain and forces a clean cherry-pick.
+    assert seen_configs[1].fix_urls == [FIX_URL, SUGGESTED_URL]
+    assert seen_configs[1].clean is True
+
+
+def test_rerun_loop_caps_extensions(monkeypatch):
+    """A pipeline that keeps suggesting new commits is stopped at the cap."""
+    calls = {"n": 0}
+
+    def fake_pipeline(config, kb, start_time):
+        calls["n"] += 1
+        # Always suggest a genuinely-new hash.
+        new = f"{calls['n']:040x}"
+        raise orch._AcceptedSuggestion([FIX_URL, SUGGESTED_URL], [new])
+
+    monkeypatch.setattr(orch, "_run_cve_pipeline", fake_pipeline)
+    result = orch.process_single_cve(_cfg(trust_mode=True), None)
+
+    assert result.status is ResultStatus.ESCALATED
+    # Initial run + _MAX_CHAIN_EXTENSIONS re-runs.
+    assert calls["n"] == orch._MAX_CHAIN_EXTENSIONS + 1
+
+
+def test_rerun_loop_stops_on_repeated_suggestion(monkeypatch):
+    """Re-suggesting an already-accepted commit does not loop forever."""
+    calls = {"n": 0}
+
+    def fake_pipeline(config, kb, start_time):
+        calls["n"] += 1
+        raise orch._AcceptedSuggestion([FIX_URL, SUGGESTED_URL], [SUGGESTED_HASH])
+
+    monkeypatch.setattr(orch, "_run_cve_pipeline", fake_pipeline)
+    result = orch.process_single_cve(_cfg(trust_mode=True), None)
+
+    assert result.status is ResultStatus.ESCALATED
+    # First run accepts (extends once); second run's repeat has no new hash.
+    assert calls["n"] == 2

--- a/tests/corrector/test_workflow_full.py
+++ b/tests/corrector/test_workflow_full.py
@@ -34,6 +34,7 @@ from cve_corrector.ui import (
     print_edit_instructions,
 )
 from cve_corrector.workflow import (
+    _clean_and_reset_sstate,
     _handle_failed_series,
     _handle_no_clean_apply,
     _log_ptest_debug_conf,
@@ -785,6 +786,26 @@ class TestContinueFromConflict:
         assert state.current_step == "ptest_after_patch"
 
 
+class TestCleanAndResetSstate:
+    """Removing files from the workspace must be paired with cleansstate so a
+    stale do_configure sstate can't be setscene-restored without regenerating
+    run-time artifacts (busybox .config.orig)."""
+
+    @patch("cve_corrector.workflow.run_cmd", return_value=0)
+    @patch("cve_corrector.workflow.remove_git_only_build_triggers")
+    @patch("cve_corrector.workflow.copy_missing_files_from_devtool")
+    @patch("cve_corrector.workflow.git_clean_workspace")
+    def test_removes_then_cleansstate(self, mock_clean, mock_copy, mock_trig,
+                                      mock_cmd, tmp_path):
+        _clean_and_reset_sstate(tmp_path, "busybox")
+        # Ignored build artifacts are removed from the workspace...
+        mock_clean.assert_called_once_with(tmp_path, remove_ignored=True)
+        mock_trig.assert_called_once_with(tmp_path)
+        # ...and the recipe's sstate is invalidated so do_configure re-runs.
+        assert mock_cmd.call_args_list[-1].args[0] == \
+            ['bitbake', '-c', 'cleansstate', 'busybox']
+
+
 class TestRunBuildStep:
     @patch("cve_corrector.workflow.run_cmd", return_value=0)
     @patch("cve_corrector.workflow.run_cmd_capture")
@@ -792,6 +813,24 @@ class TestRunBuildStep:
     def test_success(self, mock_copy, mock_capture, mock_cmd, tmp_path):
         state = _state(tmp_path, skip_build=False)
         _run_build_step(state)
+
+    @patch("cve_corrector.workflow.run_cmd", return_value=0)
+    @patch("cve_corrector.workflow.run_cmd_capture")
+    @patch("cve_corrector.workflow.copy_missing_files_from_devtool")
+    def test_uses_cleansstate_not_clean(self, mock_copy, mock_capture,
+                                        mock_cmd, tmp_path):
+        """Regression: the after-patch build must cleansstate so do_configure
+        re-executes and regenerates run-time artifacts (e.g. busybox's
+        .config.orig). Plain `-c clean` leaves do_configure sstate valid, which
+        gets restored without those artifacts and breaks do_compile."""
+        state = _state(tmp_path, skip_build=False)
+        _run_build_step(state)
+        commands = [call.args[0] for call in mock_cmd.call_args_list]
+        assert ['bitbake', '-c', 'cleansstate', 'busybox'] in commands
+        assert ['bitbake', '-c', 'clean', 'busybox'] not in commands
+        # cleansstate must precede the build so do_configure runs fresh.
+        assert commands.index(['bitbake', '-c', 'cleansstate', 'busybox']) < \
+            commands.index(['devtool', 'build', 'busybox'])
 
     def test_skip(self, tmp_path):
         state = _state(tmp_path, skip_build=True)
@@ -802,7 +841,7 @@ class TestRunBuildStep:
     @patch("cve_corrector.workflow.run_cmd_capture")
     @patch("cve_corrector.workflow.copy_missing_files_from_devtool")
     def test_failure(self, mock_copy, mock_capture, mock_cmd, mock_save, tmp_path):
-        # clean ok, bitbake -c clean ok, devtool build fails
+        # cleansstate ok, devtool build fails
         mock_cmd.side_effect = [0, 1]
         state = _state(tmp_path, skip_build=False)
         with pytest.raises(BuildError):
@@ -821,11 +860,18 @@ class TestRunPtestStep:
         assert "PASSED" in result
 
     @patch("cve_corrector.workflow.save_progress")
-    @patch("cve_corrector.workflow.run_ptest", return_value="PASSED: 4, FAILED: 1")
+    @patch("cve_corrector.workflow.run_ptest",
+           return_value="PASSED: 4, FAILED: 1\nFailing cases:\n  tar hardlink")
     def test_regression(self, mock_ptest, mock_save, tmp_path):
         state = _state(tmp_path, skip_ptest=False, ptest_before="PASSED: 5, FAILED: 0")
         with pytest.raises(PtestError):
             _run_ptest_step(state)
+        # The failing-case summary must be persisted to state BEFORE the raise
+        # so the agent's context can surface the failing cases.
+        assert state.ptest_after == \
+            "PASSED: 4, FAILED: 1\nFailing cases:\n  tar hardlink"
+        assert "tar hardlink" in mock_save.call_args_list[-1].args[0].ptest_after
+        assert mock_save.call_args_list[-1].args[1] == 'ptest_after_patch'
 
     @patch("cve_corrector.workflow.save_progress")
     @patch("cve_corrector.workflow.run_ptest", return_value=None)


### PR DESCRIPTION
## Summary

A set of related improvements to `cve-agent`/`cve-corrector` that make
AI-assisted CVE backporting more reliable on real recipes and cheaper on the
model's context budget. Highlights: split the agent's instructions so each
phase only receives what it needs, surface ptest failures to the AI, recover
from stale sstate instead of escalating, and let the agent propose an
out-of-scope companion commit that a human (or `--trust`) can accept for a
scoped re-run.

## What's included

### Context efficiency
- **Split `AGENT_INSTRUCTIONS.md` into a phase-independent core + per-phase
  fragments** (`cve_agent/instructions/{conflict,build,ptest}.md`).
  `build_context` embeds only the fragment matching the corrector's exit code,
  so a small-context model gets just the workflow its phase needs instead of the
  whole manual. Also removes the non-interactive kiro double-send (the manual
  was inlined into the query on top of the `file://` system prompt), de-dupes
  the how-to-fix prose out of `context.py`, and drops the SPDX header from the
  model-facing prompt files.
- **Refine the instructions and enforce file-tool writes.** Advertise `fs_write`
  in the tool preamble and require `conclusion.json`, source edits, and
  `.git/MERGE_MSG` to be written with the file tool — the command guard rejects
  `>`/`>>` and heredocs, so the old `cat > … <<EOF` examples could never write
  the file.

### Backport reliability
- **Surface ptest failing cases and guide investigation.** Fix
  `_find_state_file` (it looked one directory too high and silently found
  nothing, so ptest before/after never reached the context), include the
  `Failing cases:` list, and steer resolution toward upstream companion commits
  (classify defect vs expected behavior change, search upstream history, then
  cherry-pick in scope or escalate).
- **Recover from stale sstate instead of escalating.** Pair the workspace
  `git clean -fdx` with `bitbake -c cleansstate` in the corrector so a rebuild
  regenerates run-time artifacts (fixes busybox's `cp: cannot stat
  '.config.orig'`), and permit a scoped `bitbake -c cleansstate <recipe>`
  (single recipe, no chaining) for the agent — arbitrary bitbake targets,
  chaining, and command substitution stay denied.

### Scope handling
- **Suggest a commit for an accepted scope extension.** When the blocker is a
  companion/prerequisite commit outside the allowed files (e.g. a testsuite
  update), the agent names it in `suggested_commits`. On escalation the run can
  accept it (auto under `--trust`, prompted when interactive) and re-run with
  the commit appended to the fix-url chain; the allowed-files guard widens
  automatically. Chain building is forge-agnostic, dedupes already-tried
  commits, and caps re-run extensions.

## Testing

Full local CI green:
- `ruff check .` — all checks passed
- `mypy cve_agent cve_corrector cve_metadata_extractor shared` — success (49 files)
- `pytest --cov` — 1262 passed, 7 skipped, 80.76% coverage (gate 65%)

## Commits

- `cve-corrector: reset sstate when clearing the workspace before a build`
- `cve-agent: surface ptest failing cases and guide investigation`
- `cve-agent: allow scoped cleansstate to recover stale build state`
- `cve-agent: suggest a commit for an accepted scope extension`
- `cve-agent: write conclusion.json via the file tool and refine instructions`
- `cve-agent: split agent instructions into per-phase fragments`
