### PR TITLE
ptest: enable kvm only when usable, keep slirp for testimage

### DIFF
--- a/cve_corrector/ptest.py
+++ b/cve_corrector/ptest.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Ericsson AB
 # SPDX-License-Identifier: MIT
 """Ptest operations for CVE corrector."""
+import os
 import re
 import sys
 from typing import Optional
@@ -8,6 +9,25 @@ from typing import Optional
 from .bitbake_ops import get_build_path
 from .state import BuildPreexistingError
 from .utils import logger, run_cmd, run_cmd_capture
+
+
+def _kvm_available() -> bool:
+    """Check whether KVM acceleration is usable on this build host.
+
+    Mirrors the conditions ``runqemu`` itself enforces for its ``kvm``
+    convenience option (see the Yocto Project dev-manual QEMU chapter):
+    ``/dev/kvm`` must exist and be both readable and writable by the
+    current user. Anything short of that (missing device node, running
+    inside a container without ``/dev/kvm`` passed through, permission
+    denied, etc.) means KVM acceleration is not usable and callers must
+    fall back to full software emulation instead of asking ``runqemu``
+    to enable an accelerator that will fail to initialize.
+
+    Returns:
+        True if ``/dev/kvm`` is present and both readable and writable.
+    """
+    kvm_dev = '/dev/kvm'
+    return os.path.exists(kvm_dev) and os.access(kvm_dev, os.R_OK | os.W_OK)
 
 
 def enable_ptest() -> None:
@@ -49,12 +69,27 @@ def run_ptest(recipe: str, build_timeout: int = 7200,
     # Save original content for cleanup
     _original_conf = local_conf.read_text() if local_conf.exists() else None
 
+    # KVM acceleration is opportunistic: only ask runqemu to enable it when
+    # /dev/kvm is actually usable. Requesting "kvm" on a host without a
+    # working accelerator (no /dev/kvm, no VT-capable CPU, container
+    # without the device passed through, etc.) makes runqemu fail outright
+    # instead of quietly falling back to software emulation, so the token
+    # is only added when _kvm_available() confirms it will work.
+    qemuparams = 'slirp nographic'
+    if _kvm_available():
+        qemuparams += ' kvm'
+        logger.debug("KVM is available, enabling KVM acceleration for testimage")
+    else:
+        logger.info(
+            "KVM not usable (/dev/kvm missing or not read/write-accessible), "
+            "falling back to software emulation for testimage")
+
     result_inherit = run_cmd_capture(
         ['bitbake-getvar', 'IMAGE_CLASSES', '-r', 'core-image-minimal'])
     if 'testimage' not in result_inherit.stdout and local_conf.exists():
         with open(local_conf, 'a', encoding='utf-8') as f:
             f.write('\n## Added by CVE corrector (test-only, auto-removed)\n')
-            f.write('\nTEST_RUNQEMUPARAMS += "slirp nographic"\n')
+            f.write(f'\nTEST_RUNQEMUPARAMS += "{qemuparams}"\n')
             # WARNING: These features weaken security. They are required
             # for automated testimage/ptest execution only.
             f.write('\nEXTRA_IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"\n')

--- a/tests/corrector/test_ptest.py
+++ b/tests/corrector/test_ptest.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cve_corrector.ptest import (
+    _kvm_available,
     check_ptest_in_recipe,
     compare_ptest_results,
     enable_ptest,
@@ -13,6 +14,24 @@ from cve_corrector.ptest import (
     summarize_ptest_log,
 )
 from cve_corrector.state import BuildPreexistingError
+
+
+class TestKvmAvailable:
+    @patch("cve_corrector.ptest.os.access", return_value=True)
+    @patch("cve_corrector.ptest.os.path.exists", return_value=True)
+    def test_available_when_device_readable_writable(self, mock_exists, mock_access):
+        assert _kvm_available() is True
+        mock_exists.assert_called_once_with("/dev/kvm")
+
+    @patch("cve_corrector.ptest.os.path.exists", return_value=False)
+    def test_unavailable_when_device_missing(self, mock_exists):
+        assert _kvm_available() is False
+
+    @patch("cve_corrector.ptest.os.access", return_value=False)
+    @patch("cve_corrector.ptest.os.path.exists", return_value=True)
+    def test_unavailable_when_not_accessible(self, mock_exists, mock_access):
+        # e.g. /dev/kvm exists but current user lacks read/write permission
+        assert _kvm_available() is False
 
 
 class TestEnablePtest:
@@ -132,6 +151,55 @@ class TestRunPtest:
         # After run, local.conf should be restored to original
         content = conf.read_text()
         assert content == "# config\n"
+
+    @patch("cve_corrector.ptest._kvm_available", return_value=True)
+    @patch("cve_corrector.ptest.run_cmd")
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_enables_kvm_when_available(self, mock_bp, mock_check, mock_capture,
+                                         mock_cmd, mock_kvm, tmp_path):
+        mock_bp.return_value = tmp_path
+        (tmp_path / "conf").mkdir()
+        conf = tmp_path / "conf" / "local.conf"
+        conf.write_text("# config\n")
+        mock_capture.return_value = MagicMock(stdout="IMAGE_CLASSES = ''")
+
+        captured = {}
+
+        def capture_conf_on_build(*_args, **_kwargs):
+            captured["content"] = conf.read_text()
+            return 0
+
+        mock_cmd.side_effect = capture_conf_on_build
+        run_ptest("busybox")
+
+        assert 'TEST_RUNQEMUPARAMS += "slirp nographic kvm"' in captured["content"]
+
+    @patch("cve_corrector.ptest._kvm_available", return_value=False)
+    @patch("cve_corrector.ptest.run_cmd")
+    @patch("cve_corrector.ptest.run_cmd_capture")
+    @patch("cve_corrector.ptest.check_ptest_in_recipe", return_value=True)
+    @patch("cve_corrector.ptest.get_build_path")
+    def test_omits_kvm_when_unavailable(self, mock_bp, mock_check, mock_capture,
+                                         mock_cmd, mock_kvm, tmp_path):
+        mock_bp.return_value = tmp_path
+        (tmp_path / "conf").mkdir()
+        conf = tmp_path / "conf" / "local.conf"
+        conf.write_text("# config\n")
+        mock_capture.return_value = MagicMock(stdout="IMAGE_CLASSES = ''")
+
+        captured = {}
+
+        def capture_conf_on_build(*_args, **_kwargs):
+            captured["content"] = conf.read_text()
+            return 0
+
+        mock_cmd.side_effect = capture_conf_on_build
+        run_ptest("busybox")
+
+        assert 'TEST_RUNQEMUPARAMS += "slirp nographic"' in captured["content"]
+        assert "kvm" not in captured["content"]
 
 
 # A trimmed excerpt of the real ptest-runner.log that surfaced this bug:


### PR DESCRIPTION
- Keep slirp networking enabled in TEST_RUNQEMUPARAMS for testimage/ptest runs (unchanged, already required for automated runs without root).
- Add _kvm_available() to check /dev/kvm is present and both readable and writable, mirroring the conditions runqemu enforces for its kvm convenience option.
- Only append kvm to TEST_RUNQEMUPARAMS when the accelerator is usable; otherwise leave it out so bitbake falls back to full software emulation instead of runqemu failing to initialize KVM.

Assisted-by: kiro:claude-sonnet-5