### PR TITLE
cve-agent: capture and report per-session kiro credit cost

### DIFF
--- a/cve_agent/__init__.py
+++ b/cve_agent/__init__.py
@@ -112,6 +112,11 @@ class CveResult:
     retries: int = 0
     duration: float = 0.0
     resolution_summary: str = ""
+    # Backend cost summed across all AI sessions run for this CVE (initial
+    # attempt + retries + any extended-chain re-runs). ``None`` when the
+    # backend reported no cost (e.g. claude, or an interrupted kiro session).
+    total_credits: Optional[float] = None
+    credits_unit: Optional[str] = None
 
 
 def get_build_dir(workspace_path: Path) -> Path:

--- a/cve_agent/__main__.py
+++ b/cve_agent/__main__.py
@@ -62,6 +62,18 @@ def _show_trust_warning() -> bool:
 
 # --- Logging ---
 
+def _credits(result: CveResult, sep: str = " | ") -> str:
+    """Render a CVE's total backend cost as ``<sep>credits=<amount> <unit>``,
+    or ``''`` when the backend reported no cost, so callers can append it
+    unconditionally. ``sep`` is ``" | "`` for log/summary lines and ``", "``
+    for the saved-results parenthesized form.
+    """
+    if result.total_credits is None:
+        return ""
+    unit = result.credits_unit or "credits"
+    return f"{sep}credits={result.total_credits:.2f} {unit}"
+
+
 def _log_result(config: AgentConfig, result: CveResult,
                 workspace_path: Optional[Path] = None) -> None:
     """Append result entry to the CVE agent log file."""
@@ -75,7 +87,8 @@ def _log_result(config: AgentConfig, result: CveResult,
     lines = [
         f"[{datetime.now(timezone.utc).isoformat()}] "
         f"{result.cve_id} | {result.status.value} | "
-        f"{result.duration:.1f}s | retries={result.retries} | "
+        f"{result.duration:.1f}s | retries={result.retries}"
+        f"{_credits(result)} | "
         f"{result.resolution_summary}"
     ]
 
@@ -119,7 +132,8 @@ def _process_batch(cve_list: list[str], config_template: AgentConfig,
         result = process_single_cve(config, knowledge_base)
         _log_result(config, result)
         results.append(result)
-        print(f"  Result: {result.status.value} — {result.resolution_summary}")
+        print(f"  Result: {result.status.value} — {result.resolution_summary}"
+              f"{_credits(result)}")
 
         if result.status in (ResultStatus.FAILED, ResultStatus.ESCALATED) and not config_template.trust_mode:
             response = input(
@@ -148,7 +162,14 @@ def _print_batch_summary(results: list[CveResult]) -> None:
     print("\nPer-CVE results:")
     for result in results:
         retries_info = f" ({result.retries} retries)" if result.retries else ""
-        print(f"  {result.cve_id}: {result.status.value}{retries_info}")
+        print(f"  {result.cve_id}: {result.status.value}{retries_info}"
+              f"{_credits(result)}")
+
+    costs = [r.total_credits for r in results if r.total_credits is not None]
+    if costs:
+        unit = next(r.credits_unit for r in results
+                    if r.total_credits is not None) or "credits"
+        print(f"\nTotal {unit}: {sum(costs):.2f}")
 
     print(f"{'=' * 60}")
 
@@ -166,7 +187,8 @@ def _save_results(results: list[CveResult]) -> None:
             file.write(
                 f"{result.cve_id}: {result.status.value} "
                 f"(retries={result.retries}, "
-                f"duration={result.duration:.1f}s)\n"
+                f"duration={result.duration:.1f}s"
+                f"{_credits(result, ', ')})\n"
                 f"  {result.resolution_summary}\n\n"
             )
     print(f"Results saved to: {filepath}")
@@ -359,6 +381,9 @@ def main() -> None:
         _log_result(config, result)
         if result.resolution_summary:
             print(f"  {result.resolution_summary}")
+        if result.total_credits is not None:
+            print(f"  credits: {result.total_credits:.2f} "
+                  f"{result.credits_unit or 'credits'}")
         if result.status not in (ResultStatus.SUCCESS,
                                  ResultStatus.CONFLICT_RESOLVED,
                                  ResultStatus.SKIPPED):

--- a/cve_agent/backend.py
+++ b/cve_agent/backend.py
@@ -10,10 +10,19 @@ from typing import Optional
 
 @dataclass
 class SessionResult:
-    """Outcome of an AI session."""
+    """Outcome of an AI session.
+
+    ``credits``/``credits_unit`` capture the backend's own end-of-session cost
+    report when it emits one (kiro-cli prints ``Credits: 5.86 • Time: …``).
+    They are backend-agnostic and default to ``None`` — only backends that
+    surface a parseable cost figure populate them. ``duration`` remains the
+    authoritative wall-clock time measured by the agent.
+    """
     resolved: bool
     duration: float
     transcript_path: Optional[Path] = None
+    credits: Optional[float] = None
+    credits_unit: Optional[str] = None
 
 
 class AIBackend:

--- a/cve_agent/kiro_backend.py
+++ b/cve_agent/kiro_backend.py
@@ -10,6 +10,8 @@ import logging
 import shlex
 import shutil
 import subprocess
+import sys
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -19,6 +21,7 @@ from shared.git_runner import run_capture
 
 from .backend import AIBackend, SessionResult
 from .git import has_in_progress_operation
+from .metrics import parse_kiro_credits
 
 
 class KiroBackend(AIBackend):
@@ -63,12 +66,17 @@ class KiroBackend(AIBackend):
 
         start = time.monotonic()
         timed_out = False
+        captured = ""
         # Interactive sessions have a human at the terminal — never kill them
         # with a timeout.  Non-interactive (CI) runs use the configured limit.
         effective_timeout: Optional[int] = None if interactive else timeout
         try:
-            subprocess.run(run_cmd, cwd=workspace_path, env=env,
-                         check=False, timeout=effective_timeout)
+            if interactive:
+                subprocess.run(run_cmd, cwd=workspace_path, env=env,
+                             check=False, timeout=effective_timeout)
+            else:
+                captured = self._run_capturing_tee(
+                    run_cmd, workspace_path, env, effective_timeout)
         except subprocess.TimeoutExpired:
             timed_out = True
         except FileNotFoundError:
@@ -81,9 +89,67 @@ class KiroBackend(AIBackend):
             return SessionResult(resolved=False, duration=duration,
                                 transcript_path=transcript_path)
 
+        # Interactive output isn't captured inline (full-screen TUI needs the
+        # real TTY); read the tee'd transcript instead. Non-interactive runs
+        # already have the streamed stdout in ``captured``.
+        if interactive and transcript_path is not None:
+            try:
+                captured = transcript_path.read_text(
+                    encoding="utf-8", errors="replace")
+            except OSError as exc:
+                logging.debug("Could not read transcript %s: %s",
+                              transcript_path, exc)
+
         resolved = self._check_resolution(workspace_path)
-        return SessionResult(resolved=resolved, duration=duration,
-                            transcript_path=transcript_path)
+        result = SessionResult(resolved=resolved, duration=duration,
+                              transcript_path=transcript_path)
+        credits = parse_kiro_credits(captured)
+        if credits is not None:
+            result.credits = credits
+            result.credits_unit = "credits"
+        return result
+
+    @staticmethod
+    def _run_capturing_tee(cmd: list, workspace_path: Path, env: dict,
+                           timeout: Optional[int]) -> str:
+        """Run ``cmd`` capturing combined stdout+stderr while streaming it live.
+
+        kiro-cli's ``--no-interactive`` output is plain text (no TUI), so it
+        can be piped without breaking the session. A reader thread echoes each
+        line to the real stdout as it arrives (preserving the live CI log) and
+        accumulates it so the trailing ``Credits: … • Time: …`` summary can be
+        parsed once the process exits.
+
+        Raises:
+            subprocess.TimeoutExpired: if the process outlives ``timeout``; the
+                process (group) is killed first so it can't keep mutating the
+                workspace while the caller inspects git state.
+            FileNotFoundError: if kiro-cli is not on PATH.
+        """
+        proc = subprocess.Popen(
+            cmd, cwd=workspace_path, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1)
+        chunks: list[str] = []
+
+        def _pump() -> None:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                chunks.append(line)
+                sys.stdout.write(line)
+                sys.stdout.flush()
+
+        reader = threading.Thread(target=_pump, daemon=True)
+        reader.start()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            reader.join(timeout=5)
+            raise
+        reader.join(timeout=5)
+        return "".join(chunks)
 
     @staticmethod
     def _build_kiro_cmd(prompt: str, agent_name: Optional[str], model: str,

--- a/cve_agent/metrics.py
+++ b/cve_agent/metrics.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Parse per-session cost/time metrics from AI backend output.
+
+kiro-cli prints a summary line at the end of each session, e.g.::
+
+    Credits: 5.86 • Time: 1m 23s
+
+This module extracts that figure so the agent can record how many credits a
+session consumed and surface it in its result reports. The parser is a pure
+function (no I/O) so it can be unit-tested against captured stdout or a
+transcript file regardless of how the text was obtained.
+"""
+import re
+from typing import Optional
+
+# Strip ANSI escape sequences (colours, cursor moves) that kiro-cli emits when
+# writing to a TTY — the interactive transcript captured via ``script`` is full
+# of them, and even non-interactive output can carry colour codes.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+# Match the end-of-session summary line. Tolerates:
+#   - a leading label in any case ("Credits:")
+#   - thousands separators and a decimal point in the amount (e.g. "1,234.5")
+#   - either bullet glyph (U+2022 '•' or U+00B7 '·') or a plain separator
+#   - a free-form time string ("45s", "1m 23s", "1h 2m 3s")
+_CREDITS_RE = re.compile(
+    r"Credits:\s*(?P<credits>[0-9][0-9,]*(?:\.[0-9]+)?)\s*"
+    r"[\u2022\u00b7|]\s*"
+    r"Time:\s*(?P<time>[0-9hms][0-9hms \t]*)",
+    re.IGNORECASE,
+)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*."""
+    return _ANSI_RE.sub("", text)
+
+
+def parse_kiro_credits(text: str) -> Optional[float]:
+    """Extract the credits figure from kiro-cli output.
+
+    Scans *text* for the ``Credits: <num> • Time: <str>`` summary line and
+    returns the amount from the last match (a session may print progress lines
+    that look similar; the final line is the authoritative session total). The
+    ``Time:`` half anchors the match to the real summary line; it is not
+    returned (wall-clock time is measured by the agent). ANSI colour codes are
+    stripped first.
+
+    Args:
+        text: Captured kiro-cli stdout or transcript contents.
+
+    Returns:
+        The credits float, or ``None`` when no valid summary line is present.
+    """
+    if not text:
+        return None
+    clean = strip_ansi(text)
+    last: Optional[float] = None
+    for match in _CREDITS_RE.finditer(clean):
+        raw_credits = match.group("credits").replace(",", "")
+        try:
+            last = float(raw_credits)
+        except ValueError:
+            continue
+    return last

--- a/cve_agent/orchestrator.py
+++ b/cve_agent/orchestrator.py
@@ -3,6 +3,7 @@
 """CVE processing orchestration — single-CVE workflow and resolution loop."""
 import dataclasses
 import json
+import os
 import shutil
 import time
 from pathlib import Path
@@ -579,18 +580,32 @@ def process_single_cve(config: AgentConfig,
 
     accepted_hashes: set[str] = set()
     extensions = 0
+    total_credits: Optional[float] = None
+    credits_unit: Optional[str] = None
     while True:
         try:
-            return _run_cve_pipeline(config, knowledge_base, start_time)
+            result = _run_cve_pipeline(config, knowledge_base, start_time)
+            total_credits, credits_unit = _accumulate_credits(
+                config, total_credits, credits_unit)
+            result.total_credits = total_credits
+            result.credits_unit = credits_unit
+            return result
         except _AcceptedSuggestion as accepted:
+            # Read this run's credits before the next pipeline's clean=True
+            # wipes the agent dir, so re-run costs accumulate rather than reset.
+            total_credits, credits_unit = _accumulate_credits(
+                config, total_credits, credits_unit)
             genuinely_new = [h for h in accepted.new_hashes
                              if h not in accepted_hashes]
             if not genuinely_new or extensions >= _MAX_CHAIN_EXTENSIONS:
-                return _make_result(
+                result = _make_result(
                     config.cve_id, ResultStatus.ESCALATED, 0, start_time,
                     "Suggested commits already tried or chain-extension cap "
                     f"({_MAX_CHAIN_EXTENSIONS}) reached — escalating"
                 )
+                result.total_credits = total_credits
+                result.credits_unit = credits_unit
+                return result
             accepted_hashes.update(genuinely_new)
             extensions += 1
             # Keep --cve-info (version + recipe metadata); the fix-url chain is
@@ -605,6 +620,69 @@ def process_single_cve(config: AgentConfig,
             print(f"{'=' * 60}")
 
 
+def _resolve_cve_data(config: AgentConfig) -> Optional[dict]:
+    """Build the CVE metadata dict from ``--cve-info`` or ``--fix-url``.
+
+    Mirrors the resolution in :func:`_run_cve_pipeline` so credit aggregation
+    can locate the recipe workspace by the same rules. Returns ``None`` when
+    neither source is available or metadata can't be loaded.
+    """
+    if config.cve_info_path:
+        return load_cve_metadata(config.cve_info_path)
+    if config.fix_urls and config.recipe:
+        from shared.url_parser import parse_fix_urls
+        url_metadata = parse_fix_urls(config.fix_urls)
+        return {config.cve_id: {'name': config.recipe, **url_metadata}}
+    return None
+
+
+def _accumulate_credits(
+        config: AgentConfig, running_total: Optional[float],
+        running_unit: Optional[str]) -> tuple[Optional[float], Optional[str]]:
+    """Fold this pipeline run's session credits into the running per-CVE total.
+
+    Reads ``sum_session_credits`` from the recipe's agent dir (populated by
+    :func:`cve_agent.session.guarded_session` via ``sessions.log``) and adds it
+    to ``running_total``. The agent dir is derived straight from ``BBPATH`` and
+    the recipe name rather than via :func:`get_workspace_path`, because a
+    successful run's ``devtool finish`` removes the source workspace before we
+    get here — but the agent dir lives outside it and survives. Failures to
+    resolve it are non-fatal (credits are best-effort telemetry), so the
+    running total is returned unchanged.
+    """
+    from .session import sum_session_credits
+
+    agent_dir = _agent_dir_for(config)
+    if agent_dir is None:
+        return running_total, running_unit
+
+    run_credits, run_unit = sum_session_credits(agent_dir)
+    if run_credits is None:
+        return running_total, running_unit
+    if running_total is None:
+        return run_credits, run_unit
+    return running_total + run_credits, running_unit or run_unit
+
+
+def _agent_dir_for(config: AgentConfig) -> Optional[Path]:
+    """Resolve the recipe's agent dir from ``BBPATH`` + recipe name.
+
+    Mirrors :func:`cve_agent.get_agent_dir`'s layout
+    (``<build>/workspace/cve_agent/<recipe>``) without needing the source
+    workspace to exist, so it still works after ``devtool finish``. Returns
+    ``None`` when the recipe or ``BBPATH`` can't be determined.
+    """
+    try:
+        cve_data = _resolve_cve_data(config)
+    except Exception:
+        return None
+    recipe = (cve_data or {}).get(config.cve_id, {}).get('name')
+    bbpath = os.environ.get('BBPATH', '')
+    if not recipe or not bbpath:
+        return None
+    return Path(bbpath.split(':')[0]) / 'workspace' / 'cve_agent' / recipe
+
+
 def _run_cve_pipeline(config: AgentConfig, knowledge_base: KnowledgeBase,
                       start_time: float) -> CveResult:
     """Run the CVE pipeline once (corrector -> resolution loop).
@@ -613,13 +691,8 @@ def _run_cve_pipeline(config: AgentConfig, knowledge_base: KnowledgeBase,
     catches to re-run with an extended commit chain.
     """
     try:
-        if config.cve_info_path:
-            cve_data = load_cve_metadata(config.cve_info_path)
-        elif config.fix_urls and config.recipe:
-            from shared.url_parser import parse_fix_urls
-            url_metadata = parse_fix_urls(config.fix_urls)
-            cve_data = {config.cve_id: {'name': config.recipe, **url_metadata}}
-        else:
+        cve_data = _resolve_cve_data(config)
+        if cve_data is None:
             return _make_result(
                 config.cve_id, ResultStatus.FAILED, 0, start_time,
                 "No --cve-info or --fix-url provided"

--- a/cve_agent/session.py
+++ b/cve_agent/session.py
@@ -6,8 +6,10 @@ Spawns AI sessions with context files, wraps them with file-scope
 enforcement (pre-commit hook + post-session revert).
 """
 import difflib
+import re
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 from shared.git_runner import copy_missing_files_from_devtool, force_checkout_branch
 
@@ -215,7 +217,7 @@ def guarded_session(context_file: Path, workspace_path: Path,
     finally:
         remove_scope_hook(workspace_path)
 
-    _log_session_end(agent_dir, result.resolved, result.duration)
+    _log_session_end(agent_dir, result)
 
     if not workspace_path.exists():
         return result
@@ -431,10 +433,50 @@ def _log_session_start(agent_dir: Path, context_file: Path) -> None:
         log.write(f"[{timestamp}] SESSION START context={context_file}\n")
 
 
-def _log_session_end(agent_dir: Path, resolved: bool, duration: float) -> None:
-    """Log session end to the sessions log file."""
+def _log_session_end(agent_dir: Path, result: SessionResult) -> None:
+    """Log session end to the sessions log file.
+
+    Appends the backend's per-session cost (``credits=<amount> unit=<unit>``)
+    when present, so :func:`sum_session_credits` can tally it across a CVE's
+    retry attempts. The RESOLVED/UNRESOLVED status and measured ``duration``
+    tokens are kept unchanged for backward compatibility with existing log
+    readers.
+    """
     log_file = agent_dir / 'sessions.log'
     timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    status = "RESOLVED" if resolved else "UNRESOLVED"
+    status = "RESOLVED" if result.resolved else "UNRESOLVED"
+    line = (f"[{timestamp}] SESSION END {status} "
+            f"duration={result.duration:.1f}s")
+    if result.credits is not None:
+        line += f" credits={result.credits:.2f} unit={result.credits_unit}"
     with open(log_file, 'a', encoding='utf-8') as log:
-        log.write(f"[{timestamp}] SESSION END {status} duration={duration:.1f}s\n")
+        log.write(line + "\n")
+
+
+# Matches the ``credits=<amount> unit=<unit>`` tokens written by
+# _log_session_end. ``unit`` runs to end-of-token (no spaces in a unit label).
+_CREDITS_LOG_RE = re.compile(
+    r"credits=(?P<amount>[0-9]+(?:\.[0-9]+)?)\s+unit=(?P<unit>\S+)")
+
+
+def sum_session_credits(agent_dir: Path) -> tuple[Optional[float], Optional[str]]:
+    """Sum per-session credits recorded in ``agent_dir/sessions.log``.
+
+    Reads the ``credits=<amount> unit=<unit>`` tokens appended by
+    :func:`_log_session_end` and returns their total plus the unit.
+
+    Returns:
+        ``(total, unit)`` when at least one session recorded a cost, else
+        ``(None, None)``.
+    """
+    log_file = agent_dir / 'sessions.log'
+    try:
+        text = log_file.read_text(encoding='utf-8')
+    except OSError:
+        return None, None
+
+    matches = list(_CREDITS_LOG_RE.finditer(text))
+    if not matches:
+        return None, None
+    total = sum(float(m.group('amount')) for m in matches)
+    return total, matches[0].group('unit')

--- a/tests/agent/test_audit.py
+++ b/tests/agent/test_audit.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from cve_agent import AgentConfig, CveResult, ResultStatus
 from cve_agent.__main__ import _log_result
+from cve_agent.backend import SessionResult
 from cve_agent.session import _log_session_end, _log_session_start, _write_audit_log
 
 
@@ -100,6 +101,17 @@ class TestLogResult:
         assert 'success' in content
         assert '2.5s' in content
 
+    def test_writes_credits(self, tmp_path):
+        log_dir = tmp_path / 'workspace' / 'cve_agent'
+        with patch.dict(os.environ, {'BBPATH': str(tmp_path)}):
+            with patch('cve_agent.__main__.load_cve_metadata',
+                       side_effect=FileNotFoundError('not found')):
+                _log_result(_cfg(), CveResult(
+                    'CVE-1', ResultStatus.SUCCESS, duration=2.5,
+                    total_credits=5.86, credits_unit='credits'))
+        content = (log_dir / 'cve_agent.log').read_text()
+        assert 'credits=5.86 credits' in content
+
 
 class TestSessionLogs:
     def test_log_start(self, tmp_path):
@@ -107,11 +119,11 @@ class TestSessionLogs:
         assert 'SESSION START' in (tmp_path / 'sessions.log').read_text()
 
     def test_log_end_resolved(self, tmp_path):
-        _log_session_end(tmp_path, True, 5.0)
+        _log_session_end(tmp_path, SessionResult(resolved=True, duration=5.0))
         content = (tmp_path / 'sessions.log').read_text()
         assert 'RESOLVED' in content
         assert '5.0s' in content
 
     def test_log_end_unresolved(self, tmp_path):
-        _log_session_end(tmp_path, False, 3.0)
+        _log_session_end(tmp_path, SessionResult(resolved=False, duration=3.0))
         assert 'UNRESOLVED' in (tmp_path / 'sessions.log').read_text()

--- a/tests/agent/test_credits_aggregation.py
+++ b/tests/agent/test_credits_aggregation.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for per-CVE credit aggregation in the orchestrator."""
+from pathlib import Path
+from unittest.mock import patch
+
+from cve_agent import AgentConfig, CveResult, ResultStatus
+from cve_agent.knowledge import KnowledgeBase
+from cve_agent.orchestrator import (
+    _AcceptedSuggestion,
+    _accumulate_credits,
+    process_single_cve,
+)
+
+
+def _cfg(**kwargs):
+    defaults = dict(cve_id="CVE-2025-0001", cve_info_path=Path("/tmp/c.json"),
+                    trust_mode=True)
+    defaults.update(kwargs)
+    return AgentConfig(**defaults)
+
+
+def test_accumulate_credits_sums_run_over_run(tmp_path):
+    cfg = _cfg()
+    with patch("cve_agent.orchestrator._agent_dir_for", return_value=tmp_path), \
+         patch("cve_agent.session.sum_session_credits",
+               return_value=(2.14, "credits")):
+        total, unit = _accumulate_credits(cfg, 5.86, "credits")
+    assert total == 8.0
+    assert unit == "credits"
+
+
+def test_accumulate_credits_none_when_no_workspace():
+    cfg = _cfg()
+    with patch("cve_agent.orchestrator._agent_dir_for", return_value=None):
+        assert _accumulate_credits(cfg, None, None) == (None, None)
+
+
+def test_agent_dir_for_resolves_without_workspace(tmp_path, monkeypatch):
+    """The agent dir must resolve from BBPATH + recipe even after devtool
+    finish has removed the source workspace (the success path)."""
+    from cve_agent.orchestrator import _agent_dir_for
+    monkeypatch.setenv("BBPATH", str(tmp_path))
+    cfg = _cfg()
+    with patch("cve_agent.orchestrator._resolve_cve_data",
+               return_value={"CVE-2025-0001": {"name": "busybox"}}):
+        agent_dir = _agent_dir_for(cfg)
+    assert agent_dir == tmp_path / "workspace" / "cve_agent" / "busybox"
+    # No source workspace exists — resolution still succeeds.
+    assert not (tmp_path / "workspace" / "sources").exists()
+
+
+def test_accumulate_credits_no_session_cost_keeps_running(tmp_path):
+    cfg = _cfg()
+    with patch("cve_agent.orchestrator._agent_dir_for", return_value=tmp_path), \
+         patch("cve_agent.session.sum_session_credits",
+               return_value=(None, None)):
+        assert _accumulate_credits(cfg, 5.86, "credits") == (5.86, "credits")
+
+
+def test_process_single_cve_sets_total_credits():
+    cfg = _cfg()
+    kb = KnowledgeBase()
+    result = CveResult(cve_id="CVE-2025-0001", status=ResultStatus.SUCCESS)
+    with patch("cve_agent.orchestrator._run_cve_pipeline", return_value=result), \
+         patch("cve_agent.orchestrator._accumulate_credits",
+               return_value=(5.86, "credits")):
+        out = process_single_cve(cfg, kb)
+    assert out.total_credits == 5.86
+    assert out.credits_unit == "credits"
+
+
+def test_process_single_cve_sums_credits_across_chain_reruns():
+    """A re-run triggered by an accepted suggestion accumulates the earlier
+    run's credits (read before the clean=True wipe) plus the final run's."""
+    cfg = _cfg()
+    kb = KnowledgeBase()
+    final = CveResult(cve_id="CVE-2025-0001",
+                      status=ResultStatus.CONFLICT_RESOLVED)
+
+    pipeline_calls = [
+        _AcceptedSuggestion(["url-a", "url-b"], ["b" * 40]),
+        final,
+    ]
+
+    def fake_pipeline(config, knowledge_base, start_time):
+        outcome = pipeline_calls.pop(0)
+        if isinstance(outcome, _AcceptedSuggestion):
+            raise outcome
+        return outcome
+
+    # Each _accumulate_credits call adds 3.0 to the running total.
+    def fake_accumulate(config, running_total, running_unit):
+        base = running_total or 0.0
+        return base + 3.0, "credits"
+
+    with patch("cve_agent.orchestrator._run_cve_pipeline",
+               side_effect=fake_pipeline), \
+         patch("cve_agent.orchestrator._accumulate_credits",
+               side_effect=fake_accumulate):
+        out = process_single_cve(cfg, kb)
+
+    assert out.status == ResultStatus.CONFLICT_RESOLVED
+    assert out.total_credits == 6.0
+    assert out.credits_unit == "credits"

--- a/tests/agent/test_interactive.py
+++ b/tests/agent/test_interactive.py
@@ -12,6 +12,25 @@ from cve_agent.kiro_backend import KiroBackend
 _kiro = KiroBackend()
 
 
+class _FakePopen:
+    """subprocess.Popen stand-in for the non-interactive tee path."""
+
+    def __init__(self, lines=(), wait_exc=None):
+        self.stdout = iter(lines)
+        self._wait_exc = wait_exc
+        self.wait_timeout = "unset"
+        self.killed = False
+
+    def wait(self, timeout=None):
+        self.wait_timeout = timeout
+        if self._wait_exc is not None:
+            raise self._wait_exc
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
 def _spawn_kiro_cli(context_file, workspace_path, model, timeout, interactive=False):
     result = _kiro.run_session(
         f"Read {context_file}", workspace_path, set(), model, timeout, interactive)
@@ -78,10 +97,12 @@ class TestInteractiveAgentSelection:
         cmd = mock_run.call_args_list[0][0][0]
         assert 'yocto-cve-backport-interactive' in cmd
 
-    @patch('subprocess.run')
-    def test_non_interactive_uses_correct_agent(self, mock_run):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_uses_correct_agent(self, mock_popen, _resolve):
+        mock_popen.return_value = _FakePopen()
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=False)
-        cmd = mock_run.call_args_list[0][0][0]
+        cmd = mock_popen.call_args_list[0][0][0]
         assert 'yocto-cve-backport' in cmd
         # Should NOT be the interactive variant
         assert 'yocto-cve-backport-interactive' not in ' '.join(cmd).replace('yocto-cve-backport-interactive', '')
@@ -92,10 +113,12 @@ class TestInteractiveAgentSelection:
         cmd = mock_run.call_args_list[0][0][0]
         assert '--no-interactive' not in cmd
 
-    @patch('subprocess.run')
-    def test_non_interactive_includes_flag(self, mock_run):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_includes_flag(self, mock_popen, _resolve):
+        mock_popen.return_value = _FakePopen()
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=False)
-        cmd = mock_run.call_args_list[0][0][0]
+        cmd = mock_popen.call_args_list[0][0][0]
         assert '--no-interactive' in cmd
         assert '--trust-tools' not in cmd
         assert '--trust-all-tools' not in cmd
@@ -108,11 +131,13 @@ class TestPromptCarriesNoInlinedInstructions:
     guard against re-introducing the AGENT_INSTRUCTIONS.md double-send that
     inlined the full manual into the query on every CI run."""
 
-    @patch('subprocess.run')
-    def test_non_interactive_prompt_is_just_context_pointer(self, mock_run):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_prompt_is_just_context_pointer(self, mock_popen, _resolve):
+        mock_popen.return_value = _FakePopen()
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300,
                         interactive=False)
-        cmd = mock_run.call_args_list[0][0][0]
+        cmd = mock_popen.call_args_list[0][0][0]
         assert cmd[-1] == 'Read /ctx.md'
         assert '--no-interactive' in cmd
 
@@ -142,26 +167,31 @@ class TestInteractiveTimeout:
         _, kwargs = mock_run.call_args_list[0]
         assert kwargs.get('timeout') is None
 
-    @patch('subprocess.run')
-    def test_non_interactive_passes_configured_timeout(self, mock_run):
-        """When interactive=False, the configured timeout is forwarded."""
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_passes_configured_timeout(self, mock_popen, _resolve):
+        """When interactive=False, the configured timeout is forwarded to wait()."""
+        fake = _FakePopen()
+        mock_popen.return_value = fake
         _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 600, interactive=False)
-        # First subprocess.run call is the kiro-cli session itself
-        _, kwargs = mock_run.call_args_list[0]
-        assert kwargs.get('timeout') == 600
+        assert fake.wait_timeout == 600
 
 
 class TestSessionErrorHandling:
-    @patch('subprocess.run', side_effect=subprocess.TimeoutExpired('cmd', 300))
-    def test_timeout_returns_true(self, _):
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_timeout_returns_true(self, mock_popen):
+        mock_popen.return_value = _FakePopen(
+            wait_exc=subprocess.TimeoutExpired('cmd', 300))
         assert _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300) is True
 
-    @patch('subprocess.run', side_effect=[KeyboardInterrupt, MagicMock(returncode=0, stdout='')])
-    def test_keyboard_interrupt_returns_false(self, _):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen', side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt_returns_false(self, _popen, _resolve):
         assert _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300) is False
 
-    @patch('subprocess.run', side_effect=[FileNotFoundError, MagicMock(returncode=0, stdout='')])
-    def test_kiro_not_found_returns_false(self, _):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen', side_effect=FileNotFoundError)
+    def test_kiro_not_found_returns_false(self, _popen, _resolve):
         assert _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300) is False
 
 
@@ -203,11 +233,12 @@ class TestTranscriptCapture:
         inner = cmd[cmd.index('-c') + 1]
         assert 'yocto-cve-backport-interactive' in inner
 
-    @patch('subprocess.run')
-    def test_non_interactive_session_never_wrapped(self, mock_run, tmp_path):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_session_never_wrapped(self, mock_popen, _resolve, tmp_path):
         """Non-interactive runs are unaffected by transcript capture."""
-        mock_run.return_value = MagicMock(returncode=0, stdout='')
+        mock_popen.return_value = _FakePopen()
         with patch('cve_agent.git.build_git_env', return_value={'PATH': '/usr/bin'}):
             _spawn_kiro_cli(Path('/ctx.md'), tmp_path, 'model', 300, interactive=False)
-        cmd = mock_run.call_args_list[0][0][0]
+        cmd = mock_popen.call_args_list[0][0][0]
         assert cmd[0] == 'kiro-cli'

--- a/tests/agent/test_kiro_metrics.py
+++ b/tests/agent/test_kiro_metrics.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for KiroBackend credit/time capture."""
+
+from cve_agent.kiro_backend import KiroBackend
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in yielding preset stdout lines."""
+
+    def __init__(self, lines):
+        self.stdout = iter(lines)
+        self.killed = False
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+def _patch_popen(monkeypatch, lines):
+    def fake_popen(cmd, **kwargs):
+        return _FakeProc(lines)
+    monkeypatch.setattr("cve_agent.kiro_backend.subprocess.Popen", fake_popen)
+
+
+def test_noninteractive_captures_credits(monkeypatch, tmp_path, capsys):
+    _patch_popen(monkeypatch, [
+        "Resolving conflict...\n",
+        "Done.\n",
+        "Credits: 5.86 • Time: 1m 23s\n",
+    ])
+    monkeypatch.setattr(KiroBackend, "_check_resolution", lambda self, ws: True)
+    monkeypatch.setattr("cve_agent.kiro_backend.build_git_env", lambda: {})
+
+    backend = KiroBackend()
+    result = backend.run_session(
+        "prompt", tmp_path, set(), "model", 60, interactive=False)
+
+    assert result.resolved is True
+    assert result.credits == 5.86
+    assert result.credits_unit == "credits"
+    # Output is streamed live to stdout while being captured.
+    assert "Resolving conflict..." in capsys.readouterr().out
+
+
+def test_noninteractive_no_summary_leaves_credits_none(monkeypatch, tmp_path):
+    _patch_popen(monkeypatch, ["working...\n", "still working...\n"])
+    monkeypatch.setattr(KiroBackend, "_check_resolution", lambda self, ws: True)
+    monkeypatch.setattr("cve_agent.kiro_backend.build_git_env", lambda: {})
+
+    backend = KiroBackend()
+    result = backend.run_session(
+        "prompt", tmp_path, set(), "model", 60, interactive=False)
+
+    assert result.resolved is True
+    assert result.credits is None
+    assert result.credits_unit is None
+
+
+def test_interactive_parses_transcript(monkeypatch, tmp_path):
+    transcript = tmp_path / "kiro-session.log"
+    transcript.write_text(
+        "\x1b[1mCredits:\x1b[0m 2.14 • Time: 45s\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        KiroBackend, "_transcript_path", staticmethod(lambda ws: transcript))
+    monkeypatch.setattr(
+        KiroBackend, "_wrap_with_script",
+        staticmethod(lambda cmd, path: ["true"]))
+    monkeypatch.setattr(
+        "cve_agent.kiro_backend.subprocess.run",
+        lambda *a, **k: None)
+    monkeypatch.setattr(KiroBackend, "_check_resolution", lambda self, ws: True)
+    monkeypatch.setattr("cve_agent.kiro_backend.build_git_env", lambda: {})
+
+    backend = KiroBackend()
+    result = backend.run_session(
+        "prompt", tmp_path, set(), "model", 60, interactive=True)
+
+    assert result.credits == 2.14
+    assert result.credits_unit == "credits"
+
+
+def test_interactive_missing_transcript_leaves_credits_none(monkeypatch, tmp_path):
+    missing = tmp_path / "does-not-exist.log"
+    monkeypatch.setattr(
+        KiroBackend, "_transcript_path", staticmethod(lambda ws: missing))
+    monkeypatch.setattr(
+        KiroBackend, "_wrap_with_script",
+        staticmethod(lambda cmd, path: ["true"]))
+    monkeypatch.setattr(
+        "cve_agent.kiro_backend.subprocess.run", lambda *a, **k: None)
+    monkeypatch.setattr(KiroBackend, "_check_resolution", lambda self, ws: True)
+    monkeypatch.setattr("cve_agent.kiro_backend.build_git_env", lambda: {})
+
+    backend = KiroBackend()
+    result = backend.run_session(
+        "prompt", tmp_path, set(), "model", 60, interactive=True)
+
+    assert result.credits is None

--- a/tests/agent/test_main.py
+++ b/tests/agent/test_main.py
@@ -416,6 +416,24 @@ class TestPrintBatchSummary:
         assert "CVE-1" in out
         assert "2 retries" in out
 
+    def test_prints_credits_and_total(self, capsys):
+        results = [
+            CveResult("CVE-1", ResultStatus.SUCCESS,
+                      total_credits=5.86, credits_unit="credits"),
+            CveResult("CVE-2", ResultStatus.CONFLICT_RESOLVED,
+                      total_credits=2.14, credits_unit="credits"),
+        ]
+        _print_batch_summary(results)
+        out = capsys.readouterr().out
+        assert "credits=5.86 credits" in out
+        assert "Total credits: 8.00" in out
+
+    def test_omits_credits_when_absent(self, capsys):
+        _print_batch_summary([CveResult("CVE-1", ResultStatus.SUCCESS)])
+        out = capsys.readouterr().out
+        assert "credits=" not in out
+        assert "Total credits" not in out
+
 
 class TestSaveResults:
     def test_saves_file(self, tmp_path, monkeypatch):
@@ -426,6 +444,15 @@ class TestSaveResults:
             "backport_agent_results_*.txt"))
         assert len(files) == 1
         assert "CVE-1" in files[0].read_text()
+
+    def test_saves_credits(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('CVE_TOOLS_DATA_DIR', str(tmp_path))
+        results = [CveResult("CVE-1", ResultStatus.SUCCESS, duration=1.5,
+                             total_credits=5.86, credits_unit="credits")]
+        _save_results(results)
+        files = list((tmp_path / 'yocto-security-tools' / 'results').glob(
+            "backport_agent_results_*.txt"))
+        assert "credits=5.86 credits" in files[0].read_text()
 
 
 class TestReadCveList:

--- a/tests/agent/test_main_cli.py
+++ b/tests/agent/test_main_cli.py
@@ -170,6 +170,35 @@ class TestTrustSignOffRejected:
         assert '--trust and --sign-off cannot be combined' not in err
 
 
+class TestMainSingleCveCostReport:
+    """On completion of a single-CVE run, main() prints the backend cost when
+    the session reported one, and stays silent when it did not."""
+
+    def _run_main(self, monkeypatch, result):
+        from cve_agent.__main__ import main
+        monkeypatch.setattr('sys.argv', [
+            'cve-agent', '--cve-id', 'CVE-2025-0001',
+            '--cve-info', '/tmp/c.json', '--trust'])
+        with patch('cve_agent.__main__.ensure_agents'), \
+             patch('cve_agent.__main__._show_trust_warning', return_value=True), \
+             patch('cve_agent.__main__._log_result'), \
+             patch('cve_agent.__main__.process_single_cve', return_value=result):
+            main()
+
+    def test_prints_cost_when_present(self, monkeypatch, capsys):
+        result = CveResult('CVE-2025-0001', ResultStatus.SUCCESS,
+                           total_credits=5.86, credits_unit='credits')
+        self._run_main(monkeypatch, result)
+        out = capsys.readouterr().out
+        assert 'credits: 5.86 credits' in out
+
+    def test_omits_cost_when_none(self, monkeypatch, capsys):
+        result = CveResult('CVE-2025-0001', ResultStatus.SUCCESS)
+        self._run_main(monkeypatch, result)
+        out = capsys.readouterr().out
+        assert 'credits:' not in out
+
+
 class TestReadCveList:
     def test_valid_file(self, tmp_path):
         f = tmp_path / 'cves.txt'

--- a/tests/agent/test_metrics.py
+++ b/tests/agent/test_metrics.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+"""Tests for cve_agent.metrics — kiro session credit/time parsing."""
+from cve_agent.metrics import parse_kiro_credits, strip_ansi
+
+
+def test_parses_plain_line():
+    assert parse_kiro_credits("Credits: 5.86 • Time: 1m 23s") == 5.86
+
+
+def test_parses_line_embedded_in_output():
+    text = (
+        "Resolving conflict in foo.c...\n"
+        "Done.\n"
+        "Credits: 5.86 • Time: 1m 23s\n"
+    )
+    assert parse_kiro_credits(text) == 5.86
+
+
+def test_parses_ansi_colored_line():
+    # kiro-cli colours the summary when writing to a TTY / script transcript.
+    text = "\x1b[1m\x1b[32mCredits:\x1b[0m 12.50 \x1b[2m•\x1b[0m Time: 45s\n"
+    assert parse_kiro_credits(text) == 12.5
+
+
+def test_parses_thousands_separator():
+    assert parse_kiro_credits("Credits: 1,234.5 • Time: 1h 2m 3s") == 1234.5
+
+
+def test_parses_seconds_only_time():
+    assert parse_kiro_credits("Credits: 0.10 • Time: 9s") == 0.10
+
+
+def test_parses_middot_bullet():
+    # U+00B7 middle dot as an alternative separator.
+    assert parse_kiro_credits("Credits: 3.00 \u00b7 Time: 2m 1s") == 3.0
+
+
+def test_takes_last_match_when_multiple():
+    text = (
+        "Credits: 1.00 • Time: 10s\n"
+        "...more work...\n"
+        "Credits: 7.25 • Time: 2m 5s\n"
+    )
+    assert parse_kiro_credits(text) == 7.25
+
+
+def test_missing_line_returns_none():
+    assert parse_kiro_credits("no summary here\njust logs\n") is None
+
+
+def test_empty_text_returns_none():
+    assert parse_kiro_credits("") is None
+
+
+def test_garbled_line_returns_none():
+    # Non-numeric credit value must not raise, just skip.
+    assert parse_kiro_credits("Credits: N/A • Time: ?") is None
+
+
+def test_strip_ansi_removes_escapes():
+    assert strip_ansi("\x1b[1mbold\x1b[0m text") == "bold text"

--- a/tests/agent/test_security.py
+++ b/tests/agent/test_security.py
@@ -13,6 +13,23 @@ _kiro = KiroBackend()
 _ALLOWED_ENV_VARS = GIT_ENV_ALLOWLIST
 
 
+class _FakePopen:
+    """subprocess.Popen stand-in for the non-interactive tee path."""
+
+    def __init__(self, lines=(), wait_exc=None):
+        self.stdout = iter(lines)
+        self._wait_exc = wait_exc
+        self.killed = False
+
+    def wait(self, timeout=None):
+        if self._wait_exc is not None:
+            raise self._wait_exc
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
 def _build_session_env():
     return build_git_env()
 
@@ -318,18 +335,18 @@ class TestAgentConfig:
 
 
 class TestTrustToolsInNonInteractiveMode:
-    @patch('subprocess.run')
-    def test_non_interactive_does_not_pass_trust_flags(self, mock_run):
+    @patch('cve_agent.kiro_backend.KiroBackend._check_resolution', return_value=True)
+    @patch('cve_agent.kiro_backend.subprocess.Popen')
+    def test_non_interactive_does_not_pass_trust_flags(self, mock_popen, _resolve):
         """Non-interactive mode passes no --trust-tools/--trust-all-tools —
         permissions live entirely in the agent config JSON (allowedTools +
         toolsSettings.execute_bash.allowedCommands), so execute_bash relies
         on that allowlist instead of blanket tool trust (which would
         shadow it)."""
-        mock_run.return_value = MagicMock(returncode=0, stdout='')
+        mock_popen.return_value = _FakePopen()
         with patch('cve_agent.git.build_git_env', return_value={'PATH': '/usr/bin'}):
             _spawn_kiro_cli(Path('/ctx.md'), Path('/ws'), 'model', 300, interactive=False)
-        # First call is kiro-cli, second is git status --porcelain
-        cmd = mock_run.call_args_list[0][0][0]
+        cmd = mock_popen.call_args_list[0][0][0]
         cmd_str = ' '.join(cmd)
         assert '--agent' in cmd_str
         assert 'yocto-cve-backport' in cmd_str

--- a/tests/agent/test_session_full.py
+++ b/tests/agent/test_session_full.py
@@ -19,9 +19,31 @@ from cve_agent.session import (
     _write_audit_log,
     check_resolution_state,
     guarded_session,
+    sum_session_credits,
 )
 
 _kiro = KiroBackend()
+
+
+class _FakePopen:
+    """Minimal subprocess.Popen stand-in for the non-interactive tee path.
+
+    ``lines`` are yielded from ``stdout``; ``wait_exc`` (if set) is raised by
+    ``wait()`` to simulate a timeout.
+    """
+
+    def __init__(self, lines, wait_exc=None):
+        self.stdout = iter(lines)
+        self._wait_exc = wait_exc
+        self.killed = False
+
+    def wait(self, timeout=None):
+        if self._wait_exc is not None:
+            raise self._wait_exc
+        return 0
+
+    def kill(self):
+        self.killed = True
 
 
 def _spawn_kiro_cli(context_file, workspace_path, model, timeout, interactive=False):
@@ -134,34 +156,50 @@ class TestBuildDeviationSection:
 
 
 class TestSpawnKiroCli:
-    @patch("subprocess.run")
-    def test_normal_run(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='')
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.KiroBackend._check_resolution",
+           return_value=True)
+    @patch("cve_agent.kiro_backend.subprocess.Popen")
+    def test_normal_run(self, mock_popen, _resolve, _env):
+        mock_popen.return_value = _FakePopen([])
         result = _spawn_kiro_cli(Path("/ctx.md"), Path("/ws"), "model", 300)
         assert result is False
 
-    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 300))
-    def test_timeout(self, _):
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.subprocess.Popen")
+    def test_timeout(self, mock_popen, _env):
+        mock_popen.return_value = _FakePopen([], wait_exc=subprocess.TimeoutExpired("cmd", 300))
         assert _spawn_kiro_cli(Path("/ctx.md"), Path("/ws"), "model", 300) is True
 
-    @patch("subprocess.run", side_effect=[FileNotFoundError, MagicMock(returncode=0, stdout="")])
-    def test_not_found(self, _):
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.KiroBackend._check_resolution",
+           return_value=True)
+    @patch("cve_agent.kiro_backend.subprocess.Popen", side_effect=FileNotFoundError)
+    def test_not_found(self, _popen, _resolve, _env):
         assert _spawn_kiro_cli(Path("/ctx.md"), Path("/ws"), "model", 300) is False
 
-    @patch("subprocess.run", side_effect=[KeyboardInterrupt, MagicMock(returncode=0, stdout="")])
-    def test_keyboard_interrupt(self, _):
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.KiroBackend._check_resolution",
+           return_value=True)
+    @patch("cve_agent.kiro_backend.subprocess.Popen", side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt(self, _popen, _resolve, _env):
         assert _spawn_kiro_cli(Path("/ctx.md"), Path("/ws"), "model", 300) is False
 
 
 class TestRunKiroSession:
-    @patch("subprocess.run")
-    def test_resolved(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='')
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.KiroBackend._check_resolution",
+           return_value=True)
+    @patch("cve_agent.kiro_backend.subprocess.Popen")
+    def test_resolved(self, mock_popen, _resolve, _env):
+        mock_popen.return_value = _FakePopen([])
         result = run_kiro_session(Path("/ctx"), Path("/ws"), {"a.c"})
         assert result.resolved is True
 
-    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 300))
-    def test_timed_out(self, _):
+    @patch("cve_agent.kiro_backend.build_git_env", return_value={})
+    @patch("cve_agent.kiro_backend.subprocess.Popen")
+    def test_timed_out(self, mock_popen, _env):
+        mock_popen.return_value = _FakePopen([], wait_exc=subprocess.TimeoutExpired("cmd", 300))
         result = run_kiro_session(Path("/ctx"), Path("/ws"), {"a.c"})
         assert result.resolved is False
 
@@ -264,12 +302,35 @@ class TestLogSessionStartEnd:
         assert "SESSION START" in log.read_text()
 
     def test_log_end(self, tmp_path):
-        _log_session_end(tmp_path, True, 5.0)
+        _log_session_end(tmp_path, SessionResult(resolved=True, duration=5.0))
         log = tmp_path / "sessions.log"
         content = log.read_text()
         assert "RESOLVED" in content
         assert "5.0s" in content
 
     def test_log_end_unresolved(self, tmp_path):
-        _log_session_end(tmp_path, False, 3.0)
+        _log_session_end(tmp_path, SessionResult(resolved=False, duration=3.0))
         assert "UNRESOLVED" in (tmp_path / "sessions.log").read_text()
+
+    def test_log_end_records_credits(self, tmp_path):
+        _log_session_end(tmp_path, SessionResult(
+            resolved=True, duration=5.0, credits=5.86, credits_unit="credits"))
+        content = (tmp_path / "sessions.log").read_text()
+        assert "credits=5.86" in content
+        assert "unit=credits" in content
+
+    def test_sum_session_credits_totals_across_sessions(self, tmp_path):
+        _log_session_end(tmp_path, SessionResult(
+            resolved=False, duration=1.0, credits=5.86, credits_unit="credits"))
+        _log_session_end(tmp_path, SessionResult(
+            resolved=True, duration=2.0, credits=2.14, credits_unit="credits"))
+        total, unit = sum_session_credits(tmp_path)
+        assert total == 8.0
+        assert unit == "credits"
+
+    def test_sum_session_credits_none_when_absent(self, tmp_path):
+        _log_session_end(tmp_path, SessionResult(resolved=True, duration=1.0))
+        assert sum_session_credits(tmp_path) == (None, None)
+
+    def test_sum_session_credits_missing_log(self, tmp_path):
+        assert sum_session_credits(tmp_path / "nope") == (None, None)


### PR DESCRIPTION
Record how many credits each kiro-cli session consumes and surface the total everywhere a CVE result is reported, so operators can see the cost of a backport run.

- Add cve_agent/metrics.py: parse_kiro_credits() extracts the amount from kiro's "Credits: X • Time: Y" summary line (ANSI-tolerant, takes the last match)
- Capture kiro-cli stdout in non-interactive runs via a reader-thread tee that streams output live while accumulating it; parse the transcript for interactive runs
- Add credits/credits_unit to SessionResult and CveResult; persist each session's cost to sessions.log and sum it across retries in sum_session_credits()
- Aggregate per-CVE credits in process_single_cve(), resolving the agent dir from BBPATH + recipe so it survives devtool finish removing the workspace on success
- Print the cost on completion: single-CVE summary, batch per-CVE lines, batch grand total, agent log, and saved results file
- Only kiro populates the cost fields; claude leaves them None

Assisted-by: kiro:claude-opus-4.8