### PR TITLE
cve_metadata_extractor: add Ubuntu CVE Tracker source, deprecate Ubuntu API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 │   ├── sources.py               # CveSource base + SOURCE_REGISTRY + plugin loader
 │   ├── cve_sources.py           # Input loading (cve-summary.json, VEX)
 │   ├── oe_status.py             # Check CVE status in OE branches
-│   ├── debian.py / osv.py / cvelistv5.py / ubuntu.py  # Data sources
+│   ├── debian.py / osv.py / cvelistv5.py / uct.py / ubuntu.py  # Data sources
 │   └── config.json              # Public URLs (override via CVE_EXTRACTOR_CONFIG)
 ├── cve_corrector/               # Tool 2: apply patches via devtool
 │   ├── workflow.py              # Main state machine (largest file)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Standalone CVE management tools for Yocto/OpenEmbedded Linux distributions.
 
 | Tool | Purpose |
 |------|---------|
-| **cve-metadata-extractor** | Find fix commits for CVEs from multiple public sources (Debian, OSV, CVEList V5, Ubuntu, NVD) |
+| **cve-metadata-extractor** | Find fix commits for CVEs from multiple public sources (Debian, OSV, CVEList V5, Ubuntu CVE Tracker, NVD) |
 | **cve-corrector** | Automate backporting CVE fixes to Yocto recipes using devtool |
 | **cve-agent** | Orchestrate CVE backporting with AI-assisted conflict resolution |
 
@@ -152,7 +152,23 @@ Override with the `CVE_EXTRACTOR_CONFIG` environment variable.
 | `cvelistv5_url` | GitHub | Git URL to clone CVEList V5 from |
 | `debian_tracker_url` | salsa.debian.org | Git URL for Debian tracker |
 | `nvd_url` | GitHub | Git URL for NVD data |
+| `uct_url` | git.launchpad.net | Git URL to clone the Ubuntu CVE Tracker from |
+| `uct_branch` | `master` | Branch to track for the Ubuntu CVE Tracker clone |
 | `oe_branches` | `["scarthgap"]` | OE branches to check for fix status |
+
+### Ubuntu Sources
+
+By default, Ubuntu CVE data comes from a local clone of the
+[Ubuntu CVE Tracker](https://git.launchpad.net/ubuntu-cve-tracker) (`--uct-dir`,
+default under the shared data directory). The clone is shallow but still
+sizeable (tens of thousands of CVE records) — expect the first run to take a
+while to fetch. Disable with `--no-uct`.
+
+The legacy Ubuntu Security API source (one HTTP request per CVE to
+`ubuntu.com`) is **deprecated and disabled by default**, since it gets
+rate-limited on batch runs. It is slated for removal; use `--ubuntu-api` to
+re-enable it for comparison. `--no-ubuntu` is accepted but is now a no-op
+(it warns and does nothing, since the API source is already off by default).
 
 ## Environment Variables
 

--- a/cve_metadata_extractor/__main__.py
+++ b/cve_metadata_extractor/__main__.py
@@ -22,6 +22,7 @@ from . import debian as _debian  # noqa: F401
 from . import load_pr_cache, process_cve
 from . import osv as _osv  # noqa: F401
 from . import ubuntu as _ubuntu  # noqa: F401
+from . import uct as _uct  # noqa: F401
 from .config import load_config
 from .sources import SOURCE_REGISTRY
 from .utils import PR_CACHE, deduplicate_metadata
@@ -111,7 +112,15 @@ def parse_arguments(cfg):
     source_group.add_argument('--no-osv', action='store_true',
                        help='Disable OSV')
     source_group.add_argument('--no-ubuntu', action='store_true',
-                       help='Disable Ubuntu tracker')
+                       help='Deprecated, no-op: Ubuntu API source is now '
+                            'disabled by default. Use --ubuntu-api to '
+                            're-enable it.')
+    source_group.add_argument('--ubuntu-api', action='store_true',
+                       help='Enable the deprecated Ubuntu Security API '
+                            'source (rate-limited; superseded by the '
+                            'Ubuntu CVE Tracker source, enabled by default)')
+    source_group.add_argument('--no-uct', action='store_true',
+                       help='Disable Ubuntu CVE Tracker source')
 
     # --- Source directories (advanced) ---
     dirs_group = parser.add_argument_group('data source directories (advanced)')
@@ -127,13 +136,17 @@ def parse_arguments(cfg):
     dirs_group.add_argument('--nvd-dir',
                        default=cfg.get('nvd_dir'),
                        help='NVD data clone (default: %(default)s)')
+    dirs_group.add_argument('--uct-dir',
+                       default=cfg.get('uct_dir'),
+                       help='Ubuntu CVE Tracker clone (default: %(default)s)')
 
     # Register CLI args from plugins (extra/ directory)
     # Built-in source args are already added above; only add new ones from plugins
     _builtin_flags = {
         '--debian-tracker-dir', '--no-debian', '--download-patches',
         '--debian-release', '--cvelistv5-dir', '--no-cvelistv5',
-        '--nvd-dir', '--no-nvd', '--no-osv', '--no-ubuntu',
+        '--nvd-dir', '--no-nvd', '--no-osv', '--no-ubuntu', '--ubuntu-api',
+        '--no-uct', '--uct-dir',
     }
     plugin_group = None
     for source in SOURCE_REGISTRY:
@@ -381,6 +394,12 @@ def main():
 
     logging.basicConfig(format='[%(filename)s:%(lineno)d] %(message)s',
                        level=logging.INFO)
+
+    if args.no_ubuntu:
+        logging.warning(
+            '--no-ubuntu is deprecated and no longer needed: the Ubuntu '
+            'Security API source is disabled by default. Use --ubuntu-api '
+            'to re-enable it.')
 
     # Check if at least one input source is provided (built-in or plugin)
     has_builtin_input = any([args.cve_id, args.yocto_summary])

--- a/cve_metadata_extractor/config.json
+++ b/cve_metadata_extractor/config.json
@@ -9,5 +9,7 @@
   "oe_branches": ["scarthgap"],
   "osv_api": "https://api.osv.dev",
   "ubuntu_api": "https://ubuntu.com",
+  "uct_url": "https://git.launchpad.net/ubuntu-cve-tracker",
+  "uct_branch": "master",
   "snapshot_api": "https://snapshot.debian.org"
 }

--- a/cve_metadata_extractor/config.py
+++ b/cve_metadata_extractor/config.py
@@ -50,6 +50,7 @@ def load_config(config_path=None):
     cfg.setdefault('debian_tracker_dir', f'{_shared_data}/security-tracker')
     cfg.setdefault('cvelistv5_dir', f'{_shared_data}/cvelistV5')
     cfg.setdefault('nvd_dir', f'{_shared_data}/nvd')
+    cfg.setdefault('uct_dir', f'{_shared_data}/ubuntu-cve-tracker')
 
     if config_path == str(_DEFAULT_CONFIG):
         _cached_config = cfg

--- a/cve_metadata_extractor/ubuntu.py
+++ b/cve_metadata_extractor/ubuntu.py
@@ -9,14 +9,7 @@ import requests
 
 from .config import load_config
 from .sources import SOURCE_REGISTRY, CveSource
-from .utils import (
-    _GITLAB_ISSUE_RE,
-    URL_RE,
-    extract_commit_hash,
-    process_gitlab_issue_url,
-    process_pr_url,
-    tag_results,
-)
+from .utils import URL_RE, resolve_url_refs, tag_results
 
 _cfg = load_config()
 UBUNTU_API = _cfg.get('ubuntu_api', 'https://ubuntu.com')
@@ -70,11 +63,7 @@ def get_ubuntu_cve(cache, cve_id, refresh=False):
 
 def _process_url(url, hashes, patch_links, series, *, add_patch_link=False):
     '''Extract hash, detect PRs/issues, and add to results for a single URL.'''
-    if '/pull/' in url:
-        process_pr_url(url, series)
-    elif _GITLAB_ISSUE_RE.match(url):
-        process_gitlab_issue_url(url, series)
-    h = extract_commit_hash(url)
+    h = resolve_url_refs(url, series)
     if h and not any(e['hash'] == h for e in hashes):
         hashes.append({'hash': h, 'url': url})
         if add_patch_link:
@@ -122,12 +111,21 @@ _CIRCUIT_BREAKER_THRESHOLD = 3
 
 
 class UbuntuSource(CveSource):
-    '''Ubuntu Security API source.'''
+    '''Ubuntu Security API source.
+
+    Deprecated: superseded by the Ubuntu CVE Tracker source (uct.py), which
+    reads a local git mirror instead of making a rate-limited HTTP request
+    per CVE. Disabled by default; pass --ubuntu-api to re-enable it.
+    '''
     name = 'ubuntu'
     cli_args = [
         (['--no-ubuntu'], {
             'action': 'store_true',
-            'help': 'Disable Ubuntu source',
+            'help': 'Deprecated, no-op: this source is disabled by default',
+        }),
+        (['--ubuntu-api'], {
+            'action': 'store_true',
+            'help': 'Enable the deprecated Ubuntu Security API source',
         }),
     ]
 
@@ -139,7 +137,7 @@ class UbuntuSource(CveSource):
         self._refresh = args.refresh
 
     def is_enabled(self, args):
-        return not args.no_ubuntu
+        return bool(getattr(args, 'ubuntu_api', False))
 
     def extract(self, cve_id, stats):
         '''Extract metadata from Ubuntu Security API for a single CVE.'''

--- a/cve_metadata_extractor/uct.py
+++ b/cve_metadata_extractor/uct.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+'''Ubuntu CVE Tracker (local git mirror) CVE metadata extraction.
+
+Reads CVE records directly from a local clone of the Ubuntu CVE Tracker
+(https://git.launchpad.net/ubuntu-cve-tracker), avoiding the per-CVE HTTP
+requests and rate limiting of the Ubuntu Security API (see ubuntu.py).
+'''
+import logging
+import os
+import re
+
+from .config import load_config
+from .mirrors import ensure_data_repo
+from .sources import SOURCE_REGISTRY, CveSource
+from .utils import URL_RE, resolve_url_refs, tag_results
+
+_cfg = load_config()
+UCT_URL = 'https://git.launchpad.net/ubuntu-cve-tracker'
+UCT_BRANCH = 'master'
+
+CVE_RE = re.compile(r'^CVE-\d{4}-\d+$')
+PKG_RE = re.compile(r'^Patches_(\S+):', re.M)
+
+
+def load_uct_record(repo, cve_id):
+    '''Load raw UCT record text for cve_id from a local UCT clone.
+
+    Args:
+        repo: Path to the UCT clone, or None/empty if unavailable.
+        cve_id: CVE identifier (e.g. "CVE-2023-48795").
+
+    Returns:
+        Record text, or '' if the repo is unavailable, the id is not a
+        well-formed CVE identifier, or no record exists.
+    '''
+    if not repo or not CVE_RE.match(cve_id):
+        return ''
+    for sub in ('active', 'retired'):
+        path = os.path.join(repo, sub, cve_id)
+        if os.path.isfile(path):
+            with open(path, encoding='utf-8', errors='replace') as f:
+                return f.read()
+    return ''
+
+
+class UctSource(CveSource):
+    '''Ubuntu CVE Tracker source (local git mirror, no per-CVE HTTP).'''
+    name = 'uct'
+    cli_args = [
+        (['--no-uct'], {
+            'action': 'store_true',
+            'help': 'Disable Ubuntu CVE Tracker source',
+        }),
+        (['--uct-dir'], {
+            'default': _cfg.get('uct_dir'),
+            'help': 'Ubuntu CVE Tracker clone (default: %(default)s)',
+        }),
+    ]
+
+    def __init__(self) -> None:
+        self._repo = None
+
+    def setup(self, args, cfg):
+        self._repo = ensure_data_repo(
+            args.uct_dir, cfg.get('uct_url', UCT_URL),
+            'Ubuntu CVE Tracker', cfg.get('uct_branch', UCT_BRANCH))
+        if not self._repo:
+            logging.warning(
+                'Ubuntu CVE Tracker repo unavailable at %s; uct source will'
+                ' return no data', args.uct_dir)
+
+    def is_enabled(self, args):
+        return not args.no_uct
+
+    def extract(self, cve_id, stats):
+        '''Extract fix hashes/patches/references from a UCT record.
+
+        Hashes and patches are collected only from the Patches_* region of
+        the record (from the first "Patches_<pkg>:" line onward). Commit
+        URLs cited in free-text Notes/Description before that point are
+        analyst commentary, not confirmed fixes, and must not be reported
+        as hashes.
+        '''
+        hashes, patches, series, refs = [], [], [], []
+        text = load_uct_record(self._repo, cve_id)
+
+        match = PKG_RE.search(text)
+        head, patch_region = (text[:match.start()], text[match.start():]) \
+            if match else (text, '')
+
+        for url in URL_RE.findall(head):
+            refs.append(url.rstrip('.,;)'))
+
+        for url in URL_RE.findall(patch_region):
+            url = url.rstrip('.,;)')
+            refs.append(url)
+            h = resolve_url_refs(url, series)
+            if h and not any(e['hash'] == h for e in hashes):
+                hashes.append({'hash': h, 'url': url})
+                patches.append({'url': url, 'tags': 'patch'})
+
+        if hashes:
+            stats['uct_hashes'] += 1
+        if patches:
+            stats['uct_patches'] += 1
+
+        tagged_hashes, tagged_patches, tagged_refs = tag_results(
+            hashes, patches, refs, 'uct')
+        return tagged_hashes, tagged_patches, series, tagged_refs
+
+    def deduce_component(self, cve_id, cache):
+        '''Deduce component name from the first Patches_<pkg> block.'''
+        match = PKG_RE.search(load_uct_record(self._repo, cve_id))
+        return match.group(1) if match else None
+
+
+SOURCE_REGISTRY.append(UctSource())

--- a/cve_metadata_extractor/utils.py
+++ b/cve_metadata_extractor/utils.py
@@ -113,6 +113,15 @@ def extract_github_pr_commits(pr_url):
     return result
 
 
+def resolve_url_refs(url, series):
+    '''Dispatch PR/issue URLs into series; return the commit hash, if any.'''
+    if '/pull/' in url:
+        process_pr_url(url, series)
+    elif _GITLAB_ISSUE_RE.match(url):
+        process_gitlab_issue_url(url, series)
+    return extract_commit_hash(url)
+
+
 def tag_results(hashes, patches, refs, source):
     '''Add source attribution to hashes, patches, and references.'''
     return (

--- a/tests/extractor/test_main_and_processing.py
+++ b/tests/extractor/test_main_and_processing.py
@@ -57,6 +57,72 @@ class TestParseArguments:
         assert args.no_debian is True
         assert args.no_osv is True
 
+    def test_no_ubuntu_flag_parses_without_error(self):
+        '''Deprecated --no-ubuntu still parses; it does not enable ubuntu.'''
+        from cve_metadata_extractor.__main__ import parse_arguments
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        with patch('sys.argv', ['prog', '--cve-id', 'CVE-1', '--no-ubuntu']):
+            with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
+                args = parse_arguments(cfg)
+        assert args.no_ubuntu is True
+        assert args.ubuntu_api is False
+
+    def test_ubuntu_api_flag(self):
+        from cve_metadata_extractor.__main__ import parse_arguments
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        with patch('sys.argv', ['prog', '--cve-id', 'CVE-1', '--ubuntu-api']):
+            with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
+                args = parse_arguments(cfg)
+        assert args.ubuntu_api is True
+
+    def test_no_uct_flag(self):
+        from cve_metadata_extractor.__main__ import parse_arguments
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        with patch('sys.argv', ['prog', '--cve-id', 'CVE-1', '--no-uct']):
+            with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', []):
+                args = parse_arguments(cfg)
+        assert args.no_uct is True
+
+
+class TestUbuntuUctActivation:
+    '''Test that uct is active by default and ubuntu (HTTP) is opt-in.'''
+
+    def _active_names(self, extra_argv=None):
+        from cve_metadata_extractor.__main__ import parse_arguments
+        from cve_metadata_extractor.ubuntu import UbuntuSource
+        from cve_metadata_extractor.uct import UctSource
+        cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],
+               'repo_dir': '/tmp/r'}
+        argv = ['prog', '--cve-id', 'CVE-1'] + (extra_argv or [])
+        sources = [UbuntuSource(), UctSource()]
+        with patch('cve_metadata_extractor.__main__.SOURCE_REGISTRY', sources):
+            with patch('sys.argv', argv):
+                args = parse_arguments(cfg)
+        return {s.name for s in sources if s.is_enabled(args)}, args
+
+    def test_default_has_uct_not_ubuntu(self):
+        active, _ = self._active_names()
+        assert 'uct' in active
+        assert 'ubuntu' not in active
+
+    def test_ubuntu_api_enables_both(self):
+        active, _ = self._active_names(['--ubuntu-api'])
+        assert 'uct' in active
+        assert 'ubuntu' in active
+
+    def test_no_uct_disables_uct(self):
+        active, _ = self._active_names(['--no-uct'])
+        assert 'uct' not in active
+        assert 'ubuntu' not in active
+
+    def test_no_ubuntu_alone_does_not_enable_ubuntu(self):
+        active, _ = self._active_names(['--no-ubuntu'])
+        assert 'ubuntu' not in active
+        assert 'uct' in active
+
     def test_check_oe_flag(self):
         from cve_metadata_extractor.__main__ import parse_arguments
         cfg = {'cache_dir': '/tmp/c', 'oe_branches': ['scarthgap'],

--- a/tests/extractor/test_sources.py
+++ b/tests/extractor/test_sources.py
@@ -21,7 +21,8 @@ class TestSourceRegistry(unittest.TestCase):
         import cve_metadata_extractor.debian  # noqa: F401
         import cve_metadata_extractor.osv  # noqa: F401
         import cve_metadata_extractor.ubuntu  # noqa: F401
-        expected = {'cvelistv5', 'nvd', 'debian', 'osv', 'ubuntu'}
+        import cve_metadata_extractor.uct  # noqa: F401
+        expected = {'cvelistv5', 'nvd', 'debian', 'osv', 'ubuntu', 'uct'}
         self.assertTrue(expected <= {s.name for s in SOURCE_REGISTRY})
 
 

--- a/tests/extractor/test_ubuntu.py
+++ b/tests/extractor/test_ubuntu.py
@@ -172,7 +172,7 @@ class TestExtractFromUbuntuResponse(unittest.TestCase):
             },
             'references': []
         }
-        with patch('cve_metadata_extractor.ubuntu.process_pr_url') as mock_pr:
+        with patch('cve_metadata_extractor.utils.process_pr_url') as mock_pr:
             extract_from_ubuntu_response(ubuntu_data)
             mock_pr.assert_called_once()
 
@@ -199,18 +199,18 @@ class TestUbuntuSource(unittest.TestCase):
     '''Test UbuntuSource class integration.'''
 
     def test_is_enabled_default(self):
-        '''Ubuntu is enabled by default.'''
+        '''Ubuntu API source is disabled by default.'''
         args = MagicMock()
-        args.no_ubuntu = False
-        source = UbuntuSource()
-        self.assertTrue(source.is_enabled(args))
-
-    def test_is_disabled_with_flag(self):
-        '''Ubuntu is disabled with --no-ubuntu.'''
-        args = MagicMock()
-        args.no_ubuntu = True
+        args.ubuntu_api = False
         source = UbuntuSource()
         self.assertFalse(source.is_enabled(args))
+
+    def test_is_disabled_with_flag(self):
+        '''Ubuntu API source is enabled with --ubuntu-api.'''
+        args = MagicMock()
+        args.ubuntu_api = True
+        source = UbuntuSource()
+        self.assertTrue(source.is_enabled(args))
 
     def test_extract_tags_results(self):
         '''Extract returns results tagged with source ubuntu.'''

--- a/tests/extractor/test_uct.py
+++ b/tests/extractor/test_uct.py
@@ -1,0 +1,235 @@
+# Copyright (C) 2026 Ericsson AB
+# SPDX-License-Identifier: MIT
+'''Tests for the Ubuntu CVE Tracker (UCT) source extractor.'''
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cve_metadata_extractor.uct import UctSource, load_uct_record
+
+
+def _write_record(repo, subdir, cve_id, text):
+    path = os.path.join(repo, subdir, cve_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(text)
+
+
+class TestLoadUctRecord(unittest.TestCase):
+    '''Test raw record lookup from a local UCT clone.'''
+
+    def test_finds_active_record(self):
+        '''Record in active/ is found.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2023-48795', 'Candidate: CVE-2023-48795\n')
+            self.assertIn('CVE-2023-48795', load_uct_record(repo, 'CVE-2023-48795'))
+
+    def test_active_wins_over_retired(self):
+        '''When both active/ and retired/ have the record, active/ wins.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2023-48795', 'from-active\n')
+            _write_record(repo, 'retired', 'CVE-2023-48795', 'from-retired\n')
+            self.assertEqual(
+                load_uct_record(repo, 'CVE-2023-48795'), 'from-active\n')
+
+    def test_falls_back_to_retired(self):
+        '''Record only in retired/ is found.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'retired', 'CVE-2020-0001', 'from-retired\n')
+            self.assertEqual(
+                load_uct_record(repo, 'CVE-2020-0001'), 'from-retired\n')
+
+    def test_missing_record_returns_empty_string(self):
+        '''No record in either directory returns ''.'''
+        with tempfile.TemporaryDirectory() as repo:
+            os.makedirs(os.path.join(repo, 'active'))
+            self.assertEqual(load_uct_record(repo, 'CVE-2099-9999'), '')
+
+    def test_no_repo_returns_empty_string(self):
+        '''Falsy repo path returns '' without touching the filesystem.'''
+        self.assertEqual(load_uct_record(None, 'CVE-2023-48795'), '')
+        self.assertEqual(load_uct_record('', 'CVE-2023-48795'), '')
+
+    def test_rejects_malformed_cve_id(self):
+        '''Non-CVE-shaped id is rejected before any path join.'''
+        with tempfile.TemporaryDirectory() as repo:
+            self.assertEqual(load_uct_record(repo, 'not-a-cve'), '')
+
+    def test_rejects_path_traversal_attempt(self):
+        '''Path-traversal id is rejected, not joined onto the repo path.'''
+        with tempfile.TemporaryDirectory() as repo:
+            self.assertEqual(
+                load_uct_record(repo, '../../etc/passwd'), '')
+
+
+_OPENSSH_RECORD = '''Candidate: CVE-2023-48795
+PublicDate: 2023-12-18
+References:
+ https://www.cve.org/CVERecord?id=CVE-2023-48795
+Description:
+ The SSH transport protocol...
+Notes:
+ someone> see also https://github.com/unrelated/repo/commit/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+ for background, not a fix for this CVE
+Priority: medium
+
+Patches_openssh:
+ upstream: https://github.com/openssh/openssh-portable/commit/1edb00c58f8a6875fad6a497aa2bacf37f9e6cd5
+upstream_openssh: released (1:9.6p1-1)
+noble_openssh: released (1:9.6p1-1)
+
+Patches_dropbear:
+ upstream: https://github.com/mkj/dropbear/commit/6e43be5c7b99dbee49dc72b6f989f29fdd7e9356
+upstream_dropbear: released
+'''
+
+_NO_PATCHES_RECORD = '''Candidate: CVE-2099-0001
+References:
+ https://www.cve.org/CVERecord?id=CVE-2099-0001
+Notes:
+ nobody> nothing to see here
+Priority: low
+'''
+
+_PR_RECORD = '''Candidate: CVE-2024-0001
+References:
+
+Patches_foo:
+ upstream: https://github.com/test/repo/pull/42
+'''
+
+
+class TestUctSourceExtract(unittest.TestCase):
+    '''Test UctSource.extract().'''
+
+    def _source(self, repo):
+        source = UctSource()
+        source._repo = repo
+        return source
+
+    def test_extracts_hash_from_patches_region(self):
+        '''upstream: commit URL in a Patches_ block yields a tagged hash.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2023-48795', _OPENSSH_RECORD)
+            source = self._source(repo)
+            stats = {'uct_hashes': 0, 'uct_patches': 0}
+            hashes, patches, series, refs = source.extract(
+                'CVE-2023-48795', stats)
+
+            hash_values = {h['hash'] for h in hashes}
+            self.assertIn('1edb00c58f8a6875fad6a497aa2bacf37f9e6cd5', hash_values)
+            self.assertIn('6e43be5c7b99dbee49dc72b6f989f29fdd7e9356', hash_values)
+            self.assertTrue(all(h['source'] == 'uct' for h in hashes))
+            self.assertTrue(all(p['source'] == 'uct' for p in patches))
+            self.assertEqual(stats['uct_hashes'], 1)
+            self.assertEqual(stats['uct_patches'], 1)
+            self.assertTrue(series == [] or isinstance(series, list))
+            self.assertTrue(len(refs) > 0)
+
+    def test_notes_section_urls_excluded_from_hashes(self):
+        '''A commit URL cited in Notes/before Patches_ never becomes a hash.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2023-48795', _OPENSSH_RECORD)
+            source = self._source(repo)
+            stats = {'uct_hashes': 0, 'uct_patches': 0}
+            hashes, _, _, refs = source.extract('CVE-2023-48795', stats)
+
+            hash_values = {h['hash'] for h in hashes}
+            self.assertNotIn(
+                'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', hash_values)
+            # The Notes URL is still captured as a reference, just not a hash.
+            self.assertTrue(any('unrelated/repo/commit' in r['url']
+                                for r in refs))
+
+    def test_record_with_no_patches_block_returns_empty(self):
+        '''No Patches_ block anywhere -> four empty lists.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2099-0001', _NO_PATCHES_RECORD)
+            source = self._source(repo)
+            stats = {'uct_hashes': 0, 'uct_patches': 0}
+            hashes, patches, series, refs = source.extract(
+                'CVE-2099-0001', stats)
+            self.assertEqual(hashes, [])
+            self.assertEqual(patches, [])
+            self.assertEqual(series, [])
+            self.assertEqual(stats['uct_hashes'], 0)
+            self.assertEqual(stats['uct_patches'], 0)
+
+    def test_pr_url_in_patch_region_lands_in_series_not_hashes(self):
+        '''A GitHub PR URL inside Patches_ goes to series, not hashes.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2024-0001', _PR_RECORD)
+            source = self._source(repo)
+            stats = {'uct_hashes': 0, 'uct_patches': 0}
+            with patch('cve_metadata_extractor.utils.process_pr_url') as mock_pr:
+                hashes, _, _, _ = source.extract('CVE-2024-0001', stats)
+                mock_pr.assert_called_once()
+            self.assertEqual(hashes, [])
+
+    def test_missing_record_returns_empty_without_exception(self):
+        '''No record at all -> clean empty result, no exception.'''
+        with tempfile.TemporaryDirectory() as repo:
+            source = self._source(repo)
+            stats = {'uct_hashes': 0, 'uct_patches': 0}
+            result = source.extract('CVE-2099-9999', stats)
+            self.assertEqual(result, ([], [], [], []))
+
+
+class TestUctSourceDeduceComponent(unittest.TestCase):
+    '''Test UctSource.deduce_component().'''
+
+    def test_returns_first_patches_package(self):
+        '''Returns the package name from the first Patches_ block.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2023-48795', _OPENSSH_RECORD)
+            source = UctSource()
+            source._repo = repo
+            self.assertEqual(
+                source.deduce_component('CVE-2023-48795', repo), 'openssh')
+
+    def test_returns_none_when_no_patches_block(self):
+        '''Returns None for a record with no Patches_ block.'''
+        with tempfile.TemporaryDirectory() as repo:
+            _write_record(repo, 'active', 'CVE-2099-0001', _NO_PATCHES_RECORD)
+            source = UctSource()
+            source._repo = repo
+            self.assertIsNone(
+                source.deduce_component('CVE-2099-0001', repo))
+
+
+class TestUctSourceSetup(unittest.TestCase):
+    '''Test UctSource.setup() repo-unavailable handling.'''
+
+    def test_repo_unavailable_warns_and_extract_stays_clean(self):
+        '''ensure_data_repo() returning None logs a warning; extract() still
+        works cleanly with no exception.'''
+        args = MagicMock()
+        args.uct_dir = '/nonexistent/uct'
+        source = UctSource()
+        with patch('cve_metadata_extractor.uct.ensure_data_repo',
+                   return_value=None):
+            with self.assertLogs('root', level='WARNING') as cm:
+                source.setup(args, {'uct_url': 'https://example.invalid/uct'})
+            self.assertTrue(
+                any('unavailable' in m for m in cm.output))
+
+        stats = {'uct_hashes': 0, 'uct_patches': 0}
+        self.assertEqual(
+            source.extract('CVE-2023-48795', stats), ([], [], [], []))
+
+    def test_is_enabled_default(self):
+        '''uct is enabled by default.'''
+        args = MagicMock()
+        args.no_uct = False
+        self.assertTrue(UctSource().is_enabled(args))
+
+    def test_is_disabled_with_flag(self):
+        '''uct is disabled with --no-uct.'''
+        args = MagicMock()
+        args.no_uct = True
+        self.assertFalse(UctSource().is_enabled(args))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/extractor/test_utils.py
+++ b/tests/extractor/test_utils.py
@@ -12,6 +12,7 @@ from cve_metadata_extractor.utils import (
     URL_RE,
     extract_commit_hash,
     normalize_component_name,
+    resolve_url_refs,
 )
 
 
@@ -120,6 +121,39 @@ class TestRegexPatterns(unittest.TestCase):
         match = URL_RE.search('See https://example.com/path for details')
         self.assertIsNotNone(match)
         self.assertEqual(match.group(0), 'https://example.com/path')
+
+
+class TestResolveUrlRefs(unittest.TestCase):
+    '''Test resolve_url_refs PR/issue dispatch and hash extraction.'''
+
+    def test_pr_url_appends_to_series(self):
+        '''GitHub PR URL is dispatched to process_pr_url, appending to series.'''
+        from unittest.mock import patch
+        series = []
+        with patch('cve_metadata_extractor.utils.process_pr_url') as mock_pr:
+            resolve_url_refs('https://github.com/test/repo/pull/42', series)
+            mock_pr.assert_called_once_with(
+                'https://github.com/test/repo/pull/42', series)
+
+    def test_gitlab_issue_url_appends_to_series(self):
+        '''GitLab issue URL is dispatched to process_gitlab_issue_url.'''
+        from unittest.mock import patch
+        series = []
+        url = 'https://gitlab.com/test/repo/-/issues/7'
+        with patch(
+                'cve_metadata_extractor.utils.process_gitlab_issue_url'
+        ) as mock_issue:
+            resolve_url_refs(url, series)
+            mock_issue.assert_called_once_with(url, series)
+
+    def test_commit_url_returns_hash(self):
+        '''Plain commit URL returns the extracted hash.'''
+        url = 'https://github.com/test/repo/commit/abc1234'
+        self.assertEqual(resolve_url_refs(url, []), 'abc1234')
+
+    def test_non_matching_url_returns_none(self):
+        '''URL with no commit hash and no PR/issue returns None.'''
+        self.assertIsNone(resolve_url_refs('https://example.com/page', []))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a new uct.py source that reads CVE status from a local git clone of the Ubuntu CVE Tracker (git.launchpad.net/ubuntu-cve-tracker), avoiding per-CVE HTTP requests. Enabled by default; disable with --no-uct.

Deprecate the legacy Ubuntu Security API source (one HTTP request per CVE to ubuntu.com), which gets rate-limited on batch runs. It is now disabled by default; re-enable with --ubuntu-api for comparison. --no-ubuntu is now a no-op (warns, since the API source is already off).

Updates config.json/config.py for uct_url/uct_dir defaults, __main__.py CLI args, README/AGENTS.md docs, and adds tests/extractor/test_uct.py.

Assisted-by: kiro:claude-sonnet-5